### PR TITLE
feat: Implement KeyPackage pruning [CL-16] Redux

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -139,6 +139,10 @@ export class CoreCrypto {
         return await this.#cc.client_public_key();
     }
 
+    async clientValidKeypackagesCount(): Promise<number> {
+        return await this.#cc.client_valid_keypackages_count();
+    }
+
     async clientKeypackages(amountRequested: number): Promise<Array<Uint8Array>> {
         return await this.#cc.client_keypackages(amountRequested);
     }

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_36bd_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_cc12_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_36bd_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_cc12_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,127 +264,131 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_36bd_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_cc12_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_36bd_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_36bd_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_cc12_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_36bd_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_cc12_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_cc12_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    _uniffi_out_err: RustCallStatus
+    ): Long
+
+    fun CoreCrypto_cc12_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_36bd_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_36bd_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_36bd_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Long,
+    fun CoreCrypto_cc12_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_36bd_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_36bd_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_36bd_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_cc12_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_36bd_version(
+    fun CoreCrypto_cc12_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_36bd_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_cc12_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_36bd_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_cc12_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_36bd_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_cc12_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_36bd_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_cc12_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -733,6 +737,9 @@ public interface CoreCryptoInterface {
     fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>>
     
     @Throws(CryptoException::class)
+    fun `clientValidKeypackagesCount`(): ULong
+    
+    @Throws(CryptoException::class)
     fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration)
     
     fun `conversationExists`(`conversationId`: ConversationId): Boolean
@@ -783,7 +790,7 @@ public interface CoreCryptoInterface {
     fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration)
     
     @Throws(CryptoException::class)
-    fun `randomBytes`(`length`: ULong): List<UByte>
+    fun `randomBytes`(`length`: UInt): List<UByte>
     
     @Throws(CryptoException::class)
     fun `reseedRng`(`seed`: List<UByte>)
@@ -796,7 +803,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -809,7 +816,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_36bd_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_cc12_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -817,7 +824,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -825,7 +832,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -834,23 +841,32 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
         }
     
+    @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(it,  _status)
+}
+        }.let {
+            FfiConverterULong.lift(it)
+        }
+    
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -859,7 +875,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -868,7 +884,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeMemberAddedMessages.lift(it)
@@ -877,7 +893,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -886,7 +902,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `leaveConversation`(`conversationId`: ConversationId, `otherClients`: List<ClientId>): ConversationLeaveMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
 }
         }.let {
             FfiConverterTypeConversationLeaveMessages.lift(it)
@@ -895,7 +911,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -904,7 +920,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -913,7 +929,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -922,7 +938,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -931,7 +947,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -940,7 +956,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -949,7 +965,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -958,7 +974,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -967,7 +983,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`groupState`: List<UByte>): MlsConversationInitMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
 }
         }.let {
             FfiConverterTypeMlsConversationInitMessage.lift(it)
@@ -976,7 +992,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -985,15 +1001,15 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
     
-    @Throws(CryptoException::class)override fun `randomBytes`(`length`: ULong): List<UByte> =
+    @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_random_bytes(it, FfiConverterULong.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1002,7 +1018,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1258,6 +1274,7 @@ sealed class CryptoException(message: String): Exception(message) {
         class Utf8Exception(message: String) : CryptoException(message)
         class StringUtf8Exception(message: String) : CryptoException(message)
         class ParseIntException(message: String) : CryptoException(message)
+        class ConvertIntException(message: String) : CryptoException(message)
         class InvalidByteArrayException(message: String) : CryptoException(message)
         class IoException(message: String) : CryptoException(message)
         class Unauthorized(message: String) : CryptoException(message)
@@ -1285,9 +1302,10 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
             11 -> CryptoException.Utf8Exception(FfiConverterString.read(buf))
             12 -> CryptoException.StringUtf8Exception(FfiConverterString.read(buf))
             13 -> CryptoException.ParseIntException(FfiConverterString.read(buf))
-            14 -> CryptoException.InvalidByteArrayException(FfiConverterString.read(buf))
-            15 -> CryptoException.IoException(FfiConverterString.read(buf))
-            16 -> CryptoException.Unauthorized(FfiConverterString.read(buf))
+            14 -> CryptoException.ConvertIntException(FfiConverterString.read(buf))
+            15 -> CryptoException.InvalidByteArrayException(FfiConverterString.read(buf))
+            16 -> CryptoException.IoException(FfiConverterString.read(buf))
+            17 -> CryptoException.Unauthorized(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
         
@@ -1446,7 +1464,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_36bd_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -1726,7 +1744,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -1735,7 +1753,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_36bd_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cc12_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_36bd_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_cc12_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_36bd_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_cc12_rustbuffer_free(self, $0) }
     }
 }
 
@@ -409,6 +409,7 @@ public protocol CoreCryptoProtocol {
     func setCallbacks(callbacks: CoreCryptoCallbacks) throws
     func clientPublicKey() throws -> [UInt8]
     func clientKeypackages(amountRequested: UInt32) throws -> [[UInt8]]
+    func clientValidKeypackagesCount() throws -> UInt64
     func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws
     func conversationExists(conversationId: ConversationId)  -> Bool
     func processWelcomeMessage(welcomeMessage: [UInt8]) throws -> ConversationId
@@ -426,7 +427,7 @@ public protocol CoreCryptoProtocol {
     func joinByExternalCommit(groupState: [UInt8]) throws -> MlsConversationInitMessage
     func exportGroupState(conversationId: ConversationId) throws -> [UInt8]
     func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws
-    func randomBytes(length: UInt64) throws -> [UInt8]
+    func randomBytes(length: UInt32) throws -> [UInt8]
     func reseedRng(seed: [UInt8]) throws
     
 }
@@ -445,7 +446,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_36bd_CoreCrypto_new(
+    CoreCrypto_cc12_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -454,7 +455,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_36bd_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_cc12_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -463,7 +464,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -472,7 +473,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_cc12_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -481,8 +482,17 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
+    )
+}
+        )
+    }
+    public func clientValidKeypackagesCount() throws -> UInt64 {
+        return try FfiConverterUInt64.lift(
+            try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -490,7 +500,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -501,7 +511,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_36bd_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -511,7 +521,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -521,7 +531,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -532,7 +542,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -543,7 +553,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationLeaveMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_leave_conversation(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_leave_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(otherClients), $0
     )
@@ -554,7 +564,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -565,7 +575,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -576,7 +586,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -587,7 +597,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -597,7 +607,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -608,7 +618,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
@@ -620,7 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -632,7 +642,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -642,7 +652,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMlsConversationInitMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(groupState), $0
     )
 }
@@ -652,7 +662,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -661,18 +671,18 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
 }
     }
-    public func randomBytes(length: UInt64) throws -> [UInt8] {
+    public func randomBytes(length: UInt32) throws -> [UInt8] {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_random_bytes(self.pointer, 
-        FfiConverterUInt64.lower(length), $0
+    CoreCrypto_cc12_CoreCrypto_random_bytes(self.pointer, 
+        FfiConverterUInt32.lower(length), $0
     )
 }
         )
@@ -680,7 +690,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_36bd_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_cc12_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -1133,6 +1143,9 @@ public enum CryptoError {
     case ParseIntError(message: String)
     
     // Simple error enums only carry a message
+    case ConvertIntError(message: String)
+    
+    // Simple error enums only carry a message
     case InvalidByteArrayError(message: String)
     
     // Simple error enums only carry a message
@@ -1205,15 +1218,19 @@ fileprivate struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: buf)
         )
         
-        case 14: return .InvalidByteArrayError(
+        case 14: return .ConvertIntError(
             message: try FfiConverterString.read(from: buf)
         )
         
-        case 15: return .IoError(
+        case 15: return .InvalidByteArrayError(
             message: try FfiConverterString.read(from: buf)
         )
         
-        case 16: return .Unauthorized(
+        case 16: return .IoError(
+            message: try FfiConverterString.read(from: buf)
+        )
+        
+        case 17: return .Unauthorized(
             message: try FfiConverterString.read(from: buf)
         )
         
@@ -1267,14 +1284,17 @@ fileprivate struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
         case let .ParseIntError(message):
             buf.writeInt(Int32(13))
             FfiConverterString.write(message, into: buf)
-        case let .InvalidByteArrayError(message):
+        case let .ConvertIntError(message):
             buf.writeInt(Int32(14))
             FfiConverterString.write(message, into: buf)
-        case let .IoError(message):
+        case let .InvalidByteArrayError(message):
             buf.writeInt(Int32(15))
             FfiConverterString.write(message, into: buf)
-        case let .Unauthorized(message):
+        case let .IoError(message):
             buf.writeInt(Int32(16))
+            FfiConverterString.write(message, into: buf)
+        case let .Unauthorized(message):
+            buf.writeInt(Int32(17))
             FfiConverterString.write(message, into: buf)
 
         
@@ -1404,7 +1424,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_36bd_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -1675,7 +1695,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_36bd_init_with_path_and_key(
+    CoreCrypto_cc12_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -1692,7 +1712,7 @@ public func version()  -> String {
     
     rustCall() {
     
-    CoreCrypto_36bd_version($0)
+    CoreCrypto_cc12_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
@@ -46,127 +46,131 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_36bd_CoreCrypto_object_free(
+void ffi_CoreCrypto_cc12_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_36bd_CoreCrypto_new(
+void*_Nonnull CoreCrypto_cc12_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_36bd_CoreCrypto_set_callbacks(
+void CoreCrypto_cc12_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_cc12_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_cc12_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_36bd_CoreCrypto_create_conversation(
+uint64_t CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(
+      void*_Nonnull ptr,
+    RustCallStatus *_Nonnull out_status
+    );
+void CoreCrypto_cc12_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_36bd_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_cc12_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_cc12_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_leave_conversation(
+RustBuffer CoreCrypto_cc12_CoreCrypto_leave_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer other_clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_cc12_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_cc12_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_cc12_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_cc12_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_cc12_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_cc12_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_cc12_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer group_state,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_cc12_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_36bd_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_CoreCrypto_random_bytes(
-      void*_Nonnull ptr,uint64_t length,
+RustBuffer CoreCrypto_cc12_CoreCrypto_random_bytes(
+      void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_36bd_CoreCrypto_reseed_rng(
+void CoreCrypto_cc12_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_36bd_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_36bd_init_with_path_and_key(
+void*_Nonnull CoreCrypto_cc12_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_36bd_version(
+RustBuffer CoreCrypto_cc12_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_36bd_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_cc12_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_36bd_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_cc12_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_36bd_rustbuffer_free(
+void ffi_CoreCrypto_cc12_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_36bd_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_cc12_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -32,6 +32,7 @@ enum CryptoError {
     "Utf8Error",
     "StringUtf8Error",
     "ParseIntError",
+    "ConvertIntError",
     "InvalidByteArrayError",
     "IoError",
     "Unauthorized"
@@ -87,6 +88,9 @@ interface CoreCrypto {
     sequence<sequence<u8>> client_keypackages(u32 amount_requested);
 
     [Throws=CryptoError]
+    u64 client_valid_keypackages_count();
+
+    [Throws=CryptoError]
     void create_conversation(ConversationId conversation_id, ConversationConfiguration config);
 
     boolean conversation_exists(ConversationId conversation_id);
@@ -137,7 +141,7 @@ interface CoreCrypto {
     void merge_pending_group_from_external_commit(ConversationId conversation_id, ConversationConfiguration config);
 
     [Throws=CryptoError]
-    sequence<u8> random_bytes(u64 length);
+    sequence<u8> random_bytes(u32 length);
 
     [Throws=CryptoError]
     void reseed_rng(sequence<u8> seed);

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -73,6 +73,7 @@ impl From<CiphersuiteName> for Ciphersuite {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<CiphersuiteName> for Ciphersuite {
     fn into(self) -> CiphersuiteName {
         match self {
@@ -98,25 +99,28 @@ pub type FfiClientId = Box<[u8]>;
 #[wasm_bindgen]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct MemberAddedMessages {
-    welcome: Box<[u8]>,
-    message: Box<[u8]>,
+    welcome: Vec<u8>,
+    message: Vec<u8>,
 }
 
 #[wasm_bindgen]
 impl MemberAddedMessages {
     #[wasm_bindgen(constructor)]
-    pub fn new(welcome: Box<[u8]>, message: Box<[u8]>) -> Self {
-        Self { welcome, message }
+    pub fn new(welcome: Uint8Array, message: Uint8Array) -> Self {
+        Self {
+            welcome: welcome.to_vec(),
+            message: message.to_vec(),
+        }
     }
 
     #[wasm_bindgen(getter)]
-    pub fn welcome(&self) -> Box<[u8]> {
-        self.welcome.clone()
+    pub fn welcome(&self) -> Uint8Array {
+        Uint8Array::from(&*self.welcome)
     }
 
     #[wasm_bindgen(getter)]
-    pub fn message(&self) -> Box<[u8]> {
-        self.message.clone()
+    pub fn message(&self) -> Uint8Array {
+        Uint8Array::from(&*self.message)
     }
 }
 
@@ -125,103 +129,103 @@ impl TryFrom<MlsConversationCreationMessage> for MemberAddedMessages {
 
     fn try_from(msg: MlsConversationCreationMessage) -> Result<Self, Self::Error> {
         let (welcome, message) = msg.to_bytes_pairs()?;
-        Ok(Self {
-            welcome: welcome.into(),
-            message: message.into(),
-        })
+        Ok(Self { welcome, message })
     }
 }
 
 #[wasm_bindgen]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct ConversationLeaveMessages {
-    self_removal_proposal: Box<[u8]>,
-    other_clients_removal_commit: Option<Box<[u8]>>,
+    self_removal_proposal: Vec<u8>,
+    other_clients_removal_commit: Option<Vec<u8>>,
 }
 
 #[wasm_bindgen]
 impl ConversationLeaveMessages {
     #[wasm_bindgen(constructor)]
-    pub fn new(self_removal_proposal: Box<[u8]>, other_clients_removal_commit: Option<Box<[u8]>>) -> Self {
+    pub fn new(self_removal_proposal: Uint8Array, other_clients_removal_commit: Option<Uint8Array>) -> Self {
         Self {
-            self_removal_proposal,
-            other_clients_removal_commit,
+            self_removal_proposal: self_removal_proposal.to_vec(),
+            other_clients_removal_commit: other_clients_removal_commit.map(|a| a.to_vec()),
         }
     }
 
     #[wasm_bindgen(getter)]
-    pub fn self_removal_proposal(&self) -> Box<[u8]> {
-        self.self_removal_proposal.clone()
+    pub fn self_removal_proposal(&self) -> Uint8Array {
+        Uint8Array::from(&*self.self_removal_proposal)
     }
 
     #[wasm_bindgen(getter)]
-    pub fn other_clients_removal_commit(&self) -> Option<Box<[u8]>> {
-        self.other_clients_removal_commit.clone()
+    pub fn other_clients_removal_commit(&self) -> Option<Uint8Array> {
+        self.other_clients_removal_commit.clone().map(|c| Uint8Array::from(&*c))
     }
 }
 
 #[wasm_bindgen]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CommitBundle {
-    message: Box<[u8]>,
-    welcome: Option<Box<[u8]>>,
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct MlsConversationInitMessage {
-    group: Box<[u8]>,
-    message: Box<[u8]>,
+    message: Vec<u8>,
+    welcome: Option<Vec<u8>>,
 }
 
 #[wasm_bindgen]
 impl CommitBundle {
     #[wasm_bindgen(getter)]
-    pub fn message(&self) -> Box<[u8]> {
-        self.message.clone()
+    pub fn message(&self) -> Uint8Array {
+        Uint8Array::from(&*self.message)
     }
 
     #[wasm_bindgen(getter)]
-    pub fn welcome(&self) -> Option<Box<[u8]>> {
-        self.welcome.clone()
+    pub fn welcome(&self) -> Option<Uint8Array> {
+        self.welcome.as_ref().map(|buf| Uint8Array::from(buf.as_slice()))
     }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MlsConversationInitMessage {
+    group: Vec<u8>,
+    message: Vec<u8>,
 }
 
 #[wasm_bindgen]
 impl MlsConversationInitMessage {
     #[wasm_bindgen(getter)]
-    pub fn message(&self) -> Box<[u8]> {
-        self.message.clone()
+    pub fn message(&self) -> Uint8Array {
+        Uint8Array::from(&*self.message)
     }
 
     #[wasm_bindgen(getter)]
-    pub fn group(&self) -> Box<[u8]> {
-        self.group.clone()
+    pub fn group(&self) -> Uint8Array {
+        Uint8Array::from(&*self.group)
     }
 }
 
 #[wasm_bindgen]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Invitee {
-    id: Box<[u8]>,
-    kp: Box<[u8]>,
+    id: Vec<u8>,
+    kp: Vec<u8>,
 }
 
 #[wasm_bindgen]
 impl Invitee {
     #[wasm_bindgen(constructor)]
-    pub fn new(id: Box<[u8]>, kp: Box<[u8]>) -> Self {
-        Self { id, kp }
+    pub fn new(id: Uint8Array, kp: Uint8Array) -> Self {
+        Self {
+            id: id.to_vec(),
+            kp: kp.to_vec(),
+        }
     }
 
     #[wasm_bindgen(getter)]
-    pub fn id(&self) -> Box<[u8]> {
-        self.id.clone()
+    pub fn id(&self) -> Uint8Array {
+        Uint8Array::from(&*self.id)
     }
 
     #[wasm_bindgen(getter)]
-    pub fn kp(&self) -> Box<[u8]> {
-        self.kp.clone()
+    pub fn kp(&self) -> Uint8Array {
+        Uint8Array::from(&*self.kp)
     }
 }
 
@@ -470,8 +474,21 @@ impl CoreCrypto {
         )
     }
 
+    /// Returns: WasmCryptoResult<usize>
+    pub fn client_valid_keypackages_count(&self) -> Promise {
+        let this = self.0.clone();
+
+        future_to_promise(
+            async move {
+                let count = this.read().await.client_valid_keypackages_count().await?;
+                WasmCryptoResult::Ok(count.into())
+            }
+            .err_into(),
+        )
+    }
+
     /// Returns: WasmCryptoResult<CommitBundle>
-    pub fn update_keying_material(&mut self, conversation_id: Box<[u8]>) -> Promise {
+    pub fn update_keying_material(&self, conversation_id: Box<[u8]>) -> Promise {
         let this = self.0.clone();
 
         future_to_promise(
@@ -483,14 +500,10 @@ impl CoreCrypto {
                     .await
                     .update_keying_material(conversation_id.to_vec())
                     .await?;
-                let message = result
-                    .0
-                    .tls_serialize_detached()
-                    .map_err(MlsError::from)?
-                    .into_boxed_slice();
+                let message = result.0.tls_serialize_detached().map_err(MlsError::from)?;
                 let welcome = result
                     .1
-                    .map(|v| v.tls_serialize_detached().map(|v| v.into_boxed_slice()))
+                    .map(|v| v.tls_serialize_detached())
                     .transpose()
                     .map_err(MlsError::from)?;
 
@@ -563,7 +576,7 @@ impl CoreCrypto {
         future_to_promise(
             async move {
                 let invitees = clients
-                    .into_iter()
+                    .iter()
                     .cloned()
                     .map(|js_client| Ok(serde_wasm_bindgen::from_value(js_client)?))
                     .collect::<WasmCryptoResult<Vec<Invitee>>>()?;
@@ -598,7 +611,7 @@ impl CoreCrypto {
         future_to_promise(
             async move {
                 let clients = clients
-                    .into_iter()
+                    .iter()
                     .cloned()
                     .map(|c| c.to_vec().into())
                     .collect::<Vec<ClientId>>();
@@ -624,7 +637,7 @@ impl CoreCrypto {
         future_to_promise(
             async move {
                 let other_clients = other_clients
-                    .into_iter()
+                    .iter()
                     .cloned()
                     .map(|c| c.to_vec().into())
                     .collect::<Vec<ClientId>>();
@@ -824,6 +837,7 @@ impl CoreCrypto {
         )
     }
 
+    #[allow(clippy::boxed_local)]
     pub fn join_by_external_commit(&self, group_state: Box<[u8]>) -> Promise {
         use core_crypto::prelude::tls_codec::Deserialize as _;
         use core_crypto::prelude::tls_codec::Serialize as _;
@@ -840,13 +854,11 @@ impl CoreCrypto {
                     message: message
                         .tls_serialize_detached()
                         .map_err(MlsError::from)
-                        .map_err(CryptoError::from)?
-                        .into_boxed_slice(),
+                        .map_err(CryptoError::from)?,
                     group: group
                         .tls_serialize_detached()
                         .map_err(MlsError::from)
-                        .map_err(CryptoError::from)?
-                        .into_boxed_slice(),
+                        .map_err(CryptoError::from)?,
                 };
                 WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&result)?)
             }

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -60,6 +60,9 @@ pub enum CryptoError {
     /// Error when trying to coerce ints into Strings
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
+    /// Error when trying to convert integer sizes - usually when they don't fit
+    #[error(transparent)]
+    ConvertIntError(#[from] std::num::TryFromIntError),
     /// Error when trying to coerce a Vec<u8> into a [u8 ; N]
     #[error("Byte array supplied did not have the expected size {0}")]
     InvalidByteArrayError(usize),

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -328,7 +328,10 @@ impl MlsCentral {
         self.mls_client.id().clone().into()
     }
 
-    /// Loads keypackages from the client and generates `KeyPackageBundle`s to return.
+    /// Returns `amount_requested` OpenMLS [`KeyPackageBundle`]s.
+    /// Will always return the requested amount as it will generate the necessary (lacking) amount on-the-fly
+    ///
+    /// Note: Keypackage pruning is performed as a first step
     ///
     /// # Arguments
     /// * `amount_requested` - number of KeyPackages to request and fill the `KeyPackageBundle`
@@ -342,6 +345,11 @@ impl MlsCentral {
         self.mls_client
             .request_keying_material(amount_requested, &self.mls_backend)
             .await
+    }
+
+    /// Returns the count of valid, non-expired, unclaimed keypackages in store
+    pub async fn client_valid_keypackages_count(&self) -> CryptoResult<usize> {
+        self.mls_client.valid_keypackages_count(&self.mls_backend).await
     }
 
     /// Create a new empty conversation

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -65,7 +65,7 @@ default-features = false
 features = ["rusqlite"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-rexie = "0.4"
+rexie = { version = "0.4", default-features = false, features = ["js"] }
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
 wasm-bindgen = "0.2"

--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -28,7 +28,7 @@ pub mod platform {
 }
 
 pub use self::platform::*;
-use crate::entities::{Entity, StringEntityId};
+use crate::entities::{Entity, EntityFindParams, StringEntityId};
 
 use crate::{CryptoKeystoreError, CryptoKeystoreResult};
 use async_lock::{Mutex, MutexGuard};
@@ -149,6 +149,14 @@ impl Connection {
         E::find_one(&mut *conn, &id.as_ref().into()).await
     }
 
+    pub async fn find_all<E: Entity<ConnectionType = KeystoreDatabaseConnection>>(
+        &self,
+        params: EntityFindParams,
+    ) -> CryptoKeystoreResult<Vec<E>> {
+        let mut conn = self.conn.lock().await;
+        E::find_all(&mut *conn, params).await
+    }
+
     pub async fn find_many<E: Entity<ConnectionType = KeystoreDatabaseConnection>, S: AsRef<[u8]>>(
         &self,
         ids: &[S],
@@ -163,7 +171,7 @@ impl Connection {
         id: S,
     ) -> CryptoKeystoreResult<()> {
         let mut conn = self.conn.lock().await;
-        E::delete(&mut *conn, &id.as_ref().into()).await?;
+        E::delete(&mut *conn, &[id.as_ref().into()]).await?;
         Ok(())
     }
 

--- a/keystore/src/connection/platform/wasm/mod.rs
+++ b/keystore/src/connection/platform/wasm/mod.rs
@@ -26,9 +26,6 @@ pub struct WasmConnection {
     conn: WasmEncryptedStorage,
 }
 
-// FIXME: Fix persitent storage's timeout
-// FIXME: Enable the persistent storage in mls-provider
-
 impl WasmConnection {
     pub fn storage(&self) -> &WasmEncryptedStorage {
         &self.conn

--- a/keystore/src/entities/platform/wasm/proteus/mod.rs
+++ b/keystore/src/entities/platform/wasm/proteus/mod.rs
@@ -29,25 +29,33 @@ impl EntityBase for ProteusPrekey {
         MissingKeyErrorKind::ProteusPrekey
     }
 
-    async fn save(&self, conn: &mut Self::ConnectionType) -> crate::CryptoKeystoreResult<()> {
-        conn.storage_mut().save("proteus_prekeys", &mut [self.clone()]).await?;
+    async fn find_all(conn: &mut Self::ConnectionType, params: EntityFindParams) -> CryptoKeystoreResult<Vec<Self>> {
+        let storage = conn.storage();
+        storage.get_all("proteus_prekeys", Some(params)).await
+    }
 
-        Ok(())
+    async fn save(&self, conn: &mut Self::ConnectionType) -> crate::CryptoKeystoreResult<()> {
+        let storage = conn.storage();
+        storage.save("proteus_prekeys", &mut [self.clone()]).await
     }
 
     async fn find_one(
         conn: &mut Self::ConnectionType,
         id: &StringEntityId,
     ) -> crate::CryptoKeystoreResult<Option<Self>> {
-        conn.storage().get("proteus_prekeys", id.as_bytes()).await
+        let storage = conn.storage();
+        storage.get("proteus_prekeys", id.as_bytes()).await
     }
 
     async fn count(conn: &mut Self::ConnectionType) -> crate::CryptoKeystoreResult<usize> {
-        conn.storage().count("proteus_prekeys").await
+        let storage = conn.storage();
+        storage.count("proteus_prekeys").await
     }
 
-    async fn delete(conn: &mut Self::ConnectionType, id: &StringEntityId) -> crate::CryptoKeystoreResult<()> {
-        conn.storage_mut().delete("proteus_prekeys", &[id.as_bytes()]).await
+    async fn delete(conn: &mut Self::ConnectionType, id: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
+        let storage = conn.storage_mut();
+        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+        storage.delete("proteus_prekeys", &ids).await
     }
 }
 

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -114,6 +114,7 @@ impl From<wasm_bindgen::JsValue> for CryptoKeystoreError {
 }
 
 #[cfg(target_family = "wasm")]
+#[allow(clippy::from_over_into)]
 impl Into<wasm_bindgen::JsValue> for CryptoKeystoreError {
     fn into(self) -> wasm_bindgen::JsValue {
         wasm_bindgen::JsValue::from_str(&self.to_string())

--- a/keystore/tests/common.rs
+++ b/keystore/tests/common.rs
@@ -27,7 +27,7 @@ const TEST_ENCRYPTION_KEY: &str = "test1234";
 pub fn store_name() -> String {
     use rand::Rng as _;
     let mut rng = rand::thread_rng();
-    let name: String = (0..6)
+    let name: String = (0usize..12)
         .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
         .collect();
     cfg_if::cfg_if! {

--- a/mls-provider/tests/fixtures.rs
+++ b/mls-provider/tests/fixtures.rs
@@ -24,11 +24,10 @@ use mls_crypto_provider::{EntropySeed, MlsCryptoProvider};
 
 const TEST_ENCRYPTION_KEY: &str = "test1234";
 
-#[fixture]
 pub fn store_name() -> String {
     use rand::Rng as _;
     let mut rng = rand::thread_rng();
-    let name: String = (0..6)
+    let name: String = (0..12)
         .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
         .collect();
     cfg_if::cfg_if! {
@@ -41,14 +40,12 @@ pub fn store_name() -> String {
 }
 
 #[fixture]
-pub async fn setup(
-    #[default(false)] in_memory: bool,
-    #[default(store_name())] name: impl AsRef<str>,
-) -> MlsCryptoProvider {
+pub async fn setup(#[default(false)] in_memory: bool) -> MlsCryptoProvider {
+    let store_name = store_name();
     let store = if !in_memory {
-        core_crypto_keystore::Connection::open_with_key(name, TEST_ENCRYPTION_KEY).await
+        core_crypto_keystore::Connection::open_with_key(store_name, TEST_ENCRYPTION_KEY).await
     } else {
-        core_crypto_keystore::Connection::open_in_memory_with_key(name, TEST_ENCRYPTION_KEY).await
+        core_crypto_keystore::Connection::open_in_memory_with_key(store_name, TEST_ENCRYPTION_KEY).await
     }
     .unwrap();
 
@@ -59,6 +56,7 @@ pub async fn setup(
 #[rstest]
 async fn use_provider(
     #[from(setup)]
+    #[with(true)]
     #[future]
     backend: MlsCryptoProvider,
 ) {
@@ -74,143 +72,143 @@ pub fn entropy() -> EntropySeed {
 #[template]
 #[rstest]
 #[case::ed25519_aes128__sys_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
     None
 )]
 #[case::ed25519_aes128__ext_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
     Some(entropy())
 )]
 #[case::ed25519_aes128__sys_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
     None
 )]
 #[case::ed25519_aes128__ext_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
     Some(entropy())
 )]
 #[case::p256_aes128__sys_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
     None
 )]
 #[case::p256_aes128__ext_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
     Some(entropy())
 )]
 #[case::p256_aes128__sys_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
     None
 )]
 #[case::p256_aes128__ext_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
     Some(entropy())
 )]
 #[case::ed25519_chacha20poly1305__sys_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
     None
 )]
 #[case::ed25519_chacha20poly1305__ext_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
     Some(entropy())
 )]
 #[case::ed25519_chacha20poly1305__sys_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
     None
 )]
 #[case::ed25519_chacha20poly1305__ext_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
     Some(entropy())
 )]
 // TODO: Those 3 next ciphersuites aren't supported because of the lack of both p521 (wip) and ed448 (status unknown) crates
 // #[case::ed448_aes256_sys_entropy__persistent(
-//     setup(false, store_name()),
+//     setup(false),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
 //     None
 // )]
 // #[case::ed448_aes256__ext_entropy__persistent(
-//     setup(false, store_name()),
+//     setup(false),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
 //     Some(entropy())
 // )]
 // #[case::ed448_aes256__sys_entropy__in_memory(
-//     setup(true, store_name()),
+//     setup(true),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
 //     None
 // )]
 // #[case::ed448_aes256__ext_entropy__in_memory(
-//     setup(true, store_name()),
+//     setup(true),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
 //     Some(entropy())
 // )]
 // #[case::p521_aes256__sys_entropy__persistent(
-//     setup(false, store_name()),
+//     setup(false),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
 //     None
 // )]
 // #[case::p521_aes256__ext_entropy__persistent(
-//     setup(false, store_name()),
+//     setup(false),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
 //     Some(entropy())
 // )]
 // #[case::p521_aes256__sys_entropy__in_memory(
-//     setup(true, store_name()),
+//     setup(true),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
 //     None
 // )]
 // #[case::p521_aes256__ext_entropy__in_memory(
-//     setup(true, store_name()),
+//     setup(true),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
 //     Some(entropy())
 // )]
 // #[case::ed448_chacha20poly1305_sys_entropy__persistent(
-//     setup(false, store_name()),
+//     setup(false),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
 //     None
 // )]
 // #[case::ed448_chacha20poly1305__ext_entropy__persistent(
-//     setup(false, store_name()),
+//     setup(false),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
 //     Some(entropy())
 // )]
 // #[case::ed448_chacha20poly1305__sys_entropy__in_memory(
-//     setup(true, store_name()),
+//     setup(true),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
 //     None
 // )]
 // #[case::ed448_chacha20poly1305__ext_entropy__in_memory(
-//     setup(true, store_name()),
+//     setup(true),
 //     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
 //     Some(entropy())
 // )]
 #[case::p384_aes256__sys_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
     None
 )]
 #[case::p384_aes256__ext_entropy__persistent(
-    setup(false, store_name()),
+    setup(false),
     openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
     Some(entropy())
 )]
 #[case::p384_aes256__sys_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
     None
 )]
 #[case::p384_aes256__ext_entropy__in_memory(
-    setup(true, store_name()),
+    setup(true),
     openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
     Some(entropy())
 )]

--- a/mls-provider/tests/randomness.rs
+++ b/mls-provider/tests/randomness.rs
@@ -36,15 +36,8 @@ pub mod tests {
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
 
-    #[apply(all_storage_types_and_ciphersuites)]
-    #[wasm_bindgen_test]
-    async fn can_generate_sufficient_randomness(
-        backend: MlsCryptoProvider,
-        _ciphersuite: Ciphersuite,
-        entropy_seed: Option<EntropySeed>,
-    ) {
-        let mut backend = backend.await;
-        backend.reseed(entropy_seed);
+    fn test_randomness(backend: &mut MlsCryptoProvider, entropy: Option<EntropySeed>) {
+        backend.reseed(entropy);
 
         let random = backend.rand();
         let mut hashes = Vec::with_capacity(ITER_ROUNDS);
@@ -70,7 +63,21 @@ pub mod tests {
             }
             hashes.push(hash);
         }
+    }
 
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn can_generate_sufficient_randomness_ext_entropy(backend: MlsCryptoProvider) {
+        let mut backend = backend.await;
+        test_randomness(&mut backend, Some(entropy()));
+        teardown(backend).await;
+    }
+
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn can_generate_sufficient_randomness_sys_entropy(backend: MlsCryptoProvider) {
+        let mut backend = backend.await;
+        test_randomness(&mut backend, None);
         teardown(backend).await;
     }
 


### PR DESCRIPTION
* Previous PR here: #32

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Keypackages that were past their configured lifetime would stay in the keystore, leading to duplication and maybe multi-use of Keypackages

### Solutions

* Added an API to allow consumers to manually prune uploaded Keypackages from the Keystore
	* Added warnings that this can be misused and direct calls to the method implies that the consumer knows what they're doing
* Add an API to get the count of valid KeyPackages.
* Added automatic calls to the keypackage pruning method to ensure lifetime-expired keypackages are removed from the store
* ~~Added automatic keypackage pruning of keypackage refs covered by a Welcome message~~
	* Edit: This has been discarded as OpenMLS does it internally already
* WASM API fixes + Added rustdoc comments in some places
	* Moved all `Box<[u8]>` getters to concrete JS `Uint8Array` because sometimes `wasm-bindgen` wouldn't get it right and it would end up as a JS `Array` of `number` (between 0 and 255) making it extremely inefficient and confusing API-wise.
	* Fixed an issue with async double borrows on WASM causing panics when certain mutable operations occur simultaneously
* Fixed some edge case bugs here and there

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

```
cargo test client_automatically_prunes_lifetime_expired_keypackages
cargo test client_generates_correct_number_of_kpbs
cargo test conversation_from_welcome_prunes_local_keypackage
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
