### PR TITLE
feat: Add ability to manually seed the PRNG entropy pool [CL-38]

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,8 @@ jobs:
 
     - name: Run build (wasm)
       run: |
-        wasm-pack build --release keystore
+        wasm-pack build keystore
+        wasm-pack build mls-provider
         wasm-pack build --release crypto
 
     - name: Run tests
@@ -56,5 +57,6 @@ jobs:
 
     - name: Run tests (wasm)
       run: |
-        wasm-pack test --release --headless --chrome keystore
+        wasm-pack test --headless --chrome keystore
+        wasm-pack test --headless --chrome mls-provider
         wasm-pack test --release --headless --chrome crypto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,25 @@ git = "https://github.com/wireapp/openmls"
 branch = "feat/async"
 package = "openmls"
 
-[patch.crates-io.openmls_rust_crypto]
-git = "https://github.com/wireapp/openmls"
-branch = "feat/async"
-package = "openmls_rust_crypto"
+# [patch.crates-io.openmls_rust_crypto]
+# git = "https://github.com/wireapp/openmls"
+# branch = "feat/async"
+# package = "openmls_rust_crypto"
+
+[patch.crates-io.hpke-rs]
+git = "https://github.com/wireapp/hpke-rs"
+branch = "fix/updated-deps"
+package = "hpke-rs"
+
+[patch.crates-io.hpke-rs-crypto]
+git = "https://github.com/wireapp/hpke-rs"
+branch = "fix/updated-deps"
+package = "hpke-rs-crypto"
+
+[patch.crates-io.hpke-rs-rust-crypto]
+git = "https://github.com/wireapp/hpke-rs"
+branch = "fix/updated-deps"
+package = "hpke-rs-rust-crypto"
 
 [patch.crates-io.openmls_traits]
 git = "https://github.com/wireapp/openmls"

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -36,6 +36,7 @@ async-executor = "1.4"
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+async-lock = "2.5"
 serde-wasm-bindgen = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 wee_alloc = "0.4"

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_57b9_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_4a3d_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_57b9_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_4a3d_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,119 +264,119 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_57b9_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_4a3d_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_57b9_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_57b9_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_4a3d_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_57b9_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_4a3d_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_4a3d_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_57b9_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_57b9_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_57b9_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_57b9_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_4a3d_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_57b9_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_4a3d_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_57b9_version(
+    fun CoreCrypto_4a3d_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_57b9_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_4a3d_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_57b9_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_4a3d_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_57b9_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_4a3d_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_57b9_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_4a3d_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -779,10 +779,10 @@ public interface CoreCryptoInterface {
 class CoreCrypto(
     pointer: Pointer
 ) : FFIObject(pointer), CoreCryptoInterface {
-    constructor(`path`: String, `key`: String, `clientId`: String) :
+    constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -795,7 +795,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_57b9_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_4a3d_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -803,7 +803,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -811,7 +811,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -820,7 +820,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -829,14 +829,14 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -845,7 +845,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -854,7 +854,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeMemberAddedMessages.lift(it)
@@ -863,7 +863,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -872,7 +872,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `leaveConversation`(`conversationId`: ConversationId, `otherClients`: List<ClientId>): ConversationLeaveMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
 }
         }.let {
             FfiConverterTypeConversationLeaveMessages.lift(it)
@@ -881,7 +881,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -890,7 +890,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -899,7 +899,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -908,7 +908,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -917,7 +917,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -926,7 +926,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -935,7 +935,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -944,7 +944,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -953,7 +953,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`groupState`: List<UByte>): MlsConversationInitMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
 }
         }.let {
             FfiConverterTypeMlsConversationInitMessage.lift(it)
@@ -962,7 +962,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -971,7 +971,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1413,7 +1413,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_57b9_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_4a3d_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -1690,10 +1690,10 @@ public typealias MemberId = List<UByte>
 public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 @Throws(CryptoException::class)
 
-fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String): CoreCrypto {
+fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -1702,7 +1702,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String): Cor
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_57b9_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_4a3d_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_57b9_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_4a3d_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_57b9_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_4a3d_rustbuffer_free(self, $0) }
     }
 }
 
@@ -438,20 +438,21 @@ public class CoreCrypto: CoreCryptoProtocol {
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.pointer = pointer
     }
-    public convenience init(path: String, key: String, clientId: String) throws {
+    public convenience init(path: String, key: String, clientId: String, entropySeed: [UInt8]?) throws {
         self.init(unsafeFromRawPointer: try
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_57b9_CoreCrypto_new(
+    CoreCrypto_4a3d_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
-        FfiConverterString.lower(clientId), $0)
+        FfiConverterString.lower(clientId), 
+        FfiConverterOptionSequenceUInt8.lower(entropySeed), $0)
 })
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_57b9_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_4a3d_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -460,7 +461,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -469,7 +470,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_4a3d_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -478,7 +479,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -487,7 +488,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -498,7 +499,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_57b9_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -508,7 +509,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -518,7 +519,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -529,7 +530,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -540,7 +541,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationLeaveMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_leave_conversation(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_leave_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(otherClients), $0
     )
@@ -551,7 +552,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -562,7 +563,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -573,7 +574,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -584,7 +585,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -594,7 +595,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -605,7 +606,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
@@ -617,7 +618,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -629,7 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -639,7 +640,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMlsConversationInitMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(groupState), $0
     )
 }
@@ -649,7 +650,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -658,7 +659,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_57b9_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_4a3d_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -1373,7 +1374,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_57b9_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_4a3d_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -1638,16 +1639,17 @@ fileprivate typealias FfiConverterTypeConversationId = FfiConverterSequenceUInt8
 public typealias MemberId = [UInt8]
 fileprivate typealias FfiConverterTypeMemberId = FfiConverterSequenceUInt8
 
-public func initWithPathAndKey(path: String, key: String, clientId: String) throws -> CoreCrypto {
+public func initWithPathAndKey(path: String, key: String, clientId: String, entropySeed: [UInt8]?) throws -> CoreCrypto {
     return try FfiConverterTypeCoreCrypto.lift(
         try
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_57b9_init_with_path_and_key(
+    CoreCrypto_4a3d_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
-        FfiConverterString.lower(clientId), $0)
+        FfiConverterString.lower(clientId), 
+        FfiConverterOptionSequenceUInt8.lower(entropySeed), $0)
 }
     )
 }
@@ -1660,7 +1662,7 @@ public func version()  -> String {
     
     rustCall() {
     
-    CoreCrypto_57b9_version($0)
+    CoreCrypto_4a3d_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
@@ -46,119 +46,119 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_57b9_CoreCrypto_object_free(
+void ffi_CoreCrypto_4a3d_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_57b9_CoreCrypto_new(
-      RustBuffer path,RustBuffer key,RustBuffer client_id,
+void*_Nonnull CoreCrypto_4a3d_CoreCrypto_new(
+      RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_57b9_CoreCrypto_set_callbacks(
+void CoreCrypto_4a3d_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_57b9_CoreCrypto_create_conversation(
+void CoreCrypto_4a3d_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_57b9_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_4a3d_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_leave_conversation(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_leave_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer other_clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer group_state,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_4a3d_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_57b9_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_4a3d_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_57b9_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_4a3d_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_57b9_init_with_path_and_key(
-      RustBuffer path,RustBuffer key,RustBuffer client_id,
+void*_Nonnull CoreCrypto_4a3d_init_with_path_and_key(
+      RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_57b9_version(
+RustBuffer CoreCrypto_4a3d_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_57b9_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_4a3d_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_57b9_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_4a3d_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_57b9_rustbuffer_free(
+void ffi_CoreCrypto_4a3d_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_57b9_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_4a3d_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -74,7 +74,7 @@ callback interface CoreCryptoCallbacks {
 
 interface CoreCrypto {
     [Throws=CryptoError, Name=new]
-    constructor([ByRef] string path, [ByRef] string key, [ByRef] string client_id);
+    constructor([ByRef] string path, [ByRef] string key, [ByRef] string client_id, sequence<u8>? entropy_seed);
 
     [Throws=CryptoError]
     void set_callbacks(CoreCryptoCallbacks callbacks);
@@ -134,11 +134,17 @@ interface CoreCrypto {
 
     [Throws=CryptoError]
     void merge_pending_group_from_external_commit(ConversationId conversation_id, ConversationConfiguration config);
+
+    [Throws=CryptoError]
+    sequence<u8> random_bytes(u64 length);
+
+    [Throws=CryptoError]
+    void reseed_rng(sequence<u8> seed);
 };
 
 namespace CoreCrypto {
     [Throws=CryptoError]
-    CoreCrypto init_with_path_and_key([ByRef] string path, [ByRef] string key, [ByRef] string client_id);
+    CoreCrypto init_with_path_and_key([ByRef] string path, [ByRef] string key, [ByRef] string client_id, sequence<u8>? entropy_seed);
 
     string version();
 };

--- a/crypto-ffi/src/generic/c_api/c_api_tests.rs
+++ b/crypto-ffi/src/generic/c_api/c_api_tests.rs
@@ -5,7 +5,7 @@ fn init() -> CoreCryptoPtrMut {
         let path = CStr::from_bytes_with_nul_unchecked(b"test.edb\0");
         let key = CStr::from_bytes_with_nul_unchecked(b"test\0");
         let client_id = CStr::from_bytes_with_nul_unchecked(b"test12345\0");
-        cc_init_with_path_and_key(path.as_ptr(), key.as_ptr(), client_id.as_ptr())
+        cc_init_with_path_and_key(path.as_ptr(), key.as_ptr(), client_id.as_ptr(), std::ptr::null())
     }
 }
 

--- a/crypto-ffi/src/generic/c_api/mod.rs
+++ b/crypto-ffi/src/generic/c_api/mod.rs
@@ -206,12 +206,22 @@ pub unsafe extern "C" fn cc_init_with_path_and_key(
     path: *const c_char,
     key: *const c_char,
     client_id: *const c_char,
+    entropy_seed: *const u8,
 ) -> CoreCryptoPtrMut<'static> {
     let path = CStr::from_ptr(path).to_string_lossy();
     let key = CStr::from_ptr(key).to_string_lossy();
     let client_id = CStr::from_ptr(client_id).to_string_lossy();
+    let entropy_seed = if entropy_seed.is_null() {
+        None
+    } else {
+        let expected_seed_len = std::mem::size_of::<EntropySeed>() / std::mem::size_of::<u8>();
+        Some(unsafe { std::slice::from_raw_parts(entropy_seed, expected_seed_len) })
+    };
 
-    let cc = try_ffi!(CoreCrypto::new(&path, &key, &client_id), std::ptr::null_mut());
+    let cc = try_ffi!(
+        CoreCrypto::new(&path, &key, &client_id, entropy_seed),
+        std::ptr::null_mut()
+    );
     Box::into_raw(Box::new(cc))
 }
 

--- a/crypto-ffi/src/generic/uniffi_support.rs
+++ b/crypto-ffi/src/generic/uniffi_support.rs
@@ -23,8 +23,14 @@ pub fn init_with_path_and_key<'a, 'b>(
     path: &'a str,
     key: &'a str,
     client_id: &'a str,
+    entropy_seed: Option<Vec<u8>>,
 ) -> CryptoResult<std::sync::Arc<crate::CoreCrypto<'b>>> {
-    Ok(std::sync::Arc::new(crate::CoreCrypto::new(path, key, client_id)?))
+    Ok(std::sync::Arc::new(crate::CoreCrypto::new(
+        path,
+        key,
+        client_id,
+        entropy_seed,
+    )?))
 }
 
 pub fn version() -> String {

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -38,6 +38,9 @@ pub enum CryptoError {
     /// A conversation member is out of local stored keypackages - if it does happen something went wrong
     #[error("Member #{0:x?} is out of keypackages")]
     OutOfKeyPackage(crate::member::MemberId),
+    /// Errors that are sent by our MLS Provider
+    #[error(transparent)]
+    MlsProviderError(#[from] mls_crypto_provider::MlsProviderError),
     /// Errors that are sent by our Keystore
     #[error(transparent)]
     KeyStoreError(#[from] core_crypto_keystore::CryptoKeystoreError),

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -86,7 +86,8 @@ uuid = { version = "1.0", features = ["v4", "js"] }
 rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
 openmls = { version = "0.4", default-features = false, features = ["crypto-subtle"] }
-openmls_rust_crypto_provider = { version = "0.1", package = "openmls_rust_crypto", features = ["provider", "single-threaded"] }
+# openmls_rust_crypto_provider = { version = "0.1", package = "openmls_rust_crypto", features = ["provider", "single-threaded"] }
+mls-crypto-provider = { path = "../mls-provider" }
 rstest = "0.15"
 rstest_reuse = "0.4"
 async-std = { version = "1.12", features = ["attributes"] }

--- a/keystore/tests/common.rs
+++ b/keystore/tests/common.rs
@@ -39,26 +39,21 @@ pub fn store_name() -> String {
     }
 }
 
-#[fixture(name = store_name())]
-pub async fn setup(name: impl AsRef<str>) -> core_crypto_keystore::Connection {
-    let store = core_crypto_keystore::Connection::open_with_key(name, TEST_ENCRYPTION_KEY)
-        .await
-        .unwrap();
-    store
-}
-
-#[fixture(name = store_name())]
-pub async fn setup_in_memory(name: impl AsRef<str>) -> core_crypto_keystore::Connection {
-    let store = core_crypto_keystore::Connection::open_in_memory_with_key(name, TEST_ENCRYPTION_KEY)
-        .await
-        .unwrap();
+#[fixture(name = store_name(), in_memory = false)]
+pub async fn setup(name: impl AsRef<str>, in_memory: bool) -> core_crypto_keystore::Connection {
+    let store = if !in_memory {
+        core_crypto_keystore::Connection::open_with_key(name, TEST_ENCRYPTION_KEY).await
+    } else {
+        core_crypto_keystore::Connection::open_in_memory_with_key(name, TEST_ENCRYPTION_KEY).await
+    }
+    .unwrap();
     store
 }
 
 #[template]
 #[rstest]
-#[case::persistent(setup(store_name()))]
-#[case::in_memory(setup_in_memory(store_name()))]
+#[case::persistent(setup(store_name(), false))]
+#[case::in_memory(setup(store_name(), true))]
 pub async fn all_storage_types(
     #[case]
     #[future]

--- a/keystore/tests/mls.rs
+++ b/keystore/tests/mls.rs
@@ -21,16 +21,22 @@ mod common;
 
 pub mod tests {
     use crate::common::*;
+    use openmls::prelude::Ciphersuite;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
+
+    use mls_crypto_provider::MlsCryptoProvider;
 
     use core_crypto_keystore::entities::{
         EntityBase, MlsIdentity, MlsIdentityExt as _, MlsKeypackage, PersistedMlsGroup,
     };
     use core_crypto_keystore::{Connection, MissingKeyErrorKind};
     use openmls::prelude::TlsSerializeTrait as _;
-    use openmls_traits::key_store::{FromKeyStoreValue as _, ToKeyStoreValue as _};
+    use openmls_traits::{
+        key_store::{FromKeyStoreValue as _, ToKeyStoreValue as _},
+        OpenMlsCryptoProvider as _,
+    };
 
     #[test]
     #[wasm_bindgen_test]
@@ -54,13 +60,12 @@ pub mod tests {
     #[apply(all_storage_types)]
     #[wasm_bindgen_test]
     pub async fn can_add_read_delete_credential_bundle_keystore(store: Connection) {
-        use openmls::{credentials::CredentialBundle, prelude::Ciphersuite};
-        use openmls_rust_crypto_provider::OpenMlsRustCrypto;
+        use openmls::credentials::CredentialBundle;
 
         let store = store.await;
-
-        let backend = OpenMlsRustCrypto::default();
         let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+        let backend = MlsCryptoProvider::new_with_store(store, None);
         let identity_id: [u8; 16] = rand::random();
         let identity_id = uuid::Uuid::from_bytes(identity_id);
 
@@ -83,9 +88,9 @@ pub mod tests {
             credential: credentials.to_key_store_value().unwrap(),
         };
 
-        store.save(identity).await.unwrap();
+        backend.key_store().save(identity).await.unwrap();
 
-        let mut conn = store.borrow_conn().await.unwrap();
+        let mut conn = backend.key_store().borrow_conn().await.unwrap();
         let identity2 = MlsIdentity::find_by_signature(&mut *conn, &signature)
             .await
             .unwrap()
@@ -99,24 +104,23 @@ pub mod tests {
         assert_eq!(b1_kp, b2_kp);
         assert_eq!(b1_sk.as_slice(), b2_sk.as_slice());
 
-        let mut conn = store.borrow_conn().await.unwrap();
+        let mut conn = backend.key_store().borrow_conn().await.unwrap();
         MlsIdentity::delete_by_signature(&mut *conn, &signature).await.unwrap();
 
         drop(conn);
 
-        teardown(store).await;
+        teardown(backend.unwrap_keystore()).await;
     }
 
     #[apply(all_storage_types)]
     #[wasm_bindgen_test]
     pub async fn can_add_read_delete_credential_bundle_openmls_traits(store: Connection) {
-        use openmls::{credentials::CredentialBundle, prelude::Ciphersuite};
-        use openmls_rust_crypto_provider::OpenMlsRustCrypto;
+        use openmls::credentials::CredentialBundle;
 
         let store = store.await;
-
-        let backend = OpenMlsRustCrypto::default();
         let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+        let backend = MlsCryptoProvider::new_with_store(store, None);
         let identity_id: [u8; 16] = rand::random();
         let identity_id = uuid::Uuid::from_bytes(identity_id);
 
@@ -138,16 +142,20 @@ pub mod tests {
             signature: signature.clone(),
             credential: credentials.to_key_store_value().unwrap(),
         };
-        store.save(identity).await.unwrap();
-        let credentials2: CredentialBundle = store.read(&signature).await.unwrap();
+        backend.key_store().save(identity).await.unwrap();
+        let credentials2: CredentialBundle = backend.key_store().read(&signature).await.unwrap();
         let (b1_kp, b1_sk) = credentials.into_parts();
         let (b2_kp, b2_sk) = credentials2.into_parts();
         assert_eq!(b1_kp, b2_kp);
         assert_eq!(b1_sk.as_slice(), b2_sk.as_slice());
 
-        store.delete::<CredentialBundle>(&signature).await.unwrap();
+        backend
+            .key_store()
+            .delete::<CredentialBundle>(&signature)
+            .await
+            .unwrap();
 
-        teardown(store).await;
+        teardown(backend.unwrap_keystore()).await;
     }
 
     #[apply(all_storage_types)]
@@ -157,14 +165,12 @@ pub mod tests {
             credentials::CredentialBundle,
             extensions::{Extension, ExternalKeyIdExtension},
             key_packages::KeyPackageBundle,
-            prelude::Ciphersuite,
         };
-        use openmls_rust_crypto_provider::OpenMlsRustCrypto;
 
         let store = store.await;
-
-        let backend = OpenMlsRustCrypto::default();
         let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
+        let backend = MlsCryptoProvider::new_with_store(store, None);
         let key_id: [u8; 16] = rand::random();
         let key_id = uuid::Uuid::from_bytes(key_id);
 
@@ -183,17 +189,25 @@ pub mod tests {
         keypackage_bundle.key_package().verify(&backend).unwrap();
 
         use openmls_traits::key_store::OpenMlsKeyStore as _;
-        store.store(key_string.as_bytes(), &keypackage_bundle).await.unwrap();
-        let bundle2: KeyPackageBundle = store.read(key_string.as_bytes()).await.unwrap();
+        backend
+            .key_store()
+            .store(key_string.as_bytes(), &keypackage_bundle)
+            .await
+            .unwrap();
+        let bundle2: KeyPackageBundle = backend.key_store().read(key_string.as_bytes()).await.unwrap();
         let (b1_kp, (b1_sk, b1_ls)) = keypackage_bundle.into_parts();
         let (b2_kp, (b2_sk, b2_ls)) = bundle2.into_parts();
         assert_eq!(b1_kp, b2_kp);
         assert_eq!(b1_sk, b2_sk);
         assert_eq!(b1_ls, b2_ls);
 
-        store.delete::<KeyPackageBundle>(key_string.as_bytes()).await.unwrap();
+        backend
+            .key_store()
+            .delete::<KeyPackageBundle>(key_string.as_bytes())
+            .await
+            .unwrap();
 
-        teardown(store).await;
+        teardown(backend.unwrap_keystore()).await;
     }
 
     #[apply(all_storage_types)]
@@ -203,13 +217,11 @@ pub mod tests {
             credentials::CredentialBundle,
             extensions::{Extension, ExternalKeyIdExtension},
             key_packages::KeyPackageBundle,
-            prelude::Ciphersuite,
         };
-        use openmls_rust_crypto_provider::OpenMlsRustCrypto;
 
         let store = store.await;
 
-        let backend = OpenMlsRustCrypto::default();
+        let backend = MlsCryptoProvider::new_with_store(store, None);
         let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
         let key_id: [u8; 16] = rand::random();
@@ -235,9 +247,9 @@ pub mod tests {
             key: keypackage_bundle.to_key_store_value().unwrap(),
         };
 
-        store.save(entity).await.unwrap();
+        backend.key_store().save(entity).await.unwrap();
 
-        let entity2: MlsKeypackage = store.find(key_string.as_bytes()).await.unwrap().unwrap();
+        let entity2: MlsKeypackage = backend.key_store().find(key_string.as_bytes()).await.unwrap().unwrap();
         let bundle2 = KeyPackageBundle::from_key_store_value(&entity2.key).unwrap();
 
         let (b1_kp, (b1_sk, b1_ls)) = keypackage_bundle.into_parts();
@@ -246,8 +258,12 @@ pub mod tests {
         assert_eq!(b1_sk, b2_sk);
         assert_eq!(b1_ls, b2_ls);
 
-        store.remove::<MlsKeypackage, _>(key_string.as_bytes()).await.unwrap();
+        backend
+            .key_store()
+            .remove::<MlsKeypackage, _>(key_string.as_bytes())
+            .await
+            .unwrap();
 
-        teardown(store).await;
+        teardown(backend.unwrap_keystore()).await;
     }
 }

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -8,10 +8,44 @@ license = "GPL-3.0-only"
 name = "mls_crypto_provider"
 crate-type = ["lib", "cdylib"]
 
+[features]
+default = []
+raw-rand-access = [] # TESTING ONLY
+
 [dependencies]
-openmls_rust_crypto = "0.1"
-openmls_traits = "0.1"
+openmls_traits = { version = "0.1", features = ["single-threaded"] }
+aes-gcm = "0.9"
+sha2 = "0.10"
+chacha20poly1305 = "0.9"
+hmac = "0.12"
+ed25519-dalek = "1.0"
+ecdsa = { version = "0.14", features = ["der"] }
+p256 = "0.11"
+p384 = "0.11"
+# TODO: Uncomment this once p521 crate is ready
+# p521 = { version = "0.11", git = "https://github.com/RustCrypto/elliptic-curves", package = "p521" }
+hkdf = "0.12"
+rand = { version = "0.8", features = ["getrandom"] }
+getrandom = { version = "0.2", features = ["js"] }
+rand_chacha = "0.3"
+hpke = { version = "0.1", package = "hpke-rs", default-features = false, features = ["hazmat", "serialization"] }
+hpke-rs-crypto = "0.1"
+hpke-rs-rust-crypto = "0.1"
+zeroize = "1.5"
+thiserror = "1.0"
 
 [dependencies.core-crypto-keystore]
 version = "0.3"
 path = "../keystore"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+uuid = { version = "1.0", features = ["v4", "js"] }
+openmls = { version = "0.4", default-features = false }
+rstest = "0.15"
+rstest_reuse = "0.4"
+async-std = { version = "1.12", features = ["attributes"] }
+cfg-if = "1.0"
+sha2 = "0.10"
+hex-literal = "0.3"
+mls-crypto-provider = { path = ".", features = ["raw-rand-access"] }

--- a/mls-provider/src/crypto_provider.rs
+++ b/mls-provider/src/crypto_provider.rs
@@ -1,0 +1,481 @@
+use std::sync::RwLock;
+
+use aes_gcm::{
+    aead::{Aead, Payload},
+    Aes128Gcm, Aes256Gcm, NewAead,
+};
+use chacha20poly1305::ChaCha20Poly1305;
+use ecdsa::{signature::Verifier, Signature, SigningKey, VerifyingKey};
+use ed25519_dalek::Signer as DalekSigner;
+use hkdf::Hkdf;
+use hpke::Hpke;
+use hpke_rs_crypto::types as hpke_types;
+use hpke_rs_rust_crypto::HpkeRustCrypto;
+use openmls_traits::{
+    crypto::OpenMlsCrypto,
+    random::OpenMlsRand,
+    types::{
+        self, AeadType, Ciphersuite, CryptoError, HashType, HpkeAeadType, HpkeCiphertext, HpkeConfig, HpkeKdfType,
+        HpkeKemType, HpkeKeyPair, SignatureScheme,
+    },
+};
+use rand::{RngCore, SeedableRng};
+use sha2::{Digest, Sha256, Sha384, Sha512};
+
+use crate::{EntropySeed, MlsProviderError};
+
+#[derive(Debug)]
+pub struct RustCrypto {
+    rng: RwLock<rand_chacha::ChaCha20Rng>,
+}
+
+impl Default for RustCrypto {
+    fn default() -> Self {
+        Self {
+            rng: rand_chacha::ChaCha20Rng::from_entropy().into(),
+        }
+    }
+}
+
+impl RustCrypto {
+    pub fn new_with_seed(seed: EntropySeed) -> Self {
+        Self {
+            rng: rand_chacha::ChaCha20Rng::from_seed(seed.0).into(),
+        }
+    }
+}
+
+#[cfg(feature = "raw-rand-access")]
+impl RustCrypto {
+    pub fn borrow_rand(&self) -> std::sync::RwLockWriteGuard<rand_chacha::ChaCha20Rng> {
+        self.rng.write().unwrap()
+    }
+}
+
+impl OpenMlsRand for RustCrypto {
+    type Error = MlsProviderError;
+
+    fn random_array<const N: usize>(&self) -> Result<[u8; N], Self::Error> {
+        let mut rng = self.rng.write().map_err(|_| MlsProviderError::RngLockPoison)?;
+        let mut out = [0u8; N];
+        rng.try_fill_bytes(&mut out)
+            .map_err(|_| MlsProviderError::UnsufficientEntropy)?;
+        Ok(out)
+    }
+
+    fn random_vec(&self, len: usize) -> Result<Vec<u8>, Self::Error> {
+        let mut rng = self.rng.write().map_err(|_| MlsProviderError::RngLockPoison)?;
+        let mut out = vec![0u8; len];
+        rng.try_fill_bytes(&mut out)
+            .map_err(|_| MlsProviderError::UnsufficientEntropy)?;
+        Ok(out)
+    }
+}
+
+#[inline]
+fn kem_mode(kem: HpkeKemType) -> hpke_types::KemAlgorithm {
+    match kem {
+        HpkeKemType::DhKemP256 => hpke_types::KemAlgorithm::DhKemP256,
+        HpkeKemType::DhKemP384 => hpke_types::KemAlgorithm::DhKemP384,
+        HpkeKemType::DhKemP521 => hpke_types::KemAlgorithm::DhKemP521,
+        HpkeKemType::DhKem25519 => hpke_types::KemAlgorithm::DhKem25519,
+        HpkeKemType::DhKem448 => hpke_types::KemAlgorithm::DhKem448,
+    }
+}
+
+#[inline]
+fn kdf_mode(kdf: HpkeKdfType) -> hpke_types::KdfAlgorithm {
+    match kdf {
+        HpkeKdfType::HkdfSha256 => hpke_types::KdfAlgorithm::HkdfSha256,
+        HpkeKdfType::HkdfSha384 => hpke_types::KdfAlgorithm::HkdfSha384,
+        HpkeKdfType::HkdfSha512 => hpke_types::KdfAlgorithm::HkdfSha512,
+    }
+}
+
+#[inline]
+fn aead_mode(aead: HpkeAeadType) -> hpke_types::AeadAlgorithm {
+    match aead {
+        HpkeAeadType::AesGcm128 => hpke_types::AeadAlgorithm::Aes128Gcm,
+        HpkeAeadType::AesGcm256 => hpke_types::AeadAlgorithm::Aes256Gcm,
+        HpkeAeadType::ChaCha20Poly1305 => hpke_types::AeadAlgorithm::ChaCha20Poly1305,
+        HpkeAeadType::Export => hpke_types::AeadAlgorithm::HpkeExport,
+    }
+}
+
+impl OpenMlsCrypto for RustCrypto {
+    fn supports(&self, ciphersuite: Ciphersuite) -> Result<(), CryptoError> {
+        match ciphersuite {
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
+            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
+            | Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => Ok(()),
+            _ => Err(CryptoError::UnsupportedCiphersuite),
+        }
+    }
+
+    fn supported_ciphersuites(&self) -> Vec<Ciphersuite> {
+        vec![
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+            Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+            Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+            Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+        ]
+    }
+
+    fn hkdf_extract(
+        &self,
+        hash_type: openmls_traits::types::HashType,
+        salt: &[u8],
+        ikm: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match hash_type {
+            HashType::Sha2_256 => Ok(Hkdf::<Sha256>::extract(Some(salt), ikm).0.as_slice().into()),
+            HashType::Sha2_384 => Ok(Hkdf::<Sha384>::extract(Some(salt), ikm).0.as_slice().into()),
+            HashType::Sha2_512 => Ok(Hkdf::<Sha512>::extract(Some(salt), ikm).0.as_slice().into()),
+        }
+    }
+
+    fn hkdf_expand(
+        &self,
+        hash_type: openmls_traits::types::HashType,
+        prk: &[u8],
+        info: &[u8],
+        okm_len: usize,
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        let mut okm = vec![0u8; okm_len];
+        match hash_type {
+            HashType::Sha2_256 => {
+                let hkdf = Hkdf::<Sha256>::from_prk(prk).map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                hkdf.expand(info, &mut okm)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+            }
+            HashType::Sha2_512 => {
+                let hkdf = Hkdf::<Sha512>::from_prk(prk).map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                hkdf.expand(info, &mut okm)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+            }
+            HashType::Sha2_384 => {
+                let hkdf = Hkdf::<Sha384>::from_prk(prk).map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+                hkdf.expand(info, &mut okm)
+                    .map_err(|_| CryptoError::HkdfOutputLengthInvalid)?;
+            }
+        }
+
+        Ok(okm)
+    }
+
+    fn hash(
+        &self,
+        hash_type: openmls_traits::types::HashType,
+        data: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match hash_type {
+            HashType::Sha2_256 => Ok(Sha256::digest(data).as_slice().into()),
+            HashType::Sha2_384 => Ok(Sha384::digest(data).as_slice().into()),
+            HashType::Sha2_512 => Ok(Sha512::digest(data).as_slice().into()),
+        }
+    }
+
+    fn aead_encrypt(
+        &self,
+        alg: openmls_traits::types::AeadType,
+        key: &[u8],
+        data: &[u8],
+        nonce: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match alg {
+            AeadType::Aes128Gcm => {
+                let aes = Aes128Gcm::new_from_slice(key).map_err(|_| CryptoError::InvalidLength)?;
+                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadEncryptionError)
+            }
+            AeadType::Aes256Gcm => {
+                let aes = Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::InvalidLength)?;
+                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadEncryptionError)
+            }
+            AeadType::ChaCha20Poly1305 => {
+                let chacha_poly = ChaCha20Poly1305::new_from_slice(key).map_err(|_| CryptoError::InvalidLength)?;
+                chacha_poly
+                    .encrypt(nonce.into(), Payload { msg: data, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadEncryptionError)
+            }
+        }
+    }
+
+    fn aead_decrypt(
+        &self,
+        alg: openmls_traits::types::AeadType,
+        key: &[u8],
+        ct_tag: &[u8],
+        nonce: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match alg {
+            AeadType::Aes128Gcm => {
+                let aes = Aes128Gcm::new_from_slice(key).map_err(|_| CryptoError::InvalidLength)?;
+                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadDecryptionError)
+            }
+            AeadType::Aes256Gcm => {
+                let aes = Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::InvalidLength)?;
+                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadDecryptionError)
+            }
+            AeadType::ChaCha20Poly1305 => {
+                let chacha_poly = ChaCha20Poly1305::new_from_slice(key).map_err(|_| CryptoError::InvalidLength)?;
+                chacha_poly
+                    .decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .map(|r| r.as_slice().into())
+                    .map_err(|_| CryptoError::AeadDecryptionError)
+            }
+        }
+    }
+
+    fn signature_key_gen(
+        &self,
+        alg: openmls_traits::types::SignatureScheme,
+    ) -> Result<(Vec<u8>, Vec<u8>), openmls_traits::types::CryptoError> {
+        match alg {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let mut rng = self.rng.write().map_err(|_| CryptoError::InsufficientRandomness)?;
+                let k = p256::ecdsa::SigningKey::random(&mut *rng);
+                let pk = k.verifying_key().to_encoded_point(false).as_bytes().into();
+                Ok((k.to_bytes().as_slice().into(), pk))
+            }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let mut rng = self.rng.write().map_err(|_| CryptoError::InsufficientRandomness)?;
+                let k = p384::ecdsa::SigningKey::random(&mut *rng);
+                let pk = k.verifying_key().to_encoded_point(false).as_bytes().into();
+                Ok((k.to_bytes().as_slice().into(), pk))
+            }
+            SignatureScheme::ECDSA_SECP521R1_SHA512 => {
+                // TODO: Uncomment this once p521 crate is ready
+                // let mut rng = self.rng.write().map_err(|_| CryptoError::InsufficientRandomness)?;
+                // let k = p521::ecdsa::SigningKey::random(&mut *rng);
+                // let pk = k.verifying_key().to_encoded_point(false).as_bytes().into();
+                // Ok((k.to_bytes().as_slice().into(), pk))
+                Err(CryptoError::UnsupportedSignatureScheme)
+            }
+            SignatureScheme::ED25519 => {
+                let mut rng = self.rng.write().map_err(|_| CryptoError::InsufficientRandomness)?;
+                // TODO: Once ed25519_dalek updates its `rand` dependency to rand_core 0.6, uncomment the following line and get rid of this mess
+                // let kp = ed25519_dalek::Keypair::generate(&mut rng);
+                let mut sk_bytes = [0u8; ed25519_dalek::SECRET_KEY_LENGTH];
+                rng.fill_bytes(&mut sk_bytes);
+                let sk = ed25519_dalek::SecretKey::from_bytes(sk_bytes.as_slice())
+                    .map_err(|_| CryptoError::InvalidLength)?;
+                let pk: ed25519_dalek::PublicKey = (&sk).into();
+                let mut kp_bytes = [0u8; ed25519_dalek::KEYPAIR_LENGTH];
+
+                let sk_bytes = sk.to_bytes();
+                if sk_bytes.len() != ed25519_dalek::SECRET_KEY_LENGTH {
+                    return Err(CryptoError::InvalidLength);
+                }
+                kp_bytes[..ed25519_dalek::SECRET_KEY_LENGTH].copy_from_slice(&sk_bytes);
+
+                let pk_bytes = pk.to_bytes();
+                if pk_bytes.len() != ed25519_dalek::KEYPAIR_LENGTH - ed25519_dalek::SECRET_KEY_LENGTH {
+                    return Err(CryptoError::InvalidLength);
+                }
+                kp_bytes[ed25519_dalek::SECRET_KEY_LENGTH..ed25519_dalek::KEYPAIR_LENGTH].copy_from_slice(&pk_bytes);
+
+                let k = ed25519_dalek::Keypair::from_bytes(kp_bytes.as_slice())
+                    .map_err(|_| CryptoError::InvalidLength)?
+                    .to_bytes();
+                let pk = k[ed25519_dalek::SECRET_KEY_LENGTH..].to_vec();
+                // full key here because we need it to sign...
+                let sk_pk = k.into();
+                Ok((sk_pk, pk))
+            }
+            SignatureScheme::ED448 => Err(CryptoError::UnsupportedSignatureScheme),
+        }
+    }
+
+    fn verify_signature(
+        &self,
+        alg: openmls_traits::types::SignatureScheme,
+        data: &[u8],
+        pk: &[u8],
+        signature: &[u8],
+    ) -> Result<(), openmls_traits::types::CryptoError> {
+        match alg {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let k: p256::ecdsa::VerifyingKey = VerifyingKey::from_encoded_point(
+                    &p256::EncodedPoint::from_bytes(pk).map_err(|_| CryptoError::InvalidLength)?,
+                )
+                .map_err(|_| CryptoError::InvalidLength)?;
+
+                k.verify(
+                    data,
+                    &Signature::from_der(signature).map_err(|_| CryptoError::InvalidSignature)?,
+                )
+                .map_err(|_| CryptoError::InvalidSignature)
+            }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k: p384::ecdsa::VerifyingKey = VerifyingKey::from_encoded_point(
+                    &p384::EncodedPoint::from_bytes(pk).map_err(|_| CryptoError::InvalidLength)?,
+                )
+                .map_err(|_| CryptoError::InvalidLength)?;
+
+                k.verify(
+                    data,
+                    &Signature::from_der(signature).map_err(|_| CryptoError::InvalidSignature)?,
+                )
+                .map_err(|_| CryptoError::InvalidSignature)
+            }
+            SignatureScheme::ECDSA_SECP521R1_SHA512 => {
+                // TODO: Uncomment this once p521 crate is ready
+                // let k: p521::ecdsa::VerifyingKey = VerifyingKey::from_encoded_point(
+                //     &p521::EncodedPoint::from_bytes(pk).map_err(|_| CryptoError::InvalidLength)?,
+                // )
+                // .map_err(|_| CryptoError::InvalidLength)?;
+
+                // k.verify(
+                //     data,
+                //     &Signature::from_der(signature).map_err(|_| CryptoError::InvalidSignature)?,
+                // )
+                // .map_err(|_| CryptoError::InvalidSignature)
+                Err(CryptoError::UnsupportedSignatureScheme)
+            }
+            SignatureScheme::ED25519 => {
+                let k = ed25519_dalek::PublicKey::from_bytes(pk).map_err(|_| CryptoError::InvalidLength)?;
+                if signature.len() != ed25519_dalek::SIGNATURE_LENGTH {
+                    return Err(CryptoError::InvalidLength);
+                }
+                let mut sig = [0u8; ed25519_dalek::SIGNATURE_LENGTH];
+                sig.clone_from_slice(signature);
+                k.verify_strict(
+                    data,
+                    &ed25519_dalek::Signature::from_bytes(&sig).map_err(|_| CryptoError::InvalidLength)?,
+                )
+                .map_err(|_| CryptoError::InvalidSignature)
+            }
+            SignatureScheme::ED448 => Err(CryptoError::UnsupportedSignatureScheme),
+        }
+    }
+
+    fn sign(
+        &self,
+        alg: openmls_traits::types::SignatureScheme,
+        data: &[u8],
+        key: &[u8],
+    ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        match alg {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let k: p256::ecdsa::SigningKey = SigningKey::from_bytes(key).map_err(|_| CryptoError::InvalidLength)?;
+                let signature = k.sign(data);
+                Ok(signature.to_der().to_bytes().into())
+            }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k: p384::ecdsa::SigningKey = SigningKey::from_bytes(key).map_err(|_| CryptoError::InvalidLength)?;
+                let signature = k.sign(data);
+                Ok(signature.to_der().to_bytes().into())
+            }
+            SignatureScheme::ECDSA_SECP521R1_SHA512 => Err(CryptoError::UnsupportedSignatureScheme),
+            SignatureScheme::ED25519 => {
+                let k = ed25519_dalek::Keypair::from_bytes(key).map_err(|_| CryptoError::InvalidLength)?;
+                let signature = k.sign(data);
+                Ok(signature.to_bytes().into())
+            }
+            SignatureScheme::ED448 => Err(CryptoError::UnsupportedSignatureScheme),
+        }
+    }
+
+    fn hpke_seal(
+        &self,
+        config: HpkeConfig,
+        pk_r: &[u8],
+        info: &[u8],
+        aad: &[u8],
+        ptxt: &[u8],
+    ) -> types::HpkeCiphertext {
+        let (kem_output, ciphertext) = hpke_from_config(config)
+            .seal(&pk_r.into(), info, aad, ptxt, None, None, None)
+            .unwrap();
+        HpkeCiphertext {
+            kem_output: kem_output.into(),
+            ciphertext: ciphertext.into(),
+        }
+    }
+
+    fn hpke_open(
+        &self,
+        config: HpkeConfig,
+        input: &types::HpkeCiphertext,
+        sk_r: &[u8],
+        info: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        hpke_from_config(config)
+            .open(
+                input.kem_output.as_slice(),
+                &sk_r.into(),
+                info,
+                aad,
+                input.ciphertext.as_slice(),
+                None,
+                None,
+                None,
+            )
+            .map_err(|_| CryptoError::HpkeDecryptionError)
+    }
+
+    fn hpke_setup_sender_and_export(
+        &self,
+        config: HpkeConfig,
+        pk_r: &[u8],
+        info: &[u8],
+        exporter_context: &[u8],
+        exporter_length: usize,
+    ) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
+        let (kem_output, context) = hpke_from_config(config)
+            .setup_sender(&pk_r.into(), info, None, None, None)
+            .map_err(|_| CryptoError::SenderSetupError)?;
+        let exported_secret = context
+            .export(exporter_context, exporter_length)
+            .map_err(|_| CryptoError::ExporterError)?;
+        Ok((kem_output, exported_secret))
+    }
+
+    fn hpke_setup_receiver_and_export(
+        &self,
+        config: HpkeConfig,
+        enc: &[u8],
+        sk_r: &[u8],
+        info: &[u8],
+        exporter_context: &[u8],
+        exporter_length: usize,
+    ) -> Result<Vec<u8>, CryptoError> {
+        let context = hpke_from_config(config)
+            .setup_receiver(enc, &sk_r.into(), info, None, None, None)
+            .map_err(|_| CryptoError::ReceiverSetupError)?;
+        let exported_secret = context
+            .export(exporter_context, exporter_length)
+            .map_err(|_| CryptoError::ExporterError)?;
+        Ok(exported_secret)
+    }
+
+    fn derive_hpke_keypair(&self, config: HpkeConfig, ikm: &[u8]) -> types::HpkeKeyPair {
+        let kp = hpke_from_config(config).derive_key_pair(ikm).unwrap().into_keys();
+        HpkeKeyPair {
+            private: kp.0.as_slice().into(),
+            public: kp.1.as_slice().into(),
+        }
+    }
+}
+
+fn hpke_from_config(config: HpkeConfig) -> Hpke<HpkeRustCrypto> {
+    Hpke::<HpkeRustCrypto>::new(
+        hpke::Mode::Base,
+        kem_mode(config.0),
+        kdf_mode(config.1),
+        aead_mode(config.2),
+    )
+}

--- a/mls-provider/src/error.rs
+++ b/mls-provider/src/error.rs
@@ -1,0 +1,71 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+
+#[derive(Debug, thiserror::Error)]
+pub enum MlsProviderError {
+    #[error(transparent)]
+    KeystoreError(#[from] core_crypto_keystore::CryptoKeystoreError),
+    #[error("The provided entropy seed has an incorrect length: expected {expected}, found {actual}")]
+    EntropySeedLengthError { actual: usize, expected: usize },
+    #[error("CSPRNG lock is poisoned")]
+    RngLockPoison,
+    #[error("Unable to collect enough randomness.")]
+    UnsufficientEntropy,
+    #[error("{0}")]
+    StringError(String),
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<String> for MlsProviderError {
+    fn into(self) -> String {
+        self.to_string()
+    }
+}
+
+/// Note: You *will* be losing context when cloning the error, because errors should never be `Clone`able,
+/// but OpenMLS traits require it, so...let's do something that makes no sense.
+impl Clone for MlsProviderError {
+    fn clone(&self) -> Self {
+        Self::StringError(self.to_string())
+    }
+}
+
+/// Note: You should never test errors for equality because stacktraces can be different, yet we're
+/// constrained by OpenMLS to do this kind of things. So once again...
+impl PartialEq for MlsProviderError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (MlsProviderError::KeystoreError(_), MlsProviderError::KeystoreError(_)) => todo!(),
+            (MlsProviderError::KeystoreError(_), _) => false,
+            (
+                MlsProviderError::EntropySeedLengthError { expected, actual },
+                MlsProviderError::EntropySeedLengthError {
+                    expected: expected2,
+                    actual: actual2,
+                },
+            ) => expected == expected2 && actual == actual2,
+            (MlsProviderError::EntropySeedLengthError { .. }, _) => false,
+            (MlsProviderError::StringError(s), MlsProviderError::StringError(s2)) => s == s2,
+            (MlsProviderError::StringError(_), _) => false,
+            (MlsProviderError::RngLockPoison, MlsProviderError::RngLockPoison) => true,
+            (MlsProviderError::RngLockPoison, _) => false,
+            (MlsProviderError::UnsufficientEntropy, MlsProviderError::UnsufficientEntropy) => true,
+            (MlsProviderError::UnsufficientEntropy, _) => false,
+        }
+    }
+}
+
+pub type MlsProviderResult<T> = Result<T, MlsProviderError>;

--- a/mls-provider/src/lib.rs
+++ b/mls-provider/src/lib.rs
@@ -14,8 +14,64 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use core_crypto_keystore::{Connection as CryptoKeystore, CryptoKeystoreResult};
-use openmls_rust_crypto::RustCrypto;
+use core_crypto_keystore::Connection as CryptoKeystore;
+
+mod crypto_provider;
+mod error;
+
+pub use error::{MlsProviderError, MlsProviderResult};
+
+pub use crypto_provider::RustCrypto;
+
+pub type RawEntropySeed = <rand_chacha::ChaCha20Rng as rand::SeedableRng>::Seed;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, zeroize::ZeroizeOnDrop)]
+#[repr(transparent)]
+pub struct EntropySeed(RawEntropySeed);
+
+impl EntropySeed {
+    pub const EXPECTED_LEN: usize = std::mem::size_of::<EntropySeed>() / std::mem::size_of::<u8>();
+
+    pub fn try_from_slice(data: &[u8]) -> MlsProviderResult<Self> {
+        if data.len() < Self::EXPECTED_LEN {
+            return Err(MlsProviderError::EntropySeedLengthError {
+                actual: data.len(),
+                expected: Self::EXPECTED_LEN,
+            });
+        }
+
+        let mut inner = RawEntropySeed::default();
+        inner.copy_from_slice(&data[..Self::EXPECTED_LEN]);
+
+        Ok(Self(inner))
+    }
+
+    pub fn from_raw(raw: RawEntropySeed) -> Self {
+        Self(raw)
+    }
+}
+
+impl std::ops::Deref for EntropySeed {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for EntropySeed {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MlsCryptoProviderConfiguration<'a> {
+    pub db_path: &'a str,
+    pub identity_key: &'a str,
+    pub in_memory: bool,
+    /// External seed for the ChaCha20 PRNG entropy pool
+    pub entropy_seed: Option<EntropySeed>,
+}
 
 #[derive(Debug)]
 pub struct MlsCryptoProvider {
@@ -24,24 +80,47 @@ pub struct MlsCryptoProvider {
 }
 
 impl MlsCryptoProvider {
-    pub async fn try_new(db_path: impl AsRef<str>, identity_key: impl AsRef<str>) -> CryptoKeystoreResult<Self> {
+    pub async fn try_new_with_configuration(config: MlsCryptoProviderConfiguration<'_>) -> MlsProviderResult<Self> {
+        let crypto = config.entropy_seed.map(RustCrypto::new_with_seed).unwrap_or_default();
+        let key_store = if config.in_memory {
+            CryptoKeystore::open_in_memory_with_key("", config.identity_key).await?
+        } else {
+            CryptoKeystore::open_with_key(config.db_path, config.identity_key).await?
+        };
+        Ok(Self { crypto, key_store })
+    }
+
+    pub async fn try_new(db_path: impl AsRef<str>, identity_key: impl AsRef<str>) -> MlsProviderResult<Self> {
         let crypto = RustCrypto::default();
         let key_store = CryptoKeystore::open_with_key(db_path, identity_key.as_ref()).await?;
         Ok(Self { crypto, key_store })
     }
 
-    pub async fn try_new_in_memory(identity_key: impl AsRef<str>) -> CryptoKeystoreResult<Self> {
+    pub async fn try_new_in_memory(identity_key: impl AsRef<str>) -> MlsProviderResult<Self> {
         let crypto = RustCrypto::default();
         let key_store = CryptoKeystore::open_in_memory_with_key("", identity_key.as_ref()).await?;
         Ok(Self { crypto, key_store })
     }
 
-    pub async fn close(self) -> CryptoKeystoreResult<()> {
-        self.key_store.close().await
+    pub fn new_with_store(key_store: CryptoKeystore, entropy_seed: Option<EntropySeed>) -> Self {
+        let crypto = entropy_seed.map(RustCrypto::new_with_seed).unwrap_or_default();
+        Self { crypto, key_store }
     }
 
-    pub async fn destroy_and_reset(self) -> CryptoKeystoreResult<()> {
-        self.key_store.wipe().await
+    pub fn reseed(&mut self, entropy_seed: Option<EntropySeed>) {
+        self.crypto = entropy_seed.map(RustCrypto::new_with_seed).unwrap_or_default();
+    }
+
+    pub async fn close(self) -> MlsProviderResult<()> {
+        Ok(self.key_store.close().await?)
+    }
+
+    pub async fn destroy_and_reset(self) -> MlsProviderResult<()> {
+        Ok(self.key_store.wipe().await?)
+    }
+
+    pub fn unwrap_keystore(self) -> CryptoKeystore {
+        self.key_store
     }
 }
 

--- a/mls-provider/tests/crypto.rs
+++ b/mls-provider/tests/crypto.rs
@@ -1,0 +1,223 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+#![allow(non_snake_case, dead_code, unused_macros, unused_imports)]
+
+pub use rstest::*;
+pub use rstest_reuse::{self, *};
+
+const LEN_RANGE: std::ops::RangeInclusive<usize> = 128..=1024;
+
+mod fixtures;
+
+#[cfg(test)]
+pub mod tests {
+    use crate::fixtures::*;
+    use crate::LEN_RANGE;
+    use hex_literal::hex;
+    use mls_crypto_provider::{EntropySeed, MlsCryptoProvider};
+    use openmls::prelude::Ciphersuite;
+    use openmls_traits::types::HpkeKeyPair;
+    use openmls_traits::{crypto::OpenMlsCrypto, random::OpenMlsRand, OpenMlsCryptoProvider};
+    use rand::Rng;
+
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn ciphersuite_support_is_consistent(backend: MlsCryptoProvider) {
+        let backend = backend.await;
+        let crypto = backend.crypto();
+        let supported = crypto.supported_ciphersuites();
+        for supported_cs in supported.into_iter() {
+            crypto.supports(supported_cs).unwrap();
+        }
+
+        teardown(backend).await;
+    }
+
+    #[apply(all_storage_types_and_ciphersuites)]
+    #[wasm_bindgen_test]
+    async fn hkdf_is_consistent(
+        backend: MlsCryptoProvider,
+        ciphersuite: Ciphersuite,
+        entropy_seed: Option<EntropySeed>,
+    ) {
+        let mut backend = backend.await;
+        backend.reseed(entropy_seed);
+        let len = rand::thread_rng().gen_range(LEN_RANGE);
+        let crypto = backend.crypto();
+        let ikm = hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        let salt = hex!("000102030405060708090a0b0c");
+        let info = hex!("f0f1f2f3f4f5f6f7f8f9");
+        let prk = crypto.hkdf_extract(ciphersuite.hash_algorithm(), &salt, &ikm).unwrap();
+        let supposed_prk_len = ciphersuite.hash_length();
+        assert_eq!(prk.len(), supposed_prk_len);
+
+        let okm = crypto
+            .hkdf_expand(ciphersuite.hash_algorithm(), &prk, &info, len)
+            .unwrap();
+
+        assert_eq!(okm.len(), len);
+
+        teardown(backend).await;
+    }
+
+    #[apply(all_storage_types_and_ciphersuites)]
+    #[wasm_bindgen_test]
+    async fn hash_is_consistent(
+        backend: MlsCryptoProvider,
+        ciphersuite: Ciphersuite,
+        entropy_seed: Option<EntropySeed>,
+    ) {
+        let mut backend = backend.await;
+        backend.reseed(entropy_seed);
+        let len = rand::thread_rng().gen_range(LEN_RANGE);
+        let data = backend.rand().random_vec(len).unwrap();
+        let crypto = backend.crypto();
+        let output = crypto.hash(ciphersuite.hash_algorithm(), &data).unwrap();
+        let supposed_output_len = ciphersuite.hash_length();
+        assert_eq!(output.len(), supposed_output_len);
+
+        teardown(backend).await;
+    }
+
+    #[apply(all_storage_types_and_ciphersuites)]
+    #[wasm_bindgen_test]
+    async fn aead_is_consistent_and_can_roundtrip(
+        backend: MlsCryptoProvider,
+        ciphersuite: Ciphersuite,
+        entropy_seed: Option<EntropySeed>,
+    ) {
+        let mut backend = backend.await;
+        backend.reseed(entropy_seed);
+        let len = rand::thread_rng().gen_range(LEN_RANGE);
+        let data = backend.rand().random_vec(len).unwrap();
+        let aad = backend
+            .rand()
+            .random_vec(rand::thread_rng().gen_range(LEN_RANGE))
+            .unwrap();
+        let nonce = backend.rand().random_vec(ciphersuite.aead_nonce_length()).unwrap();
+        let key = backend.rand().random_vec(ciphersuite.aead_key_length()).unwrap();
+
+        let crypto = backend.crypto();
+        let encrypted = crypto
+            .aead_encrypt(ciphersuite.aead_algorithm(), &key, &data, &nonce, &aad)
+            .unwrap();
+
+        assert_eq!(encrypted.len(), len + ciphersuite.mac_length());
+
+        let decrypted = crypto
+            .aead_decrypt(ciphersuite.aead_algorithm(), &key, &encrypted, &nonce, &aad)
+            .unwrap();
+
+        assert_eq!(data, decrypted);
+
+        teardown(backend).await;
+    }
+
+    #[apply(all_storage_types_and_ciphersuites)]
+    #[wasm_bindgen_test]
+    async fn signature_is_consistent(
+        backend: MlsCryptoProvider,
+        ciphersuite: Ciphersuite,
+        entropy_seed: Option<EntropySeed>,
+    ) {
+        let mut backend = backend.await;
+        backend.reseed(entropy_seed);
+        let crypto = backend.crypto();
+        let (sk, pk) = crypto.signature_key_gen(ciphersuite.signature_algorithm()).unwrap();
+
+        let len = rand::thread_rng().gen_range(LEN_RANGE);
+        let data = backend.rand().random_vec(len).unwrap();
+        let signature = crypto.sign(ciphersuite.signature_algorithm(), &data, &sk).unwrap();
+        crypto
+            .verify_signature(ciphersuite.signature_algorithm(), &data, &pk, &signature)
+            .unwrap();
+
+        teardown(backend).await;
+    }
+
+    #[apply(all_storage_types_and_ciphersuites)]
+    #[wasm_bindgen_test]
+    async fn hpke_is_consistent(
+        backend: MlsCryptoProvider,
+        ciphersuite: Ciphersuite,
+        entropy_seed: Option<EntropySeed>,
+    ) {
+        let mut backend = backend.await;
+        backend.reseed(entropy_seed);
+
+        let crypto = backend.crypto();
+
+        let message = backend
+            .rand()
+            .random_vec(rand::thread_rng().gen_range(LEN_RANGE))
+            .unwrap();
+
+        let aad = backend
+            .rand()
+            .random_vec(rand::thread_rng().gen_range(LEN_RANGE))
+            .unwrap();
+
+        let info = backend
+            .rand()
+            .random_vec(rand::thread_rng().gen_range(LEN_RANGE))
+            .unwrap();
+
+        let alice = crypto.derive_hpke_keypair(
+            ciphersuite.hpke_config(),
+            &backend
+                .rand()
+                .random_vec(rand::thread_rng().gen_range(LEN_RANGE))
+                .unwrap(),
+        );
+
+        let secret_message = crypto.hpke_seal(ciphersuite.hpke_config(), &alice.public, &info, &aad, &message);
+        let unsealed_secret_message = crypto
+            .hpke_open(ciphersuite.hpke_config(), &secret_message, &alice.private, &info, &aad)
+            .unwrap();
+
+        assert_eq!(unsealed_secret_message, message);
+
+        let hpke_info = b"MLS 1.0 external init";
+
+        let (kem, secret_tx) = crypto
+            .hpke_setup_sender_and_export(
+                ciphersuite.hpke_config(),
+                &alice.public,
+                &info,
+                hpke_info,
+                ciphersuite.hash_length(),
+            )
+            .unwrap();
+
+        let secret_rx = crypto
+            .hpke_setup_receiver_and_export(
+                ciphersuite.hpke_config(),
+                &kem,
+                &alice.private,
+                &info,
+                hpke_info,
+                ciphersuite.hash_length(),
+            )
+            .unwrap();
+
+        assert_eq!(secret_tx, secret_rx);
+
+        teardown(backend).await;
+    }
+}

--- a/mls-provider/tests/fixtures.rs
+++ b/mls-provider/tests/fixtures.rs
@@ -1,0 +1,230 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+#![allow(non_snake_case, dead_code, unused_macros, unused_imports)]
+
+use getrandom::getrandom;
+
+pub use rstest::*;
+pub use rstest_reuse::{self, *};
+
+use mls_crypto_provider::{EntropySeed, MlsCryptoProvider};
+
+const TEST_ENCRYPTION_KEY: &str = "test1234";
+
+#[fixture]
+pub fn store_name() -> String {
+    use rand::Rng as _;
+    let mut rng = rand::thread_rng();
+    let name: String = (0..6)
+        .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
+        .collect();
+    cfg_if::cfg_if! {
+        if #[cfg(target_family = "wasm")] {
+            format!("corecrypto.test.{}.edb", name)
+        } else {
+            format!("./test.{}.edb", name)
+        }
+    }
+}
+
+#[fixture]
+pub async fn setup(
+    #[default(false)] in_memory: bool,
+    #[default(store_name())] name: impl AsRef<str>,
+) -> MlsCryptoProvider {
+    let store = if !in_memory {
+        core_crypto_keystore::Connection::open_with_key(name, TEST_ENCRYPTION_KEY).await
+    } else {
+        core_crypto_keystore::Connection::open_in_memory_with_key(name, TEST_ENCRYPTION_KEY).await
+    }
+    .unwrap();
+
+    MlsCryptoProvider::new_with_store(store, None)
+}
+
+#[template]
+#[rstest]
+async fn use_provider(
+    #[from(setup)]
+    #[future]
+    backend: MlsCryptoProvider,
+) {
+}
+
+#[fixture]
+pub fn entropy() -> EntropySeed {
+    let mut seed: EntropySeed = Default::default();
+    getrandom(&mut seed).unwrap();
+    seed
+}
+
+#[template]
+#[rstest]
+#[case::ed25519_aes128__sys_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+    None
+)]
+#[case::ed25519_aes128__ext_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+    Some(entropy())
+)]
+#[case::ed25519_aes128__sys_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+    None
+)]
+#[case::ed25519_aes128__ext_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+    Some(entropy())
+)]
+#[case::p256_aes128__sys_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+    None
+)]
+#[case::p256_aes128__ext_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+    Some(entropy())
+)]
+#[case::p256_aes128__sys_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+    None
+)]
+#[case::p256_aes128__ext_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
+    Some(entropy())
+)]
+#[case::ed25519_chacha20poly1305__sys_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+    None
+)]
+#[case::ed25519_chacha20poly1305__ext_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+    Some(entropy())
+)]
+#[case::ed25519_chacha20poly1305__sys_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+    None
+)]
+#[case::ed25519_chacha20poly1305__ext_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+    Some(entropy())
+)]
+// TODO: Those 3 next ciphersuites aren't supported because of the lack of both p521 (wip) and ed448 (status unknown) crates
+// #[case::ed448_aes256_sys_entropy__persistent(
+//     setup(false, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
+//     None
+// )]
+// #[case::ed448_aes256__ext_entropy__persistent(
+//     setup(false, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
+//     Some(entropy())
+// )]
+// #[case::ed448_aes256__sys_entropy__in_memory(
+//     setup(true, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
+//     None
+// )]
+// #[case::ed448_aes256__ext_entropy__in_memory(
+//     setup(true, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448,
+//     Some(entropy())
+// )]
+// #[case::p521_aes256__sys_entropy__persistent(
+//     setup(false, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
+//     None
+// )]
+// #[case::p521_aes256__ext_entropy__persistent(
+//     setup(false, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
+//     Some(entropy())
+// )]
+// #[case::p521_aes256__sys_entropy__in_memory(
+//     setup(true, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
+//     None
+// )]
+// #[case::p521_aes256__ext_entropy__in_memory(
+//     setup(true, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
+//     Some(entropy())
+// )]
+// #[case::ed448_chacha20poly1305_sys_entropy__persistent(
+//     setup(false, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
+//     None
+// )]
+// #[case::ed448_chacha20poly1305__ext_entropy__persistent(
+//     setup(false, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
+//     Some(entropy())
+// )]
+// #[case::ed448_chacha20poly1305__sys_entropy__in_memory(
+//     setup(true, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
+//     None
+// )]
+// #[case::ed448_chacha20poly1305__ext_entropy__in_memory(
+//     setup(true, store_name()),
+//     openmls::prelude::Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448,
+//     Some(entropy())
+// )]
+#[case::p384_aes256__sys_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+    None
+)]
+#[case::p384_aes256__ext_entropy__persistent(
+    setup(false, store_name()),
+    openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+    Some(entropy())
+)]
+#[case::p384_aes256__sys_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+    None
+)]
+#[case::p384_aes256__ext_entropy__in_memory(
+    setup(true, store_name()),
+    openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
+    Some(entropy())
+)]
+pub fn all_storage_types_and_ciphersuites(
+    #[case]
+    #[future]
+    backend: MlsCryptoProvider,
+    #[case] ciphersuite: openmls::prelude::Ciphersuite,
+    #[case] entropy_seed: Option<EntropySeed>,
+) {
+}
+
+#[inline(always)]
+pub async fn teardown(backend: MlsCryptoProvider) {
+    let store = backend.unwrap_keystore();
+    store.wipe().await.unwrap();
+}

--- a/mls-provider/tests/randomness.rs
+++ b/mls-provider/tests/randomness.rs
@@ -1,0 +1,227 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+#![allow(non_snake_case, dead_code, unused_macros, unused_imports)]
+
+pub use rstest::*;
+pub use rstest_reuse::{self, *};
+
+mod fixtures;
+
+const ITER_ROUNDS: usize = 10000;
+const RAND_ARR_LEN: usize = 128;
+
+#[cfg(test)]
+pub mod tests {
+    use crate::{fixtures::*, ITER_ROUNDS, RAND_ARR_LEN};
+    use getrandom::getrandom;
+    use mls_crypto_provider::{EntropySeed, MlsCryptoProvider};
+    use openmls::prelude::Ciphersuite;
+    use openmls_traits::{random::OpenMlsRand, OpenMlsCryptoProvider};
+    use rand::RngCore as _;
+    use sha2::{Digest, Sha256};
+
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[apply(all_storage_types_and_ciphersuites)]
+    #[wasm_bindgen_test]
+    async fn can_generate_sufficient_randomness(
+        backend: MlsCryptoProvider,
+        _ciphersuite: Ciphersuite,
+        entropy_seed: Option<EntropySeed>,
+    ) {
+        let mut backend = backend.await;
+        backend.reseed(entropy_seed);
+
+        let random = backend.rand();
+        let mut hashes = Vec::with_capacity(ITER_ROUNDS);
+
+        for _ in 0..ITER_ROUNDS / 2 {
+            let arr: [u8; RAND_ARR_LEN] = random.random_array().unwrap();
+            let mut hasher = Sha256::new();
+            hasher.update(arr);
+            let hash = hasher.finalize();
+            if hashes.contains(&hash) {
+                panic!("Entropy isn't sufficient")
+            }
+            hashes.push(hash);
+        }
+
+        for _ in 0..ITER_ROUNDS / 2 {
+            let arr = random.random_vec(RAND_ARR_LEN).unwrap();
+            let mut hasher = Sha256::new();
+            hasher.update(arr);
+            let hash = hasher.finalize();
+            if hashes.contains(&hash) {
+                panic!("Entropy isn't sufficient")
+            }
+            hashes.push(hash);
+        }
+
+        teardown(backend).await;
+    }
+
+    // ? Test vectors taken from https://github.com/rust-random/rand/blob/c797f070b125084d727dc0ba5104bbdae966ba78/rand_chacha/src/chacha.rs#L411
+
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn can_be_externally_seeded_ietf_vectors_1_2(backend: MlsCryptoProvider) {
+        let mut backend = backend.await;
+        // Test vectors 1 and 2 from
+        // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
+        let seed = [0u8; 32];
+        backend.reseed(Some(EntropySeed::from_raw(seed)));
+        let mut rng = backend.rand().borrow_rand();
+
+        let mut results = [0u32; 16];
+        for i in results.iter_mut() {
+            *i = rng.next_u32();
+        }
+        let expected = [
+            0xade0b876, 0x903df1a0, 0xe56a5d40, 0x28bd8653, 0xb819d2bd, 0x1aed8da0, 0xccef36a8, 0xc70d778b, 0x7c5941da,
+            0x8d485751, 0x3fe02477, 0x374ad8b8, 0xf4b8436a, 0x1ca11815, 0x69b687c3, 0x8665eeb2,
+        ];
+        assert_eq!(results, expected);
+
+        for i in results.iter_mut() {
+            *i = rng.next_u32();
+        }
+        let expected = [
+            0xbee7079f, 0x7a385155, 0x7c97ba98, 0x0d082d73, 0xa0290fcb, 0x6965e348, 0x3e53c612, 0xed7aee32, 0x7621b729,
+            0x434ee69c, 0xb03371d5, 0xd539d874, 0x281fed31, 0x45fb0a51, 0x1f0ae1ac, 0x6f4d794b,
+        ];
+        assert_eq!(results, expected);
+
+        drop(rng);
+
+        teardown(backend).await;
+    }
+
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn can_be_externally_seeded_ietf_vector_3(backend: MlsCryptoProvider) {
+        let mut backend = backend.await;
+        // Test vector 3 from
+        // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
+        let seed = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ];
+        backend.reseed(Some(EntropySeed::from_raw(seed)));
+        let mut rng = backend.rand().borrow_rand();
+
+        // Skip block 0
+        for _ in 0..16 {
+            rng.next_u32();
+        }
+
+        let mut results = [0u32; 16];
+        for i in results.iter_mut() {
+            *i = rng.next_u32();
+        }
+        let expected = [
+            0x2452eb3a, 0x9249f8ec, 0x8d829d9b, 0xddd4ceb1, 0xe8252083, 0x60818b01, 0xf38422b8, 0x5aaa49c9, 0xbb00ca8e,
+            0xda3ba7b4, 0xc4b592d1, 0xfdf2732f, 0x4436274e, 0x2561b3c8, 0xebdd4aa6, 0xa0136c00,
+        ];
+        assert_eq!(results, expected);
+
+        drop(rng);
+
+        teardown(backend).await;
+    }
+
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn can_be_externally_seeded_ietf_vector_4(backend: MlsCryptoProvider) {
+        let mut backend = backend.await;
+        // Test vector 4 from
+        // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
+        let seed = [
+            0, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let expected = [
+            0xfb4dd572, 0x4bc42ef1, 0xdf922636, 0x327f1394, 0xa78dea8f, 0x5e269039, 0xa1bebbc1, 0xcaf09aae, 0xa25ab213,
+            0x48a6b46c, 0x1b9d9bcb, 0x092c5be6, 0x546ca624, 0x1bec45d5, 0x87f47473, 0x96f0992e,
+        ];
+        let expected_end = 3 * 16;
+        let mut results = [0u32; 16];
+
+        // Test block 2 by skipping block 0 and 1
+        backend.reseed(Some(EntropySeed::from_raw(seed)));
+        let mut rng1 = backend.rand().borrow_rand();
+        for _ in 0..32 {
+            rng1.next_u32();
+        }
+        for i in results.iter_mut() {
+            *i = rng1.next_u32();
+        }
+        assert_eq!(results, expected);
+        assert_eq!(rng1.get_word_pos(), expected_end);
+
+        drop(rng1);
+
+        // Test block 2 by using `set_word_pos`
+        backend.reseed(Some(EntropySeed::from_raw(seed)));
+        let mut rng2 = backend.rand().borrow_rand();
+        rng2.set_word_pos(2 * 16);
+        for i in results.iter_mut() {
+            *i = rng2.next_u32();
+        }
+        assert_eq!(results, expected);
+        assert_eq!(rng2.get_word_pos(), expected_end);
+
+        let mut buf = [0u8; 32];
+        rng2.fill_bytes(&mut buf[..]);
+        assert_eq!(rng2.get_word_pos(), expected_end + 8);
+        rng2.fill_bytes(&mut buf[0..25]);
+        assert_eq!(rng2.get_word_pos(), expected_end + 15);
+        rng2.next_u64();
+        assert_eq!(rng2.get_word_pos(), expected_end + 17);
+        rng2.next_u32();
+        rng2.next_u64();
+        assert_eq!(rng2.get_word_pos(), expected_end + 20);
+        rng2.fill_bytes(&mut buf[0..1]);
+        assert_eq!(rng2.get_word_pos(), expected_end + 21);
+
+        drop(rng2);
+        teardown(backend).await;
+    }
+
+    #[apply(use_provider)]
+    #[wasm_bindgen_test]
+    async fn can_be_externally_seeded_ietf_vector_5(backend: MlsCryptoProvider) {
+        let mut backend = backend.await;
+        // Test vector 5 from
+        // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
+        let seed = [0u8; 32];
+        backend.reseed(Some(EntropySeed::from_raw(seed)));
+        let mut rng = backend.rand().borrow_rand();
+        // 96-bit nonce in LE order is: 0,0,0,0, 0,0,0,0, 0,0,0,2
+        rng.set_stream(2u64 << (24 + 32));
+
+        let mut results = [0u32; 16];
+        for i in results.iter_mut() {
+            *i = rng.next_u32();
+        }
+        let expected = [
+            0x374dc6c2, 0x3736d58c, 0xb904e24a, 0xcd3f93ef, 0x88228b1a, 0x96a4dfb3, 0x5b76ab72, 0xc727ee54, 0x0e0e978a,
+            0xf3145c95, 0x1b748ea8, 0xf786c297, 0x99c28f5f, 0x628314e8, 0x398a19fa, 0x6ded1b53,
+        ];
+        assert_eq!(results, expected);
+
+        drop(rng);
+        teardown(backend).await;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@otak/core-crypto",
-    "version": "0.3.0-beta-1",
+    "version": "0.3.0-beta-2",
     "description": "CoreCrypto bindings for the Web - Dev version",
     "type": "module",
     "module": "platforms/web/corecrypto.js",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Ability to insert external entropy from outside of `getrandom`

### Solutions

* Added an ability to insert external entropy from outside of `getrandom`
* Added support for P384 ciphersuites
	* Note: P521 code is ready but the Rust `p521` crate is not ready yet
	* Note: Ed448 support is an unknown. There's no official RustCrypto crate for it and the others are very much manual things and getting your hands dirty

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

```
cd mls-provider
cargo test
```

### Notes (Optional)

A lot of parametric tests have been added to the MLS provider, to test using all the scenarios: storage backends, ciphersuites, etc


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
