### PR TITLE
fix: set correct path to toolchain depending on platform & copy bindings

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -131,6 +131,11 @@ for rust_target in ${keys}
     mkdir dirname ${to}
     cp ${from} ${to}
 end
+
+println -c bright_blue "cp ./bindings/kt/wire/core/crypto/CoreCrypto.kt -> ../sample-projects/android/CoreCryptoTestApp/app/src/main/java/com/wire/core/CoreCrypto.kt"
+from = canonicalize "./bindings/kt/wire/core/crypto/CoreCrypto.kt"
+to = canonicalize "../sample-projects/android/CoreCryptoTestApp/app/src/main/java/com/wire/core/CoreCrypto.kt"
+cp ${from} ${to}
 '''
 
 #################################### Mobile ###################################
@@ -166,7 +171,18 @@ script = '''
 exit_on_error true
 
 fn update_android_env
-    android_ndk_path = set "${1}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+    platform = os_family
+    if eq ${platform} "windows"
+        platform_dir = set "windows-x86_64"
+    elseif eq ${platform} "linux"
+        platform_dir = set "linux-x86_64"
+    elseif eq ${platform} "mac"
+        platform_dir = set "darwin-x86_64"
+    else
+        trigger_error "Unsupported host platform"
+    end
+
+    android_ndk_path = set "${1}/toolchains/llvm/prebuilt/${platform_dir}/bin"
     new_path = set "${PATH}:${android_ndk_path}"
     print -c bright_blue "Updating PATH to include ${android_ndk_path}\n"
     set_env PATH "${new_path}"

--- a/sample-projects/android/CoreCryptoTestApp/.idea/vcs.xml
+++ b/sample-projects/android/CoreCryptoTestApp/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Toolchain path is incorrect when building on a Mac.
2. Kotlin bindings aren't copied to the sample project

### Solutions

1. Modify toolchain path depending on platform
2. Copy Kotlin bindings.

### Testing

n/a

### Notes

`get_home_dir` returns incorrectly return an empty string on Mac so the automatic NDK detection doesn't.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
