### PR TITLE
fix: Incorrect number of keypackages returned [CL-11]

### DIFF
--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -45,7 +45,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6a2d_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1c6f_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -53,11 +53,11 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6a2d_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1c6f_rustbuffer_free(buf, status)
         }
 
         internal fun reserve(buf: RustBuffer.ByValue, additional: Int) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6a2d_rustbuffer_reserve(buf, additional, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1c6f_rustbuffer_reserve(buf, additional, status)
         }
     }
 
@@ -326,79 +326,79 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_6a2d_CoreCrypto_object_free(ptr: Pointer,
+    fun ffi_CoreCrypto_1c6f_CoreCrypto_object_free(ptr: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6a2d_CoreCrypto_new(path: RustBuffer.ByValue,key: RustBuffer.ByValue,client_id: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_new(path: RustBuffer.ByValue,key: RustBuffer.ByValue,client_id: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_6a2d_CoreCrypto_set_callbacks(ptr: Pointer,callbacks: Long,
+    fun CoreCrypto_1c6f_CoreCrypto_set_callbacks(ptr: Pointer,callbacks: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6a2d_CoreCrypto_client_public_key(ptr: Pointer,
+    fun CoreCrypto_1c6f_CoreCrypto_client_public_key(ptr: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_client_keypackages(ptr: Pointer,amount_requested: Int,
+    fun CoreCrypto_1c6f_CoreCrypto_client_keypackages(ptr: Pointer,amount_requested: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_create_conversation(ptr: Pointer,conversation_id: RustBuffer.ByValue,config: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_create_conversation(ptr: Pointer,conversation_id: RustBuffer.ByValue,config: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_conversation_exists(ptr: Pointer,conversation_id: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_conversation_exists(ptr: Pointer,conversation_id: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_6a2d_CoreCrypto_process_welcome_message(ptr: Pointer,welcome_message: RustBuffer.ByValue,config: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_process_welcome_message(ptr: Pointer,welcome_message: RustBuffer.ByValue,config: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_add_clients_to_conversation(ptr: Pointer,conversation_id: RustBuffer.ByValue,clients: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_add_clients_to_conversation(ptr: Pointer,conversation_id: RustBuffer.ByValue,clients: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_remove_clients_from_conversation(ptr: Pointer,conversation_id: RustBuffer.ByValue,clients: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_remove_clients_from_conversation(ptr: Pointer,conversation_id: RustBuffer.ByValue,clients: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_decrypt_message(ptr: Pointer,conversation_id: RustBuffer.ByValue,payload: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_decrypt_message(ptr: Pointer,conversation_id: RustBuffer.ByValue,payload: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6a2d_CoreCrypto_encrypt_message(ptr: Pointer,conversation_id: RustBuffer.ByValue,message: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_CoreCrypto_encrypt_message(ptr: Pointer,conversation_id: RustBuffer.ByValue,message: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6a2d_CoreCryptoCallbacks_init_callback(callback_stub: ForeignCallback,
+    fun ffi_CoreCrypto_1c6f_CoreCryptoCallbacks_init_callback(callback_stub: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6a2d_init_with_path_and_key(path: RustBuffer.ByValue,key: RustBuffer.ByValue,client_id: RustBuffer.ByValue,
+    fun CoreCrypto_1c6f_init_with_path_and_key(path: RustBuffer.ByValue,key: RustBuffer.ByValue,client_id: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_6a2d_version(
+    fun CoreCrypto_1c6f_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6a2d_rustbuffer_alloc(size: Int,
+    fun ffi_CoreCrypto_1c6f_rustbuffer_alloc(size: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6a2d_rustbuffer_from_bytes(bytes: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_1c6f_rustbuffer_from_bytes(bytes: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6a2d_rustbuffer_free(buf: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_1c6f_rustbuffer_free(buf: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_6a2d_rustbuffer_reserve(buf: RustBuffer.ByValue,additional: Int,
+    fun ffi_CoreCrypto_1c6f_rustbuffer_reserve(buf: RustBuffer.ByValue,additional: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -671,7 +671,7 @@ internal object FfiConverterTypeCiphersuiteName {
 fun initWithPathAndKey(path: String, key: String, clientId: String ): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_init_with_path_and_key(FfiConverterString.lower(path), FfiConverterString.lower(key), FfiConverterString.lower(clientId) , _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_init_with_path_and_key(FfiConverterString.lower(path), FfiConverterString.lower(key), FfiConverterString.lower(clientId) , _status)
 })
 }
 
@@ -680,7 +680,7 @@ fun initWithPathAndKey(path: String, key: String, clientId: String ): CoreCrypto
 fun version(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_version( _status)
 })
 }
 
@@ -723,7 +723,7 @@ class CoreCrypto(
     constructor(path: String, key: String, clientId: String ) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_new(FfiConverterString.lower(path), FfiConverterString.lower(key), FfiConverterString.lower(clientId) , _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_new(FfiConverterString.lower(path), FfiConverterString.lower(key), FfiConverterString.lower(clientId) , _status)
 })
 
     /**
@@ -736,7 +736,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6a2d_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1c6f_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -744,7 +744,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun setCallbacks(callbacks: CoreCryptoCallbacks ) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(callbacks) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(callbacks) ,  _status)
 }
         }
     
@@ -752,7 +752,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun clientPublicKey(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_client_public_key(it,   _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_client_public_key(it,   _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -762,7 +762,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun clientKeypackages(amountRequested: UInt ): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(amountRequested) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(amountRequested) ,  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -772,7 +772,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun createConversation(conversationId: List<UByte>, config: ConversationConfiguration ): MemberAddedMessages? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterTypeConversationConfiguration.lower(config) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterTypeConversationConfiguration.lower(config) ,  _status)
 }
         }.let {
             FfiConverterOptionalTypeMemberAddedMessages.lift(it)
@@ -781,7 +781,7 @@ class CoreCrypto(
     override fun conversationExists(conversationId: List<UByte> ): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(conversationId) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(conversationId) ,  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -791,7 +791,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun processWelcomeMessage(welcomeMessage: List<UByte>, config: ConversationConfiguration ): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(welcomeMessage), FfiConverterTypeConversationConfiguration.lower(config) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(welcomeMessage), FfiConverterTypeConversationConfiguration.lower(config) ,  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -801,7 +801,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun addClientsToConversation(conversationId: List<UByte>, clients: List<Invitee> ): MemberAddedMessages? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceTypeInvitee.lower(clients) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceTypeInvitee.lower(clients) ,  _status)
 }
         }.let {
             FfiConverterOptionalTypeMemberAddedMessages.lift(it)
@@ -811,7 +811,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun removeClientsFromConversation(conversationId: List<UByte>, clients: List<Invitee> ): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceTypeInvitee.lower(clients) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceTypeInvitee.lower(clients) ,  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -821,7 +821,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun decryptMessage(conversationId: List<UByte>, payload: List<UByte> ): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUByte.lower(payload) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUByte.lower(payload) ,  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -831,7 +831,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun encryptMessage(conversationId: List<UByte>, message: List<UByte> ): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6a2d_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUByte.lower(message) ,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1c6f_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUByte.lower(message) ,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1103,7 +1103,7 @@ internal object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterfa
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_6a2d_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_1c6f_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_6a2d_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_1c6f_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_6a2d_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_1c6f_rustbuffer_free(self, $0) }
     }
 }
 
@@ -548,7 +548,7 @@ public func initWithPathAndKey( path: String,  key: String,  clientId: String ) 
     
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_init_with_path_and_key(path.lower(), key.lower(), clientId.lower() , $0)
+    CoreCrypto_1c6f_init_with_path_and_key(path.lower(), key.lower(), clientId.lower() , $0)
 }
     return try CoreCrypto.lift(_retval)
 }
@@ -561,7 +561,7 @@ public func version()  -> String {
     
     rustCall() {
     
-    CoreCrypto_6a2d_version( $0)
+    CoreCrypto_1c6f_version( $0)
 }
     return try! String.lift(_retval)
 }
@@ -597,12 +597,12 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_new(path.lower(), key.lower(), clientId.lower() , $0)
+    CoreCrypto_1c6f_CoreCrypto_new(path.lower(), key.lower(), clientId.lower() , $0)
 })
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_6a2d_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_1c6f_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -612,7 +612,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_set_callbacks(self.pointer, ffiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks) , $0
+    CoreCrypto_1c6f_CoreCrypto_set_callbacks(self.pointer, ffiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks) , $0
     )
 }
     }
@@ -620,7 +620,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_client_public_key(self.pointer,  $0
+    CoreCrypto_1c6f_CoreCrypto_client_public_key(self.pointer,  $0
     )
 }
         return try FfiConverterSequenceUInt8.lift(_retval)
@@ -629,7 +629,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_client_keypackages(self.pointer, amountRequested.lower() , $0
+    CoreCrypto_1c6f_CoreCrypto_client_keypackages(self.pointer, amountRequested.lower() , $0
     )
 }
         return try FfiConverterSequenceSequenceUInt8.lift(_retval)
@@ -638,7 +638,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_create_conversation(self.pointer, FfiConverterTypeConversationId.lower(conversationId), config.lower() , $0
+    CoreCrypto_1c6f_CoreCrypto_create_conversation(self.pointer, FfiConverterTypeConversationId.lower(conversationId), config.lower() , $0
     )
 }
         return try FfiConverterOptionRecordMemberAddedMessages.lift(_retval)
@@ -647,7 +647,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try!
     rustCall() {
     
-    CoreCrypto_6a2d_CoreCrypto_conversation_exists(self.pointer, FfiConverterTypeConversationId.lower(conversationId) , $0
+    CoreCrypto_1c6f_CoreCrypto_conversation_exists(self.pointer, FfiConverterTypeConversationId.lower(conversationId) , $0
     )
 }
         return try! Bool.lift(_retval)
@@ -656,7 +656,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_process_welcome_message(self.pointer, FfiConverterSequenceUInt8.lower(welcomeMessage), config.lower() , $0
+    CoreCrypto_1c6f_CoreCrypto_process_welcome_message(self.pointer, FfiConverterSequenceUInt8.lower(welcomeMessage), config.lower() , $0
     )
 }
         return try FfiConverterTypeConversationId.lift(_retval)
@@ -665,7 +665,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_add_clients_to_conversation(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceRecordInvitee.lower(clients) , $0
+    CoreCrypto_1c6f_CoreCrypto_add_clients_to_conversation(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceRecordInvitee.lower(clients) , $0
     )
 }
         return try FfiConverterOptionRecordMemberAddedMessages.lift(_retval)
@@ -674,7 +674,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_remove_clients_from_conversation(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceRecordInvitee.lower(clients) , $0
+    CoreCrypto_1c6f_CoreCrypto_remove_clients_from_conversation(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceRecordInvitee.lower(clients) , $0
     )
 }
         return try FfiConverterOptionSequenceUInt8.lift(_retval)
@@ -683,7 +683,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_decrypt_message(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUInt8.lower(payload) , $0
+    CoreCrypto_1c6f_CoreCrypto_decrypt_message(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUInt8.lower(payload) , $0
     )
 }
         return try FfiConverterOptionSequenceUInt8.lift(_retval)
@@ -692,7 +692,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         let _retval = try
     rustCallWithError(CryptoError.self) {
     
-    CoreCrypto_6a2d_CoreCrypto_encrypt_message(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUInt8.lower(message) , $0
+    CoreCrypto_1c6f_CoreCrypto_encrypt_message(self.pointer, FfiConverterTypeConversationId.lower(conversationId), FfiConverterSequenceUInt8.lower(message) , $0
     )
 }
         return try FfiConverterSequenceUInt8.lift(_retval)
@@ -1142,7 +1142,7 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
 // The ffiConverter which transforms the Callbacks in to Handles to pass to Rust.
 private let ffiConverterCallbackInterfaceCoreCryptoCallbacks: FfiConverterCallbackInterface<CoreCryptoCallbacks> = {
     try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-            ffi_CoreCrypto_6a2d_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+            ffi_CoreCrypto_1c6f_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
     }
     return FfiConverterCallbackInterface<CoreCryptoCallbacks>()
 }()

--- a/crypto-ffi/bindings/swift/Tests/CoreCryptoTests/CoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/Tests/CoreCryptoTests/CoreCryptoTests.swift
@@ -3,6 +3,6 @@ import XCTest
 
 class CoreCryptoTests: XCTestCase {
     func testVersion() throws {
-        XCTAssertEqual(CoreCryptoSwift.version(), "0.1.0")
+        XCTAssertEqual(CoreCryptoSwift.version(), "0.2.0")
     }
 }

--- a/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
@@ -46,79 +46,79 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_6a2d_CoreCrypto_object_free(
+void ffi_CoreCrypto_1c6f_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_6a2d_CoreCrypto_new(
+void*_Nonnull CoreCrypto_1c6f_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6a2d_CoreCrypto_set_callbacks(
+void CoreCrypto_1c6f_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_create_conversation(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_6a2d_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_1c6f_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_1c6f_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_6a2d_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_1c6f_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_6a2d_init_with_path_and_key(
+void*_Nonnull CoreCrypto_1c6f_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6a2d_version(
+RustBuffer CoreCrypto_1c6f_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_6a2d_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_1c6f_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_6a2d_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_1c6f_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_6a2d_rustbuffer_free(
+void ffi_CoreCrypto_1c6f_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_6a2d_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_1c6f_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -74,7 +74,7 @@ interface CoreCrypto {
     [Throws=CryptoError]
     MemberAddedMessages? create_conversation(ConversationId conversation_id, ConversationConfiguration config);
 
-    boolean conversation_exists([ByRef] ConversationId conversation_id);
+    boolean conversation_exists(ConversationId conversation_id);
 
     [Throws=CryptoError]
     ConversationId process_welcome_message([ByRef] sequence<u8> welcome_message, ConversationConfiguration config);

--- a/crypto-ffi/src/lib.rs
+++ b/crypto-ffi/src/lib.rs
@@ -205,8 +205,8 @@ impl CoreCrypto {
         self.0.encrypt_message(conversation_id, message)
     }
 
-    pub fn conversation_exists(&self, conversation_id: &ConversationId) -> bool {
-        self.0.conversation_exists(conversation_id)
+    pub fn conversation_exists(&self, conversation_id: ConversationId) -> bool {
+        self.0.conversation_exists(&conversation_id)
     }
 }
 

--- a/crypto-ffi/tests/bindings_tests.rs
+++ b/crypto-ffi/tests/bindings_tests.rs
@@ -2,7 +2,7 @@
 uniffi_macros::build_foreign_language_testcases!(
     ["src/CoreCrypto.udl",],
     [
-        "bindings/kt/CoreCrypto.test.kt",
+        "bindings/kt/wire/CoreCrypto.test.kt",
         "bindings/swift/Tests/CoreCryptoTests/CoreCryptoTests.swift"
     ]
 );

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -35,7 +35,6 @@ pub mod prelude {
 
 use client::{Client, ClientId};
 use conversation::{ConversationId, MlsConversation, MlsConversationConfiguration, MlsConversationCreationMessage};
-use hex::FromHex;
 use member::ConversationMember;
 use mls_crypto_provider::MlsCryptoProvider;
 use openmls::{

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -42,7 +42,7 @@ proteus = { version = "1.0", default-features = false, optional = true }
 version = "0.26"
 default-features = false
 features = [
-    "bundled-sqlcipher",
+    "bundled-sqlcipher-vendored-openssl",
     "blob",
     "limits",
     "unlock_notify",

--- a/keystore/src/mls.rs
+++ b/keystore/src/mls.rs
@@ -84,14 +84,15 @@ impl CryptoKeystore {
         Ok(count - 1)
     }
 
-    pub fn mls_all_keypackage_bundles<'a, V: openmls_traits::key_store::FromKeyStoreValue>(
+    pub fn mls_fetch_keypackage_bundles<'a, V: openmls_traits::key_store::FromKeyStoreValue>(
         &'a self,
+        count: u32,
     ) -> crate::CryptoKeystoreResult<impl Iterator<Item = V> + 'a> {
         let db = self.conn.lock().unwrap();
 
-        let mut stmt = db.prepare_cached("SELECT rowid FROM mls_keys ORDER BY rowid ASC")?;
+        let mut stmt = db.prepare_cached("SELECT rowid FROM mls_keys ORDER BY rowid DESC LIMIT ?")?;
         let kpb_ids: Vec<i64> = stmt
-            .query_map([], |r| r.get(0))?
+            .query_map([count], |r| r.get(0))?
             .map(|r| r.map_err(crate::CryptoKeystoreError::from))
             .collect::<crate::CryptoKeystoreResult<Vec<i64>>>()?;
 


### PR DESCRIPTION
Closes #12 

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Cf #12 

### Solutions

Make sure we return the correct number of KPBs

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
