### PR TITLE
Cleaner and less verbose tests

### DIFF
--- a/crypto/src/client.rs
+++ b/crypto/src/client.rs
@@ -465,7 +465,7 @@ pub mod tests {
 
     use mls_crypto_provider::MlsCryptoProvider;
 
-    use crate::{credential::CredentialSupplier, test_fixture_utils::*};
+    use crate::{credential::CredentialSupplier, test_utils::*};
 
     use super::Client;
 

--- a/crypto/src/client.rs
+++ b/crypto/src/client.rs
@@ -60,6 +60,13 @@ impl From<Box<[u8]>> for ClientId {
     }
 }
 
+#[cfg(test)]
+impl From<&str> for ClientId {
+    fn from(value: &str) -> Self {
+        Self(value.as_bytes().into())
+    }
+}
+
 #[allow(clippy::from_over_into)]
 impl Into<Vec<u8>> for ClientId {
     fn into(self) -> Vec<u8> {

--- a/crypto/src/conversation/decrypt.rs
+++ b/crypto/src/conversation/decrypt.rs
@@ -134,10 +134,7 @@ impl MlsCentral {
 pub mod tests {
     use wasm_bindgen_test::*;
 
-    use crate::{
-        credential::CredentialSupplier, proposal::MlsProposal, test_fixture_utils::*, test_utils::*,
-        MlsConversationConfiguration,
-    };
+    use crate::{credential::CredentialSupplier, proposal::MlsProposal, test_utils::*, MlsConversationConfiguration};
 
     use super::*;
 

--- a/crypto/src/conversation/handshake.rs
+++ b/crypto/src/conversation/handshake.rs
@@ -292,7 +292,7 @@ pub mod tests {
     use openmls::prelude::KeyPackage;
     use wasm_bindgen_test::*;
 
-    use crate::{credential::CredentialSupplier, test_fixture_utils::*, MlsConversationConfiguration};
+    use crate::{credential::CredentialSupplier, test_utils::*, MlsConversationConfiguration};
 
     use super::*;
 

--- a/crypto/src/conversation/handshake.rs
+++ b/crypto/src/conversation/handshake.rs
@@ -289,10 +289,8 @@ impl MlsCentral {
 
 #[cfg(test)]
 pub mod tests {
-    use openmls::prelude::KeyPackage;
+    use crate::{credential::CredentialSupplier, proposal::MlsProposal, test_utils::*, MlsConversationConfiguration};
     use wasm_bindgen_test::*;
-
-    use crate::{credential::CredentialSupplier, test_utils::*, MlsConversationConfiguration};
 
     use super::*;
 
@@ -304,45 +302,42 @@ pub mod tests {
         #[apply(all_credential_types)]
         #[wasm_bindgen_test]
         pub async fn can_add_members_to_conversation(credential: CredentialSupplier) {
-            let conversation_id = conversation_id();
-            let (alice_backend, mut alice) = alice(credential).await.unwrap();
-            let (bob_backend, bob) = bob(credential).await.unwrap();
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
 
-            let conversation_config = MlsConversationConfiguration::default();
-            let mut alice_group = MlsConversation::create(
-                conversation_id.clone(),
-                alice.local_client_mut(),
-                conversation_config,
-                &alice_backend,
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        let MlsConversationCreationMessage { welcome, .. } = alice_central
+                            .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                            .await
+                            .unwrap()
+                            .unwrap();
+
+                        // before merging, commit is not applied
+                        assert_eq!(alice_central[&id].members().len(), 1);
+                        alice_central.commit_accepted(&id).await.unwrap();
+
+                        assert_eq!(alice_central[&id].id, id);
+                        assert_eq!(alice_central[&id].group.group_id().as_slice(), id);
+                        assert_eq!(alice_central[&id].members().len(), 2);
+
+                        bob_central
+                            .process_welcome_message(welcome, MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central[&id].id(), bob_central[&id].id());
+                        assert_eq!(bob_central[&id].members().len(), 2);
+                        assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
+                    })
+                },
             )
             .await
-            .unwrap();
-
-            let conversation_creation_message = alice_group.add_members(&mut [bob], &alice_backend).await.unwrap();
-
-            // before merging, commit is not applied
-            assert_eq!(alice_group.members().len(), 1);
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-
-            assert_eq!(alice_group.id, conversation_id);
-            assert_eq!(alice_group.group.group_id().as_slice(), conversation_id);
-            assert_eq!(alice_group.members().len(), 2);
-
-            let MlsConversationCreationMessage { welcome, .. } = conversation_creation_message;
-
-            let conversation_config = MlsConversationConfiguration::default();
-
-            let mut bob_group = MlsConversation::from_welcome_message(welcome, conversation_config, &bob_backend)
-                .await
-                .unwrap();
-
-            assert_eq!(bob_group.id(), alice_group.id());
-
-            let msg = b"Hello";
-            let alice_can_send_message = alice_group.encrypt_message(msg, &alice_backend).await;
-            assert!(alice_can_send_message.is_ok());
-            let bob_can_send_message = bob_group.encrypt_message(msg, &bob_backend).await;
-            assert!(bob_can_send_message.is_ok());
         }
     }
 
@@ -352,56 +347,45 @@ pub mod tests {
         #[apply(all_credential_types)]
         #[wasm_bindgen_test]
         pub async fn alice_can_remove_bob_from_conversation(credential: CredentialSupplier) {
-            let conversation_id = conversation_id();
-            let (alice_backend, mut alice) = alice(credential).await.unwrap();
-            let (bob_backend, bob) = bob(credential).await.unwrap();
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
 
-            let conversation_config = MlsConversationConfiguration::default();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
-            let mut alice_group = MlsConversation::create(
-                conversation_id,
-                alice.local_client_mut(),
-                conversation_config,
-                &alice_backend,
+                        let commit = alice_central
+                            .remove_members_from_conversation(&id, &["bob".into()])
+                            .await
+                            .unwrap()
+                            .unwrap();
+
+                        // before merging, commit is not applied
+                        assert_eq!(alice_central[&id].members().len(), 2);
+                        alice_central.commit_accepted(&id).await.unwrap();
+                        assert_eq!(alice_central[&id].members().len(), 1);
+
+                        bob_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+
+                        // But has been removed from the conversation
+                        assert!(matches!(
+                           bob_central.get_conversation(&id).unwrap_err(),
+                            CryptoError::ConversationNotFound(conv_id) if conv_id == id
+                        ));
+                        assert!(alice_central.talk_to(&id, &mut bob_central).await.is_err());
+                    })
+                },
             )
-            .await
-            .unwrap();
-
-            let messages = alice_group
-                .add_members(&mut [bob.clone()], &alice_backend)
-                .await
-                .unwrap();
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-
-            assert_eq!(alice_group.members().len(), 2);
-
-            let mut bob_group = MlsConversation::from_welcome_message(
-                messages.welcome,
-                MlsConversationConfiguration::default(),
-                &bob_backend,
-            )
-            .await
-            .unwrap();
-
-            let remove_result = alice_group
-                .remove_members(bob.clients().cloned().collect::<Vec<_>>().as_slice(), &alice_backend)
-                .await
-                .unwrap();
-            // before merging, commit is not applied
-            assert_eq!(alice_group.members().len(), 2);
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-
-            bob_group
-                .decrypt_message(remove_result.to_bytes().unwrap(), &bob_backend)
-                .await
-                .unwrap();
-
-            assert_eq!(alice_group.members().len(), 1);
-
-            let alice_can_send_message = alice_group.encrypt_message(b"me", &alice_backend).await;
-            assert!(alice_can_send_message.is_ok());
-            let bob_cannot_send_message = alice_group.encrypt_message(b"me", &bob_backend).await;
-            assert!(bob_cannot_send_message.is_err());
+            .await;
         }
     }
 
@@ -411,191 +395,126 @@ pub mod tests {
         #[apply(all_credential_types)]
         #[wasm_bindgen_test]
         pub async fn should_update_keying_material_conversation_group(credential: CredentialSupplier) {
-            // create bob
-            let conversation_id = b"conversation".to_vec();
-            let (alice_backend, mut alice) = alice(credential).await.unwrap();
-            let (bob_backend, bob) = bob(credential).await.unwrap();
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
-            let bob_key = bob.local_client().keypackages(&bob_backend).await.unwrap()[0].clone();
+                        let bob_keys = bob_central[&id].group.members();
+                        let alice_keys = alice_central[&id].group.members();
+                        assert!(alice_keys.iter().all(|a_key| bob_keys.contains(a_key)));
 
-            let configuration = MlsConversationConfiguration::default();
+                        let alice_key = alice_central.key_package_of(&id, "alice");
 
-            // create new group and add bob
-            let mut alice_group = MlsConversation::create(
-                conversation_id,
-                alice.local_client_mut(),
-                configuration.clone(),
-                &alice_backend,
+                        // proposing the key update for alice
+                        let (commit, welcome) = alice_central.update_keying_material(&id).await.unwrap();
+                        assert!(welcome.is_none());
+
+                        // before merging, commit is not applied
+                        assert!(alice_central[&id].group.members().contains(&&alice_key));
+                        alice_central.commit_accepted(&id).await.unwrap();
+                        let alice_new_keys = alice_central[&id].group.members();
+                        assert!(!alice_new_keys.contains(&&alice_key));
+
+                        // receiving the commit on bob's side (updating key from alice)
+                        bob_central
+                            .decrypt_message(&id, &commit.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+
+                        let bob_new_keys = bob_central[&id].group.members();
+                        assert!(alice_new_keys.iter().all(|a_key| bob_new_keys.contains(a_key)));
+
+                        // ensuring both can encrypt messages
+                        assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
+                    })
+                },
             )
-            .await
-            .unwrap();
-
-            let add_message = alice_group.add_members(&mut [bob], &alice_backend).await.unwrap();
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-
-            assert_eq!(alice_group.members().len(), 2);
-
-            let MlsConversationCreationMessage { welcome, .. } = add_message;
-
-            // creating group on bob's side
-            let mut bob_group = MlsConversation::from_welcome_message(welcome, configuration, &bob_backend)
-                .await
-                .unwrap();
-
-            // ensuring both sides can encrypt messages
-            let msg = b"Hello";
-            let alice_can_send_message = alice_group.encrypt_message(msg, &alice_backend).await;
-            assert!(alice_can_send_message.is_ok());
-            let bob_can_send_message = bob_group.encrypt_message(msg, &bob_backend).await;
-            assert!(bob_can_send_message.is_ok());
-
-            let bob_keys = bob_group.group.members();
-            let alice_keys = alice_group.group.members();
-            assert!(alice_keys.iter().all(|a_key| bob_keys.contains(a_key)));
-
-            let alice_key = alice_keys.into_iter().find(|&k| *k != bob_key).unwrap().clone();
-            // proposing the key update for alice
-            let (msg_out, welcome) = alice_group.update_keying_material(&alice_backend).await.unwrap();
-            assert!(welcome.is_none());
-
-            // before merging, commit is not applied
-            assert!(alice_group.group.members().contains(&&alice_key));
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-
-            let alice_new_keys = alice_group.group.members();
-            assert!(!alice_new_keys.contains(&&alice_key));
-
-            // receiving the commit on bob's side (updating key from alice)
-            assert!(bob_group
-                .decrypt_message(&msg_out.to_bytes().unwrap(), &bob_backend)
-                .await
-                .unwrap()
-                .app_msg
-                .is_none());
-
-            let bob_new_keys = bob_group
-                .group
-                .members()
-                .into_iter()
-                .cloned()
-                .collect::<Vec<KeyPackage>>();
-
-            assert!(alice_new_keys.iter().all(|a_key| bob_new_keys.contains(a_key)));
-
-            // ensuring both can encrypt messages
-            let bob_can_send_message = bob_group.encrypt_message(msg, &bob_backend).await;
-            assert!(bob_can_send_message.is_ok());
-
-            let alice_can_send_message = alice_group.encrypt_message(msg, &alice_backend).await;
-            assert!(alice_can_send_message.is_ok());
+            .await;
         }
 
         #[apply(all_credential_types)]
         #[wasm_bindgen_test]
         pub async fn should_update_keying_material_group_pending_commit(credential: CredentialSupplier) {
-            // create members
-            let conversation_id = conversation_id();
-            let (alice_backend, mut alice) = alice(credential).await.unwrap();
-            let (bob_backend, bob) = bob(credential).await.unwrap();
-            let (charlie_backend, charlie) = charlie(credential).await.unwrap();
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
-            let bob_key = bob.local_client().keypackages(&bob_backend).await.unwrap()[0].clone();
-            let charlie_key = charlie.local_client().keypackages(&charlie_backend).await.unwrap()[0].clone();
+                        let bob_keys = bob_central[&id].group.members();
+                        let alice_keys = alice_central[&id].group.members();
 
-            let configuration = MlsConversationConfiguration::default();
+                        // checking that the members on both sides are the same
+                        assert!(alice_keys.iter().all(|a_key| bob_keys.contains(a_key)));
 
-            // create group
-            let mut alice_group = MlsConversation::create(
-                conversation_id,
-                alice.local_client_mut(),
-                configuration.clone(),
-                &alice_backend,
+                        let alice_key = alice_central.key_package_of(&id, "alice");
+
+                        // proposing adding charlie
+                        let charlie_kp = charlie_central.get_one_key_package().await;
+                        let add_charlie_proposal = alice_central
+                            .new_proposal(&id, MlsProposal::Add(charlie_kp))
+                            .await
+                            .unwrap();
+
+                        // receiving the proposal on Bob's side
+                        bob_central
+                            .decrypt_message(&id, add_charlie_proposal.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+
+                        // performing an update on Alice's key. this should generate a welcome for Charlie
+                        let (commit, welcome) = alice_central.update_keying_material(&id).await.unwrap();
+                        assert!(welcome.is_some());
+                        assert!(alice_central[&id].group.members().contains(&&alice_key));
+                        alice_central.commit_accepted(&id).await.unwrap();
+                        assert!(!alice_central[&id].group.members().contains(&&alice_key));
+
+                        // create the group on charlie's side
+                        charlie_central
+                            .process_welcome_message(welcome.unwrap(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+
+                        assert_eq!(alice_central[&id].members().len(), 3);
+                        assert_eq!(charlie_central[&id].members().len(), 3);
+                        // bob still didn't receive the message with the updated key and charlie's addition
+                        assert_eq!(bob_central[&id].members().len(), 2);
+
+                        let alice_new_keys = alice_central[&id].group.members();
+                        assert!(!alice_new_keys.contains(&&alice_key));
+
+                        // receiving the key update and the charlie's addition to the group
+                        bob_central
+                            .decrypt_message(&id, &commit.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+                        assert_eq!(bob_central[&id].members().len(), 3);
+
+                        let bob_new_keys = bob_central[&id].group.members();
+                        assert!(alice_new_keys.iter().all(|a_key| bob_new_keys.contains(a_key)));
+
+                        // ensure all parties can encrypt messages
+                        assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
+                        assert!(bob_central.talk_to(&id, &mut charlie_central).await.is_ok());
+                        assert!(charlie_central.talk_to(&id, &mut alice_central).await.is_ok());
+                    })
+                },
             )
-            .await
-            .unwrap();
-
-            // adding bob and creating the group on bob's side
-            let MlsConversationCreationMessage { welcome, .. } =
-                alice_group.add_members(&mut [bob], &alice_backend).await.unwrap();
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-
-            assert_eq!(alice_group.members().len(), 2);
-
-            let mut bob_group = MlsConversation::from_welcome_message(welcome, configuration.clone(), &bob_backend)
-                .await
-                .unwrap();
-
-            let bob_keys = bob_group.group.members();
-            let alice_keys = alice_group.group.members();
-
-            // checking that the members on both sides are the same
-            assert!(alice_keys.iter().all(|a_key| bob_keys.contains(a_key)));
-
-            let alice_key = alice_keys.into_iter().find(|&k| *k != bob_key).unwrap().clone();
-
-            // proposing adding charlie
-            let add_charlie_proposal = alice_group
-                .group
-                .propose_add_member(&alice_backend, &charlie_key)
-                .await
-                .unwrap();
-
-            // receiving the proposal on bob's side
-            assert!(bob_group
-                .decrypt_message(&add_charlie_proposal.to_bytes().unwrap(), &bob_backend)
-                .await
-                .unwrap()
-                .app_msg
-                .is_none());
-            assert_eq!(alice_group.group.members().len(), 2);
-
-            // performing an update on the alice's key. this should generate a welcome for charlie
-            let (commit, welcome) = alice_group.update_keying_material(&alice_backend).await.unwrap();
-            assert!(welcome.is_some());
-            assert!(alice_group.group.members().contains(&&alice_key));
-            alice_group.commit_accepted(&alice_backend).await.unwrap();
-            // before merging, commit is not applied
-            assert!(!alice_group.group.members().contains(&&alice_key));
-
-            // create the group on charlie's side
-            let charlie_welcome = welcome.unwrap();
-            let mut charlie_group =
-                MlsConversation::from_welcome_message(charlie_welcome, configuration, &charlie_backend)
-                    .await
-                    .unwrap();
-
-            assert_eq!(alice_group.members().len(), 3);
-            assert_eq!(charlie_group.members().len(), 3);
-            // bob still didn't receive the message with the updated key and charlie's addition
-            assert_eq!(bob_group.members().len(), 2);
-
-            let alice_new_keys = alice_group.group.members();
-
-            assert!(!alice_new_keys.contains(&&alice_key));
-
-            // receiving the key update and the charlie's addition to the group
-            assert!(bob_group
-                .decrypt_message(&commit.to_bytes().unwrap(), &bob_backend)
-                .await
-                .unwrap()
-                .app_msg
-                .is_none());
-            assert_eq!(bob_group.members().len(), 3);
-
-            let bob_new_keys = bob_group.group.members();
-
-            assert!(alice_new_keys.iter().all(|a_key| bob_new_keys.contains(a_key)));
-
-            // ensure all parties can encrypt messages
-            let msg = b"Hello World";
-            let bob_can_send_message = bob_group.encrypt_message(msg, &bob_backend).await;
-            assert!(bob_can_send_message.is_ok());
-
-            let alice_can_send_message = alice_group.encrypt_message(msg, &alice_backend).await;
-            assert!(alice_can_send_message.is_ok());
-
-            let charlie_can_send_message = charlie_group.encrypt_message(msg, &charlie_backend).await;
-            assert!(charlie_can_send_message.is_ok());
+            .await;
         }
     }
 }

--- a/crypto/src/conversation/merge.rs
+++ b/crypto/src/conversation/merge.rs
@@ -52,7 +52,7 @@ impl MlsCentral {
 pub mod tests {
     use wasm_bindgen_test::*;
 
-    use crate::{credential::CredentialSupplier, test_fixture_utils::*, test_utils::*, MlsConversationConfiguration};
+    use crate::{credential::CredentialSupplier, test_utils::*, MlsConversationConfiguration};
 
     wasm_bindgen_test_configure!(run_in_browser);
 

--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -318,7 +318,7 @@ pub mod tests {
 
     use crate::{
         conversation::handshake::MlsConversationCreationMessage, credential::CredentialSupplier,
-        member::ConversationMember, test_fixture_utils::*, MlsConversationConfiguration,
+        member::ConversationMember, test_utils::*, MlsConversationConfiguration,
     };
 
     use super::*;

--- a/crypto/src/conversation/renew.rs
+++ b/crypto/src/conversation/renew.rs
@@ -102,7 +102,7 @@ pub mod tests {
         pub async fn is_renewable_when_commit_absent(credential: CredentialSupplier) {
             run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
-                    let id = b"id".to_vec();
+                    let id = conversation_id();
                     alice_central
                         .new_conversation(id.clone(), MlsConversationConfiguration::default())
                         .await
@@ -122,7 +122,7 @@ pub mod tests {
         pub async fn update_is_always_renewable(credential: CredentialSupplier) {
             run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
-                    let id = b"id".to_vec();
+                    let id = conversation_id();
                     alice_central
                         .new_conversation(id.clone(), MlsConversationConfiguration::default())
                         .await
@@ -144,13 +144,13 @@ pub mod tests {
         pub async fn add_is_not_renewable_when_commit_already_adds_same(credential: CredentialSupplier) {
             run_test_with_client_ids(credential, ["alice", "bob"], move |[mut alice_central, bob_central]| {
                 Box::pin(async move {
-                    let id = b"id".to_vec();
+                    let id = conversation_id();
                     alice_central
                         .new_conversation(id.clone(), MlsConversationConfiguration::default())
                         .await
                         .unwrap();
 
-                    let bob_kp = bob_central.get_one_key_package().await.unwrap();
+                    let bob_kp = bob_central.get_one_key_package().await;
                     alice_central.new_proposal(&id, MlsProposal::Add(bob_kp)).await.unwrap();
                     let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
                     alice_central[&id].group.clear_pending_proposals();
@@ -175,13 +175,13 @@ pub mod tests {
                 ["alice", "bob", "charlie"],
                 move |[mut alice_central, bob_central, charlie_central]| {
                     Box::pin(async move {
-                        let id = b"id".to_vec();
+                        let id = conversation_id();
                         alice_central
                             .new_conversation(id.clone(), MlsConversationConfiguration::default())
                             .await
                             .unwrap();
 
-                        let bob_kp = bob_central.get_one_key_package().await.unwrap();
+                        let bob_kp = bob_central.get_one_key_package().await;
                         alice_central.new_proposal(&id, MlsProposal::Add(bob_kp)).await.unwrap();
                         let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
                         alice_central[&id].group.clear_pending_proposals();
@@ -203,7 +203,7 @@ pub mod tests {
         pub async fn remove_is_not_renewable_when_commit_already_removes_same(credential: CredentialSupplier) {
             run_test_with_client_ids(credential, ["alice", "bob"], move |[mut alice_central, bob_central]| {
                 Box::pin(async move {
-                    let id = b"id".to_vec();
+                    let id = conversation_id();
                     alice_central
                         .new_conversation(id.clone(), MlsConversationConfiguration::default())
                         .await
@@ -223,7 +223,7 @@ pub mod tests {
                     alice_central[&id].group.clear_pending_proposals();
 
                     alice_central
-                        .remove_members_from_conversation(&id, &[b"bob"[..].into()])
+                        .remove_members_from_conversation(&id, &["bob".into()])
                         .await
                         .unwrap();
                     let commit = alice_central.pending_commit(&id).unwrap().clone();
@@ -241,7 +241,7 @@ pub mod tests {
                 ["alice", "bob", "charlie"],
                 move |[mut alice_central, bob_central, charlie_central]| {
                     Box::pin(async move {
-                        let id = b"id".to_vec();
+                        let id = conversation_id();
                         alice_central
                             .new_conversation(id.clone(), MlsConversationConfiguration::default())
                             .await
@@ -259,7 +259,7 @@ pub mod tests {
                         alice_central[&id].group.clear_pending_proposals();
 
                         alice_central
-                            .remove_members_from_conversation(&id, &[b"charlie"[..].into()])
+                            .remove_members_from_conversation(&id, &["charlie".into()])
                             .await
                             .unwrap();
                         let commit = alice_central.pending_commit(&id).unwrap().clone();

--- a/crypto/src/conversation/renew.rs
+++ b/crypto/src/conversation/renew.rs
@@ -90,10 +90,7 @@ impl MlsConversation {
 pub mod tests {
     use wasm_bindgen_test::*;
 
-    use crate::{
-        credential::CredentialSupplier, prelude::MlsProposal, test_fixture_utils::*, test_utils::*,
-        MlsConversationConfiguration,
-    };
+    use crate::{credential::CredentialSupplier, prelude::MlsProposal, test_utils::*, MlsConversationConfiguration};
 
     use super::*;
 

--- a/crypto/src/credential.rs
+++ b/crypto/src/credential.rs
@@ -128,7 +128,7 @@ mod tests {
     use openmls::prelude::{CredentialError, WelcomeError};
 
     use crate::error::CryptoError;
-    use crate::{test_fixture_utils::*, MlsConversation, MlsConversationConfiguration};
+    use crate::{test_utils::*, MlsConversation, MlsConversationConfiguration};
 
     use super::*;
 

--- a/crypto/src/external_commit.rs
+++ b/crypto/src/external_commit.rs
@@ -122,8 +122,8 @@ mod tests {
         use core_crypto_keystore::{CryptoKeystoreError, CryptoKeystoreMls, MissingKeyErrorKind};
 
         use crate::{
-            credential::CredentialSupplier, error::MlsError, test_fixture_utils::*, test_utils::run_test_with_central,
-            MlsConversation, MlsConversationConfiguration,
+            credential::CredentialSupplier, error::MlsError, test_utils::*, MlsConversation,
+            MlsConversationConfiguration,
         };
 
         use super::*;

--- a/crypto/src/external_proposal.rs
+++ b/crypto/src/external_proposal.rs
@@ -72,8 +72,7 @@ mod tests {
     use wasm_bindgen_test::*;
 
     use crate::{
-        credential::CredentialSupplier, member::ConversationMember, test_fixture_utils::*, test_utils::*,
-        MlsConversationConfiguration,
+        credential::CredentialSupplier, member::ConversationMember, test_utils::*, MlsConversationConfiguration,
     };
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -564,14 +564,12 @@ pub mod tests {
 
                     let mut central = MlsCentral::try_new(configuration.clone(), credential()).await.unwrap();
                     let conversation_configuration = MlsConversationConfiguration::default();
-                    let conversation_id = b"conversation".to_vec();
-                    let _ = central
-                        .new_conversation(conversation_id.clone(), conversation_configuration)
-                        .await;
+                    let id = conversation_id();
+                    let _ = central.new_conversation(id.clone(), conversation_configuration).await;
 
                     central.close().await.unwrap();
                     let mut central = MlsCentral::try_new(configuration, credential()).await.unwrap();
-                    let _ = central.encrypt_message(&conversation_id, b"Test").await.unwrap();
+                    let _ = central.encrypt_message(&id, b"Test").await.unwrap();
 
                     central.mls_backend.destroy_and_reset().await.unwrap();
                 })

--- a/crypto/src/member.rs
+++ b/crypto/src/member.rs
@@ -156,7 +156,7 @@ pub mod tests {
     use crate::{
         credential::{CertificateBundle, CredentialSupplier},
         prelude::INITIAL_KEYING_MATERIAL_COUNT,
-        test_fixture_utils::*,
+        test_utils::*,
         ClientId,
     };
 

--- a/crypto/src/proposal.rs
+++ b/crypto/src/proposal.rs
@@ -84,7 +84,7 @@ pub mod proposal_tests {
     use openmls::prelude::*;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    use crate::{credential::CredentialSupplier, test_fixture_utils::*, test_utils::run_test_with_central, *};
+    use crate::{credential::CredentialSupplier, test_utils::*, *};
 
     use super::*;
 

--- a/crypto/src/test_utils.rs
+++ b/crypto/src/test_utils.rs
@@ -12,8 +12,8 @@ pub use rstest_reuse::{self, *};
 use mls_crypto_provider::MlsCryptoProvider;
 
 use crate::{
-    credential::CredentialSupplier, member::ConversationMember, ConversationId, CryptoResult, MlsCentral,
-    MlsConversation,
+    config::MlsCentralConfiguration, credential::CredentialSupplier, member::ConversationMember, ConversationId,
+    CryptoResult, MlsCentral, MlsConversation,
 };
 
 #[template]
@@ -25,6 +25,57 @@ use crate::{
 )]
 #[allow(non_snake_case)]
 pub fn all_credential_types(credential: crate::credential::CredentialSupplier) {}
+
+pub async fn run_test_with_central(
+    credential: CredentialSupplier,
+    test: impl FnOnce([MlsCentral; 1]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
+) {
+    run_test_with_client_ids(credential, ["alice"], test).await
+}
+
+pub async fn run_test_with_client_ids<const N: usize>(
+    credential: CredentialSupplier,
+    client_id: [&'static str; N],
+    test: impl FnOnce([MlsCentral; N]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
+) {
+    run_tests(move |paths: [String; N]| {
+        Box::pin(async move {
+            let stream = paths.into_iter().enumerate().map(|(i, p)| async move {
+                let client_id = client_id[i].to_string();
+                let configuration = MlsCentralConfiguration::try_new(p, "test".into(), client_id).unwrap();
+                MlsCentral::try_new(configuration, credential()).await.unwrap()
+            });
+            let centrals: [MlsCentral; N] = futures_util::future::join_all(stream).await.try_into().unwrap();
+            test(centrals).await;
+        })
+    })
+    .await
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub async fn run_tests<const N: usize>(
+    test: impl FnOnce([String; N]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
+) {
+    let dirs = (0..N)
+        .map(|_| tempfile::tempdir().unwrap())
+        .collect::<Vec<tempfile::TempDir>>();
+    let paths: [String; N] = dirs
+        .iter()
+        .map(MlsCentralConfiguration::tmp_store_path)
+        .collect::<Vec<String>>()
+        .try_into()
+        .unwrap();
+    test(paths).await;
+}
+
+#[cfg(target_family = "wasm")]
+pub async fn run_tests<const N: usize>(
+    test: impl FnOnce([String; N]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
+) {
+    use rand::distributions::{Alphanumeric, DistString};
+    let paths = [0; N].map(|_| format!("{}.idb", Alphanumeric.sample_string(&mut rand::thread_rng(), 16)));
+    test(paths).await;
+}
 
 pub fn conversation_id() -> ConversationId {
     let uuid = uuid::Uuid::new_v4();


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

So far testing was a bit cumbersome. We were using both `MlsConversation` and `MlsCentral` in our tests. There was test helpers in all sorts of places etc.. What this PR will bring
* all tests (whenever possible) will use `MlsCentral` to perform operations. Using `MlsConversation` should be abandonned. This brings better coverage and will help in case the method in central is not a pass through
* All test helpers should be in `test_utils` mod
* Added `MlsCentral::can_talk_to(&mut self, id: &ConversationId, other: &mut MlsCentral)` to streamline the process of verifying if 2 central can exchange messages
* Added `MlsCentral::invite(&mut self, id: &ConversationId, mut other: &mut MlsCentral)` to cut all the boilerplate of adding a user to a group then creating a group from welcome
* In case one needs to access a `MlsConversation` one can do e.g. `alice_central[&id]` where `id` is a `ConversationId`
* tests in `credential` mod now run on WASM

@OtaK , @augustocdias I don't want to push through, so please review, comment if something does not please you 😄 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
