### PR TITLE
feat!: add commit delay when a message with prending proposals is processed [CL-52]

### DIFF
--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_b846_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_cb14_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_b846_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_cb14_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,131 +264,131 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_b846_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_cb14_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_b846_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_b846_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_cb14_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_b846_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_cb14_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_cb14_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_cb14_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_b846_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_b846_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_b846_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_b846_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_cb14_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_b846_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_cb14_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_b846_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_cb14_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_b846_version(
+    fun CoreCrypto_cb14_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_b846_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_cb14_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_b846_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_cb14_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_b846_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_cb14_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_b846_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_cb14_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -455,26 +455,6 @@ public object FfiConverterULong: FfiConverter<ULong, Long> {
 
     override fun write(value: ULong, buf: ByteBuffer) {
         buf.putLong(value.toLong())
-    }
-}
-
-public object FfiConverterFloat: FfiConverter<Float, Float> {
-    override fun lift(value: Float): Float {
-        return value
-    }
-
-    override fun read(buf: ByteBuffer): Float {
-        return buf.getFloat()
-    }
-
-    override fun lower(value: Float): Float {
-        return value
-    }
-
-    override fun allocationSize(value: Float) = 4
-
-    override fun write(value: Float, buf: ByteBuffer) {
-        buf.putFloat(value)
     }
 }
 
@@ -777,7 +757,7 @@ public interface CoreCryptoInterface {
     fun `leaveConversation`(`conversationId`: ConversationId, `otherClients`: List<ClientId>): ConversationLeaveMessages
     
     @Throws(CryptoException::class)
-    fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): List<UByte>?
+    fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage
     
     @Throws(CryptoException::class)
     fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte>
@@ -823,7 +803,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -836,7 +816,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_b846_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_cb14_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -844,7 +824,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -852,7 +832,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -861,7 +841,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -870,7 +850,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -879,14 +859,14 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -895,7 +875,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -904,7 +884,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeMemberAddedMessages.lift(it)
@@ -913,7 +893,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -922,25 +902,25 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `leaveConversation`(`conversationId`: ConversationId, `otherClients`: List<ClientId>): ConversationLeaveMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
 }
         }.let {
             FfiConverterTypeConversationLeaveMessages.lift(it)
         }
     
-    @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): List<UByte>? =
+    @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
-            FfiConverterOptionalSequenceUByte.lift(it)
+            FfiConverterTypeDecryptedMessage.lift(it)
         }
     
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -949,7 +929,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -958,7 +938,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -967,7 +947,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -976,7 +956,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -985,7 +965,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -994,7 +974,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1003,7 +983,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`groupState`: List<UByte>): MlsConversationInitMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
 }
         }.let {
             FfiConverterTypeMlsConversationInitMessage.lift(it)
@@ -1012,7 +992,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1021,7 +1001,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1029,7 +1009,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1038,7 +1018,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1169,7 +1149,7 @@ public object FfiConverterTypeConversationLeaveMessages: FfiConverterRustBuffer<
 
 data class DecryptedMessage (
     var `message`: List<UByte>?, 
-    var `commitDelay`: Float
+    var `commitDelay`: ULong?
 ) {
     
 }
@@ -1178,18 +1158,18 @@ public object FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer<Decrypted
     override fun read(buf: ByteBuffer): DecryptedMessage {
         return DecryptedMessage(
             FfiConverterOptionalSequenceUByte.read(buf),
-            FfiConverterFloat.read(buf),
+            FfiConverterOptionalULong.read(buf),
         )
     }
 
     override fun allocationSize(value: DecryptedMessage) = (
             FfiConverterOptionalSequenceUByte.allocationSize(value.`message`) +
-            FfiConverterFloat.allocationSize(value.`commitDelay`)
+            FfiConverterOptionalULong.allocationSize(value.`commitDelay`)
     )
 
     override fun write(value: DecryptedMessage, buf: ByteBuffer) {
             FfiConverterOptionalSequenceUByte.write(value.`message`, buf)
-            FfiConverterFloat.write(value.`commitDelay`, buf)
+            FfiConverterOptionalULong.write(value.`commitDelay`, buf)
     }
 }
 
@@ -1327,6 +1307,7 @@ sealed class CryptoException(message: String): Exception(message) {
         class InvalidByteArrayException(message: String) : CryptoException(message)
         class IoException(message: String) : CryptoException(message)
         class Unauthorized(message: String) : CryptoException(message)
+        class SelfKeypackageNotFound(message: String) : CryptoException(message)
         
 
     companion object ErrorHandler : CallStatusErrorHandler<CryptoException> {
@@ -1355,6 +1336,7 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
             15 -> CryptoException.InvalidByteArrayException(FfiConverterString.read(buf))
             16 -> CryptoException.IoException(FfiConverterString.read(buf))
             17 -> CryptoException.Unauthorized(FfiConverterString.read(buf))
+            18 -> CryptoException.SelfKeypackageNotFound(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
         
@@ -1513,7 +1495,36 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_cb14_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalULong: FfiConverterRustBuffer<ULong?> {
+    override fun read(buf: ByteBuffer): ULong? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterULong.read(buf)
+    }
+
+    override fun allocationSize(value: ULong?): Int {
+        if (value == null) {
+            return 1
+        } else {
+            return 1 + FfiConverterULong.allocationSize(value)
+        }
+    }
+
+    override fun write(value: ULong?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterULong.write(value, buf)
         }
     }
 }
@@ -1793,7 +1804,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -1802,7 +1813,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_b846_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_cb14_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_cc12_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_b846_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_cc12_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_b846_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,131 +264,131 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_cc12_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_b846_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_cc12_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_cc12_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_b846_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_cc12_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_b846_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_b846_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_cc12_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_cc12_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_cc12_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_leave_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`otherClients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`groupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_cc12_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_b846_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_cc12_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_cc12_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_b846_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_cc12_version(
+    fun CoreCrypto_b846_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_cc12_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_b846_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_cc12_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_b846_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_cc12_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_b846_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_cc12_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_b846_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -455,6 +455,26 @@ public object FfiConverterULong: FfiConverter<ULong, Long> {
 
     override fun write(value: ULong, buf: ByteBuffer) {
         buf.putLong(value.toLong())
+    }
+}
+
+public object FfiConverterFloat: FfiConverter<Float, Float> {
+    override fun lift(value: Float): Float {
+        return value
+    }
+
+    override fun read(buf: ByteBuffer): Float {
+        return buf.getFloat()
+    }
+
+    override fun lower(value: Float): Float {
+        return value
+    }
+
+    override fun allocationSize(value: Float) = 4
+
+    override fun write(value: Float, buf: ByteBuffer) {
+        buf.putFloat(value)
     }
 }
 
@@ -803,7 +823,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -816,7 +836,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_cc12_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_b846_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -824,7 +844,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -832,7 +852,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -841,7 +861,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -850,7 +870,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -859,14 +879,14 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -875,7 +895,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -884,7 +904,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeMemberAddedMessages.lift(it)
@@ -893,7 +913,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -902,7 +922,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `leaveConversation`(`conversationId`: ConversationId, `otherClients`: List<ClientId>): ConversationLeaveMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_leave_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`otherClients`),  _status)
 }
         }.let {
             FfiConverterTypeConversationLeaveMessages.lift(it)
@@ -911,7 +931,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): List<UByte>? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterOptionalSequenceUByte.lift(it)
@@ -920,7 +940,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -929,7 +949,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -938,7 +958,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -947,7 +967,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -956,7 +976,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackage`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -965,7 +985,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -974,7 +994,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -983,7 +1003,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`groupState`: List<UByte>): MlsConversationInitMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`groupState`),  _status)
 }
         }.let {
             FfiConverterTypeMlsConversationInitMessage.lift(it)
@@ -992,7 +1012,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1001,7 +1021,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1009,7 +1029,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1018,7 +1038,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1141,6 +1161,35 @@ public object FfiConverterTypeConversationLeaveMessages: FfiConverterRustBuffer<
     override fun write(value: ConversationLeaveMessages, buf: ByteBuffer) {
             FfiConverterSequenceUByte.write(value.`selfRemovalProposal`, buf)
             FfiConverterOptionalSequenceUByte.write(value.`otherClientsRemovalCommit`, buf)
+    }
+}
+
+
+
+
+data class DecryptedMessage (
+    var `message`: List<UByte>?, 
+    var `commitDelay`: Float
+) {
+    
+}
+
+public object FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer<DecryptedMessage> {
+    override fun read(buf: ByteBuffer): DecryptedMessage {
+        return DecryptedMessage(
+            FfiConverterOptionalSequenceUByte.read(buf),
+            FfiConverterFloat.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: DecryptedMessage) = (
+            FfiConverterOptionalSequenceUByte.allocationSize(value.`message`) +
+            FfiConverterFloat.allocationSize(value.`commitDelay`)
+    )
+
+    override fun write(value: DecryptedMessage, buf: ByteBuffer) {
+            FfiConverterOptionalSequenceUByte.write(value.`message`, buf)
+            FfiConverterFloat.write(value.`commitDelay`, buf)
     }
 }
 
@@ -1464,7 +1513,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -1744,7 +1793,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -1753,7 +1802,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_cc12_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_b846_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_b846_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_cb14_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_b846_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_cb14_rustbuffer_free(self, $0) }
     }
 }
 
@@ -320,19 +320,6 @@ fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
     }
 }
 
-fileprivate struct FfiConverterFloat: FfiConverterPrimitive {
-    typealias FfiType = Float
-    typealias SwiftType = Float
-
-    static func read(from buf: Reader) throws -> Float {
-        return try lift(buf.readFloat())
-    }
-
-    static func write(_ value: Float, into buf: Writer) {
-        buf.writeFloat(lower(value))
-    }
-}
-
 fileprivate struct FfiConverterBool : FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool
@@ -429,7 +416,7 @@ public protocol CoreCryptoProtocol {
     func addClientsToConversation(conversationId: ConversationId, clients: [Invitee]) throws -> MemberAddedMessages?
     func removeClientsFromConversation(conversationId: ConversationId, clients: [ClientId]) throws -> [UInt8]?
     func leaveConversation(conversationId: ConversationId, otherClients: [ClientId]) throws -> ConversationLeaveMessages
-    func decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> [UInt8]?
+    func decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> DecryptedMessage
     func encryptMessage(conversationId: ConversationId, message: [UInt8]) throws -> [UInt8]
     func newAddProposal(conversationId: ConversationId, keyPackage: [UInt8]) throws -> [UInt8]
     func newUpdateProposal(conversationId: ConversationId) throws -> [UInt8]
@@ -459,7 +446,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_b846_CoreCrypto_new(
+    CoreCrypto_cb14_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -468,7 +455,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_b846_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_cb14_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -477,7 +464,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -486,7 +473,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_cb14_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -495,7 +482,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -505,7 +492,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_cb14_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -513,7 +500,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -524,7 +511,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_b846_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -534,7 +521,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -544,7 +531,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -555,7 +542,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -566,18 +553,18 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationLeaveMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_leave_conversation(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_leave_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(otherClients), $0
     )
 }
         )
     }
-    public func decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> [UInt8]? {
-        return try FfiConverterOptionSequenceUInt8.lift(
+    public func decryptMessage(conversationId: ConversationId, payload: [UInt8]) throws -> DecryptedMessage {
+        return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -588,7 +575,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -599,7 +586,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -610,7 +597,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -620,7 +607,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -631,7 +618,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
@@ -643,7 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -655,7 +642,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -665,7 +652,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMlsConversationInitMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(groupState), $0
     )
 }
@@ -675,7 +662,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -684,7 +671,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -694,7 +681,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -703,7 +690,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_b846_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_cb14_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -899,11 +886,11 @@ fileprivate struct FfiConverterTypeConversationLeaveMessages: FfiConverterRustBu
 
 public struct DecryptedMessage {
     public var message: [UInt8]?
-    public var commitDelay: Float
+    public var commitDelay: UInt64?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(message: [UInt8]?, commitDelay: Float) {
+    public init(message: [UInt8]?, commitDelay: UInt64?) {
         self.message = message
         self.commitDelay = commitDelay
     }
@@ -932,13 +919,13 @@ fileprivate struct FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer {
     fileprivate static func read(from buf: Reader) throws -> DecryptedMessage {
         return try DecryptedMessage(
             message: FfiConverterOptionSequenceUInt8.read(from: buf), 
-            commitDelay: FfiConverterFloat.read(from: buf)
+            commitDelay: FfiConverterOptionUInt64.read(from: buf)
         )
     }
 
     fileprivate static func write(_ value: DecryptedMessage, into buf: Writer) {
         FfiConverterOptionSequenceUInt8.write(value.message, into: buf)
-        FfiConverterFloat.write(value.commitDelay, into: buf)
+        FfiConverterOptionUInt64.write(value.commitDelay, into: buf)
     }
 }
 
@@ -1213,6 +1200,9 @@ public enum CryptoError {
     // Simple error enums only carry a message
     case Unauthorized(message: String)
     
+    // Simple error enums only carry a message
+    case SelfKeypackageNotFound(message: String)
+    
 }
 
 fileprivate struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
@@ -1293,6 +1283,10 @@ fileprivate struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: buf)
         )
         
+        case 18: return .SelfKeypackageNotFound(
+            message: try FfiConverterString.read(from: buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -1354,6 +1348,9 @@ fileprivate struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             FfiConverterString.write(message, into: buf)
         case let .Unauthorized(message):
             buf.writeInt(Int32(17))
+            FfiConverterString.write(message, into: buf)
+        case let .SelfKeypackageNotFound(message):
+            buf.writeInt(Int32(18))
             FfiConverterString.write(message, into: buf)
 
         
@@ -1483,7 +1480,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_cb14_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -1527,6 +1524,27 @@ extension FfiConverterCallbackInterfaceCoreCryptoCallbacks : FfiConverter {
     static func write(_ v: SwiftType, into buf: Writer) {
         ensureCallbackinitialized();
         buf.writeInt(lower(v))
+    }
+}
+
+fileprivate struct FfiConverterOptionUInt64: FfiConverterRustBuffer {
+    typealias SwiftType = UInt64?
+
+    static func write(_ value: SwiftType, into buf: Writer) {
+        guard let value = value else {
+            buf.writeInt(Int8(0))
+            return
+        }
+        buf.writeInt(Int8(1))
+        FfiConverterUInt64.write(value, into: buf)
+    }
+
+    static func read(from buf: Reader) throws -> SwiftType {
+        switch try buf.readInt() as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterUInt64.read(from: buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
     }
 }
 
@@ -1754,7 +1772,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_b846_init_with_path_and_key(
+    CoreCrypto_cb14_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -1771,7 +1789,7 @@ public func version()  -> String {
     
     rustCall() {
     
-    CoreCrypto_b846_version($0)
+    CoreCrypto_cb14_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_cc12_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_b846_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_cc12_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_b846_rustbuffer_free(self, $0) }
     }
 }
 
@@ -320,6 +320,19 @@ fileprivate struct FfiConverterUInt64: FfiConverterPrimitive {
     }
 }
 
+fileprivate struct FfiConverterFloat: FfiConverterPrimitive {
+    typealias FfiType = Float
+    typealias SwiftType = Float
+
+    static func read(from buf: Reader) throws -> Float {
+        return try lift(buf.readFloat())
+    }
+
+    static func write(_ value: Float, into buf: Writer) {
+        buf.writeFloat(lower(value))
+    }
+}
+
 fileprivate struct FfiConverterBool : FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool
@@ -446,7 +459,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_cc12_CoreCrypto_new(
+    CoreCrypto_b846_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -455,7 +468,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_cc12_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_b846_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -464,7 +477,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -473,7 +486,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_b846_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -482,7 +495,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -492,7 +505,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -500,7 +513,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -511,7 +524,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_cc12_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -521,7 +534,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -531,7 +544,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -542,7 +555,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -553,7 +566,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationLeaveMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_leave_conversation(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_leave_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(otherClients), $0
     )
@@ -564,7 +577,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -575,7 +588,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -586,7 +599,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -597,7 +610,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -607,7 +620,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -618,7 +631,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
@@ -630,7 +643,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -642,7 +655,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -652,7 +665,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMlsConversationInitMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(groupState), $0
     )
 }
@@ -662,7 +675,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -671,7 +684,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -681,7 +694,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -690,7 +703,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_cc12_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_b846_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -880,6 +893,52 @@ fileprivate struct FfiConverterTypeConversationLeaveMessages: FfiConverterRustBu
     fileprivate static func write(_ value: ConversationLeaveMessages, into buf: Writer) {
         FfiConverterSequenceUInt8.write(value.selfRemovalProposal, into: buf)
         FfiConverterOptionSequenceUInt8.write(value.otherClientsRemovalCommit, into: buf)
+    }
+}
+
+
+public struct DecryptedMessage {
+    public var message: [UInt8]?
+    public var commitDelay: Float
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(message: [UInt8]?, commitDelay: Float) {
+        self.message = message
+        self.commitDelay = commitDelay
+    }
+}
+
+
+extension DecryptedMessage: Equatable, Hashable {
+    public static func ==(lhs: DecryptedMessage, rhs: DecryptedMessage) -> Bool {
+        if lhs.message != rhs.message {
+            return false
+        }
+        if lhs.commitDelay != rhs.commitDelay {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(message)
+        hasher.combine(commitDelay)
+    }
+}
+
+
+fileprivate struct FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer {
+    fileprivate static func read(from buf: Reader) throws -> DecryptedMessage {
+        return try DecryptedMessage(
+            message: FfiConverterOptionSequenceUInt8.read(from: buf), 
+            commitDelay: FfiConverterFloat.read(from: buf)
+        )
+    }
+
+    fileprivate static func write(_ value: DecryptedMessage, into buf: Writer) {
+        FfiConverterOptionSequenceUInt8.write(value.message, into: buf)
+        FfiConverterFloat.write(value.commitDelay, into: buf)
     }
 }
 
@@ -1424,7 +1483,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -1695,7 +1754,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_cc12_init_with_path_and_key(
+    CoreCrypto_b846_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -1712,7 +1771,7 @@ public func version()  -> String {
     
     rustCall() {
     
-    CoreCrypto_cc12_version($0)
+    CoreCrypto_b846_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
@@ -46,131 +46,131 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_b846_CoreCrypto_object_free(
+void ffi_CoreCrypto_cb14_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_b846_CoreCrypto_new(
+void*_Nonnull CoreCrypto_cb14_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_b846_CoreCrypto_set_callbacks(
+void CoreCrypto_cb14_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_cb14_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_cb14_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_cb14_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_b846_CoreCrypto_create_conversation(
+void CoreCrypto_cb14_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_b846_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_cb14_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_cb14_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_cb14_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_cb14_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_leave_conversation(
+RustBuffer CoreCrypto_cb14_CoreCrypto_leave_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer other_clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_cb14_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_cb14_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_cb14_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_cb14_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_cb14_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_cb14_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_cb14_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_cb14_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_cb14_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer group_state,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_cb14_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_cb14_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_cb14_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_b846_CoreCrypto_reseed_rng(
+void CoreCrypto_cb14_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_cb14_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_b846_init_with_path_and_key(
+void*_Nonnull CoreCrypto_cb14_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_b846_version(
+RustBuffer CoreCrypto_cb14_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_b846_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_cb14_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_b846_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_cb14_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_b846_rustbuffer_free(
+void ffi_CoreCrypto_cb14_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_b846_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_cb14_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/include/core_cryptoFFI.h
@@ -46,131 +46,131 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_cc12_CoreCrypto_object_free(
+void ffi_CoreCrypto_b846_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_cc12_CoreCrypto_new(
+void*_Nonnull CoreCrypto_b846_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_cc12_CoreCrypto_set_callbacks(
+void CoreCrypto_b846_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_b846_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_b846_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_cc12_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_b846_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_cc12_CoreCrypto_create_conversation(
+void CoreCrypto_b846_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_cc12_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_b846_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_b846_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_b846_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_b846_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_leave_conversation(
+RustBuffer CoreCrypto_b846_CoreCrypto_leave_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer other_clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_b846_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_b846_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_b846_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_b846_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_b846_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_b846_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_b846_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_b846_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_b846_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer group_state,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_b846_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_cc12_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_b846_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_b846_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_cc12_CoreCrypto_reseed_rng(
+void CoreCrypto_b846_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_cc12_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_b846_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_cc12_init_with_path_and_key(
+void*_Nonnull CoreCrypto_b846_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_cc12_version(
+RustBuffer CoreCrypto_b846_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_cc12_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_b846_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_cc12_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_b846_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_cc12_rustbuffer_free(
+void ffi_CoreCrypto_b846_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_cc12_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_b846_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -35,12 +35,13 @@ enum CryptoError {
     "ConvertIntError",
     "InvalidByteArrayError",
     "IoError",
-    "Unauthorized"
+    "Unauthorized",
+    "SelfKeypackageNotFound"
 };
 
 dictionary DecryptedMessage {
     sequence<u8>? message;
-    float commit_delay;
+    u64? commit_delay;
 };
 
 dictionary MemberAddedMessages {
@@ -113,7 +114,7 @@ interface CoreCrypto {
     ConversationLeaveMessages leave_conversation(ConversationId conversation_id, [ByRef] sequence<ClientId> other_clients);
 
     [Throws=CryptoError]
-    sequence<u8>? decrypt_message(ConversationId conversation_id, [ByRef] sequence<u8> payload);
+    DecryptedMessage decrypt_message(ConversationId conversation_id, [ByRef] sequence<u8> payload);
 
     [Throws=CryptoError]
     sequence<u8> encrypt_message(ConversationId conversation_id, [ByRef] sequence<u8> message);

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -38,6 +38,11 @@ enum CryptoError {
     "Unauthorized"
 };
 
+dictionary DecryptedMessage {
+    sequence<u8>? message;
+    float commit_delay;
+};
+
 dictionary MemberAddedMessages {
     sequence<u8> message;
     sequence<u8> welcome;

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -31,6 +31,7 @@ pub use core_crypto::prelude::{CiphersuiteName, ClientId, ConversationId, CoreCr
 pub use core_crypto::CryptoError;
 
 use futures_lite::future;
+use futures_util::TryFutureExt;
 
 #[cfg_attr(feature = "c-api", repr(C))]
 #[derive(Debug)]
@@ -74,6 +75,13 @@ pub struct CommitBundle {
 pub struct MlsConversationInitMessage {
     pub group: Vec<u8>,
     pub message: Vec<u8>,
+}
+
+#[cfg_attr(feature = "c-api", repr(C))]
+#[derive(Debug)]
+pub struct DecryptedMessage {
+    pub message: Option<Vec<u8>>,
+    pub commit_delay: Option<f32>,
 }
 
 impl Invitee {
@@ -347,13 +355,14 @@ impl CoreCrypto<'_> {
         Ok(ret)
     }
 
-    pub fn decrypt_message(&self, conversation_id: ConversationId, payload: &[u8]) -> CryptoResult<Option<Vec<u8>>> {
+    pub fn decrypt_message(&self, conversation_id: ConversationId, payload: &[u8]) -> CryptoResult<DecryptedMessage> {
         future::block_on(
             self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                 self.central
                     .lock()
                     .map_err(|_| CryptoError::LockPoisonError)?
-                    .decrypt_message(conversation_id, payload),
+                    .decrypt_message(conversation_id, payload)
+                    .map_ok(|(message, commit_delay)| DecryptedMessage { message, commit_delay }),
             ),
         )
     }

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -81,7 +81,7 @@ pub struct MlsConversationInitMessage {
 #[derive(Debug)]
 pub struct DecryptedMessage {
     pub message: Option<Vec<u8>>,
-    pub commit_delay: Option<f32>,
+    pub commit_delay: Option<u64>,
 }
 
 impl Invitee {

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -205,7 +205,7 @@ impl MlsConversationInitMessage {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DecryptedMessage {
     message: Option<Vec<u8>>,
-    commit_delay: Option<f32>,
+    commit_delay: Option<u64>,
 }
 
 #[wasm_bindgen]
@@ -216,7 +216,7 @@ impl DecryptedMessage {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn commit_delay(&self) -> Option<f32> {
+    pub fn commit_delay(&self) -> Option<u64> {
         self.commit_delay
     }
 }

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -203,6 +203,26 @@ impl MlsConversationInitMessage {
 
 #[wasm_bindgen]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DecryptedMessage {
+    message: Option<Vec<u8>>,
+    commit_delay: Option<f32>,
+}
+
+#[wasm_bindgen]
+impl DecryptedMessage {
+    #[wasm_bindgen(getter)]
+    pub fn message(&self) -> Option<Uint8Array> {
+        self.message.clone().map(|m| Uint8Array::from(&*m))
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn commit_delay(&self) -> Option<f32> {
+        self.commit_delay
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Invitee {
     id: Vec<u8>,
     kp: Vec<u8>,
@@ -671,14 +691,14 @@ impl CoreCrypto {
         let this = self.0.clone();
         future_to_promise(
             async move {
-                let maybe_cleartext = this
+                let decrypted_message = this
                     .write()
                     .await
                     .decrypt_message(conversation_id.to_vec(), payload)
-                    .await?
-                    .map(|cleartext| Uint8Array::from(cleartext.as_slice()));
+                    .await
+                    .map(|(message, commit_delay)| DecryptedMessage { message, commit_delay })?;
 
-                WasmCryptoResult::Ok(maybe_cleartext.map(Into::into).unwrap_or(JsValue::NULL))
+                WasmCryptoResult::Ok(decrypted_message.into())
             }
             .err_into(),
         )

--- a/crypto/src/commit_delay.rs
+++ b/crypto/src/commit_delay.rs
@@ -1,0 +1,104 @@
+use std::num::TryFromIntError;
+
+/// These constants intend to ramp up the delay and flatten the curve for later positions
+const DELAY_RAMP_UP_MULTIPLIER: f32 = 120.0;
+const DELAY_RAMP_UP_SUB: u64 = 106;
+
+pub(crate) fn calculate_delay(self_index: usize, epoch: u64, total_members: usize) -> Result<u64, TryFromIntError> {
+    let self_index: u64 = self_index.try_into()?;
+    let total_members: u64 = total_members.try_into()?;
+    let position = ((epoch % total_members) + (self_index % total_members)) % total_members + 1;
+    let result = match position {
+        1 => 0,
+        2 => 15,
+        3 => 30,
+        _ => (((position as f32).ln() * DELAY_RAMP_UP_MULTIPLIER) as u64).saturating_sub(DELAY_RAMP_UP_SUB),
+    };
+    Ok(result)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    pub fn test_calculate_delay_single() {
+        let (self_index, epoch, total_members) = (0, 0, 1);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 0);
+    }
+
+    #[test]
+    pub fn test_calculate_delay_max() {
+        let (self_index, epoch, total_members) = (usize::MAX, u64::MAX, usize::MAX);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 0);
+    }
+
+    #[test]
+    pub fn test_calculate_delay_min() {
+        let (self_index, epoch, total_members) = (usize::MIN, u64::MIN, usize::MAX);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    pub fn test_calculate_delay_panic() {
+        let (self_index, epoch, total_members) = (0, 0, usize::MIN);
+        // total members can never be 0 as there's no group with 0 members and it will panic
+        // when trying to calculate the remainder of 0
+        calculate_delay(self_index, epoch, total_members).unwrap();
+    }
+
+    #[test]
+    pub fn test_calculate_delay_min_max() {
+        let (self_index, epoch, total_members) = (usize::MIN, u64::MAX, usize::MAX);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 0);
+    }
+
+    #[test]
+    pub fn test_calculate_delay_first() {
+        let (self_index, epoch, total_members) = (9, 1, 10);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 0);
+    }
+
+    #[test]
+    pub fn test_calculate_delay_second() {
+        let (self_index, epoch, total_members) = (0, 1, 10);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 15);
+    }
+
+    #[test]
+    pub fn test_calculate_delay_third() {
+        let (self_index, epoch, total_members) = (1, 1, 10);
+        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+        assert_eq!(delay, 30);
+    }
+
+    #[test]
+    pub fn test_calculate_delay_n() {
+        let epoch = 1;
+        let total_members = 10;
+
+        let indexes_delays = [
+            (2, 60),
+            (3, 87),
+            (4, 109),
+            (5, 127),
+            (6, 143),
+            (7, 157),
+            (8, 170),
+            // wrong but it shouldn't cause problems
+            (10, 15),
+        ];
+
+        for (self_index, expected_delay) in indexes_delays {
+            let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+            assert_eq!(delay, expected_delay);
+        }
+    }
+}

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -850,16 +850,14 @@ pub mod tests {
 
         #[test]
         pub fn test_calculate_delay_first() {
-            let self_index = 9;
-            let epoch = 1;
-            let total_members = 10;
+            let (self_index, epoch, total_members) = (9, 1, 10);
             let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
             assert_eq!(delay, 0);
         }
 
         #[test]
         pub fn test_calculate_delay_second() {
-            let self_index = 0;
+            let (self_index, epoch, total_members) = (0, 1, 10);
             let epoch = 1;
             let total_members = 10;
             let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
@@ -868,9 +866,7 @@ pub mod tests {
 
         #[test]
         pub fn test_calculate_delay_third() {
-            let self_index = 1;
-            let epoch = 1;
-            let total_members = 10;
+            let (self_index, epoch, total_members) = (1, 1, 10);
             let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
             assert_eq!(delay, 30);
         }
@@ -880,7 +876,7 @@ pub mod tests {
             let epoch = 1;
             let total_members = 10;
 
-            let table = [
+            let indexes_delays = [
                 (2, 60),
                 (3, 87),
                 (4, 109),
@@ -892,8 +888,8 @@ pub mod tests {
                 (10, 15),
             ];
 
-            for (self_index, expected_delay) in table {
-                let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
+            for (self_index, expected_delay) in indexes_delays {
+                let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
                 assert_eq!(delay, expected_delay);
             }
         }

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -874,7 +874,7 @@ pub mod tests {
         }
 
         #[test]
-        pub fn test_calculate_delay_thrird() {
+        pub fn test_calculate_delay_third() {
             let self_index = 1;
             let epoch = 1;
             let total_members = 10;

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -890,38 +890,22 @@ pub mod tests {
             let epoch = 1;
             let total_members = 10;
 
-            let self_index = 2;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 60);
+            let table = [
+                (2, 60),
+                (3, 87),
+                (4, 109),
+                (5, 127),
+                (6, 143),
+                (7, 157),
+                (8, 170),
+                // wrong but it shouldn't cause problems
+                (10, 15),
+            ];
 
-            let self_index = 3;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 87);
-
-            let self_index = 4;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 109);
-
-            let self_index = 5;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 127);
-
-            let self_index = 6;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 143);
-
-            let self_index = 7;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 157);
-
-            let self_index = 8;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 170);
-
-            // wrong but it shouldn't cause problems
-            let self_index = 10;
-            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
-            assert_eq!(delay, 15);
+            for (self_index, expected_delay) in table {
+                let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
+                assert_eq!(delay, expected_delay);
+            }
         }
     }
 

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -347,6 +347,11 @@ impl MlsConversation {
         Ok(message)
     }
 
+    /// Returns the tree index of the client owning this instance of the conversation.
+    ///
+    /// # Errors
+    /// [CryptoError::SelfKeypackageNotFound] if the [KeyPackage] can't be found. This shouldn't
+    /// happen and the conversation is in an invalid state.
     fn get_self_tree_index(&self, backend: &MlsCryptoProvider) -> CryptoResult<usize> {
         let myself = self
             .group

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -371,7 +371,7 @@ impl MlsConversation {
                 return Err(CryptoError::SelfKeypackageNotFound);
             }
         };
-        let position = ((epoch + self_leaf_index - 2) % total_members) + 1;
+        let position = ((epoch + self_leaf_index).saturating_sub(2) % total_members) + 1;
         let delay = match position {
             1 => 0.0,
             2 => 15.0,
@@ -820,6 +820,7 @@ pub mod tests {
                 .decrypt_message(&encrypted_message, &bob_backend)
                 .await
                 .unwrap()
+                .0
                 .unwrap();
             assert_eq!(original_message, roundtripped_message.as_slice());
 
@@ -833,6 +834,7 @@ pub mod tests {
                 .decrypt_message(&encrypted_message, &alice_backend)
                 .await
                 .unwrap()
+                .0
                 .unwrap();
             assert_eq!(original_message, roundtripped_message.as_slice());
         }
@@ -1071,6 +1073,7 @@ pub mod tests {
                 .decrypt_message(&msg_out.to_bytes().unwrap(), &bob_backend)
                 .await
                 .unwrap()
+                .0
                 .is_none());
 
             let bob_new_keys = bob_group
@@ -1156,6 +1159,7 @@ pub mod tests {
                 .decrypt_message(&proposal_response.to_bytes().unwrap(), &bob_backend)
                 .await
                 .unwrap()
+                .0
                 .is_none());
 
             assert_eq!(alice_group.group.members().len(), 2);
@@ -1192,6 +1196,7 @@ pub mod tests {
                 .decrypt_message(&message.to_bytes().unwrap(), &bob_backend)
                 .await
                 .unwrap()
+                .0
                 .is_none());
             assert_eq!(bob_group.members().len(), 3);
 

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -305,7 +305,8 @@ impl MlsConversation {
     /// This method will return a tuple containing an optional message and an optional delay time
     /// for the callers to wait for committing. A message will be `None` in case the provided payload is
     /// a system message, such as Proposals and Commits. Otherwise it will return the message as a
-    /// byte array. The delay will be `Some` only when the message contains a proposal
+    /// byte array. The delay will be `Some` when the message is a proposal. 
+    TODO: It might also be Some in the case the message is a commit and we have local pending proposals not covered by this commit
     ///
     /// # Errors
     /// KeyStore errors can happen only if it is not an Application Message (hence causing group

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -31,6 +31,10 @@ use crate::{
     CryptoError, CryptoResult, MlsCiphersuite, MlsError,
 };
 
+/// These constants intend to ramp up the delay and flatten the curve for later positions
+const DELAY_RAMP_UP_MULTIPLIER: f32 = 120.0;
+const DELAY_RAMP_UP_SUB: u64 = 106;
+
 /// A unique identifier for a group/conversation. The identifier must be unique within a client.
 pub type ConversationId = Vec<u8>;
 
@@ -374,7 +378,7 @@ impl MlsConversation {
             1 => 0,
             2 => 15,
             3 => 30,
-            _ => (((position as f32).ln() * 120.0) as u64).saturating_sub(106),
+            _ => (((position as f32).ln() * DELAY_RAMP_UP_MULTIPLIER) as u64).saturating_sub(DELAY_RAMP_UP_SUB),
         };
         Ok(result)
     }

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -369,12 +369,12 @@ impl MlsConversation {
     fn calculate_delay(self_index: usize, epoch: u64, total_members: usize) -> CryptoResult<u64> {
         let self_index: u64 = self_index.try_into().map_err(CryptoError::from)?;
         let total_members: u64 = total_members.try_into().map_err(CryptoError::from)?;
-        let position = ((epoch + self_index) % total_members) + 1;
+        let position = ((epoch % total_members) + (self_index % total_members)) % total_members + 1;
         let result = match position {
             1 => 0,
             2 => 15,
             3 => 30,
-            _ => ((TryInto::<f32>::try_into(position).ln() * 120.0) as u64).saturating_sub(106),
+            _ => (((position as f32).ln() * 120.0) as u64).saturating_sub(106),
         };
         Ok(result)
     }
@@ -849,6 +849,36 @@ pub mod tests {
         }
 
         #[test]
+        pub fn test_calculate_delay_max() {
+            let (self_index, epoch, total_members) = (usize::MAX, u64::MAX, usize::MAX);
+            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
+            assert_eq!(delay, 0);
+        }
+
+        #[test]
+        pub fn test_calculate_delay_min() {
+            let (self_index, epoch, total_members) = (usize::MIN, u64::MIN, usize::MAX);
+            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
+            assert_eq!(delay, 0);
+        }
+
+        #[test]
+        #[should_panic]
+        pub fn test_calculate_delay_panic() {
+            let (self_index, epoch, total_members) = (0, 0, usize::MIN);
+            // total members can never be 0 as there's no group with 0 members and it will panic
+            // when trying to calculate the remainder of 0
+            MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
+        }
+
+        #[test]
+        pub fn test_calculate_delay_min_max() {
+            let (self_index, epoch, total_members) = (usize::MIN, u64::MAX, usize::MAX);
+            let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
+            assert_eq!(delay, 0);
+        }
+
+        #[test]
         pub fn test_calculate_delay_first() {
             let (self_index, epoch, total_members) = (9, 1, 10);
             let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
@@ -858,8 +888,6 @@ pub mod tests {
         #[test]
         pub fn test_calculate_delay_second() {
             let (self_index, epoch, total_members) = (0, 1, 10);
-            let epoch = 1;
-            let total_members = 10;
             let delay = MlsConversation::calculate_delay(self_index, epoch, total_members).unwrap();
             assert_eq!(delay, 15);
         }

--- a/crypto/src/conversation.rs
+++ b/crypto/src/conversation.rs
@@ -850,9 +850,7 @@ pub mod tests {
 
         #[test]
         pub fn test_calculate_delay_single() {
-            let self_index = 0;
-            let epoch = 0;
-            let total_members = 1;
+            let (self_index, epoch, total_members) = (0, 0, 1);
             let delay = MlsConversation::calculate_delay(self_index, epoch, total_members);
             assert_eq!(delay, 0);
         }

--- a/crypto/src/credential.rs
+++ b/crypto/src/credential.rs
@@ -285,6 +285,7 @@ mod tests {
         let decrypted_msg = bob_group
             .decrypt_message(&encrypted_msg, &bob_backend)
             .await?
+            .0
             .ok_or(CryptoError::Unauthorized)?;
         assert_eq!(msg, decrypted_msg.as_slice());
 
@@ -293,6 +294,7 @@ mod tests {
         let decrypted_msg = alice_group
             .decrypt_message(&encrypted_msg, &alice_backend)
             .await?
+            .0
             .ok_or(CryptoError::Unauthorized)?;
         assert_eq!(msg, decrypted_msg.as_slice());
         Ok(())

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -38,6 +38,9 @@ pub enum CryptoError {
     /// A conversation member is out of local stored keypackages - if it does happen something went wrong
     #[error("Member #{0:x?} is out of keypackages")]
     OutOfKeyPackage(crate::member::MemberId),
+    /// Own key couldn't be found inside group - if it does happen something went wrong
+    #[error("Own key couldn't be found inside group")]
+    SelfKeypackageNotFound,
     /// Errors that are sent by our MLS Provider
     #[error(transparent)]
     MlsProviderError(#[from] mls_crypto_provider::MlsProviderError),

--- a/crypto/src/external_commit.rs
+++ b/crypto/src/external_commit.rs
@@ -311,7 +311,7 @@ mod tests {
 
     async fn person(name: &str, credential: CredentialSupplier) -> (MlsCryptoProvider, ConversationMember) {
         let backend = MlsCryptoProvider::try_new_in_memory(name).await.unwrap();
-        let member = ConversationMember::random_generate(&backend, credential).await.unwrap();
+        let (member, _) = ConversationMember::random_generate(&backend, credential).await.unwrap();
         (backend, member)
     }
 }

--- a/crypto/src/external_commit.rs
+++ b/crypto/src/external_commit.rs
@@ -203,7 +203,7 @@ mod tests {
                     let (alice_backend, mut alice) = person("alice", credential).await;
                     let (_, bob) = person("bob", credential).await;
 
-                    // create alice group
+                    // create Alice group
                     let mut alice_group = MlsConversation::create(
                         conversation_id.clone(),
                         alice.local_client_mut(),

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -560,7 +560,7 @@ impl MlsCentral {
         &mut self,
         conversation_id: ConversationId,
         message: impl AsRef<[u8]>,
-    ) -> CryptoResult<(Option<Vec<u8>>, Option<f32>)> {
+    ) -> CryptoResult<(Option<Vec<u8>>, Option<u64>)> {
         let conversation = self
             .mls_groups
             .get_mut(&conversation_id)

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -560,7 +560,7 @@ impl MlsCentral {
         &mut self,
         conversation_id: ConversationId,
         message: impl AsRef<[u8]>,
-    ) -> CryptoResult<Option<Vec<u8>>> {
+    ) -> CryptoResult<(Option<Vec<u8>>, Option<f32>)> {
         let conversation = self
             .mls_groups
             .get_mut(&conversation_id)

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -549,9 +549,10 @@ impl MlsCentral {
     /// * `message` - the encrypted message as a byte array
     ///
     /// # Return type
-    /// This method will return None for the message in case the provided payload is
-    /// a system message, such as Proposals and Commits. Otherwise it will return the message as a
-    /// byte array
+    /// This method will return a tuple containing an optional message and an optional delay time
+    /// for the callers to wait for committing. A message will be `None` in case the provided payload in
+    /// case of a system message, such as Proposals and Commits. Otherwise it will return the message as a
+    /// byte array. The delay will be `Some` when the message has a proposal
     ///
     /// # Errors
     /// If the conversation can't be found, an error will be returned. Other errors are originating

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -32,6 +32,7 @@ pub mod test_fixture_utils;
 pub use self::error::*;
 
 mod client;
+mod commit_delay;
 mod conversation;
 mod credential;
 mod error;

--- a/crypto/src/test_fixture_utils.rs
+++ b/crypto/src/test_fixture_utils.rs
@@ -39,7 +39,7 @@ async fn new_client(
     credential: CredentialSupplier,
 ) -> CryptoResult<(MlsCryptoProvider, ConversationMember)> {
     let backend = init_keystore(name).await;
-    let member = ConversationMember::random_generate(&backend, credential).await?;
+    let (member, _) = ConversationMember::random_generate(&backend, credential).await?;
     Ok((backend, member))
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds a commit delay value for clients to not possibly DDOS the backend with all of the sending commits at the same time.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
