### PR TITLE
return commit delay when decrypting commit [CL-52]

### DIFF
--- a/crypto/src/conversation/commit_delay.rs
+++ b/crypto/src/conversation/commit_delay.rs
@@ -1,50 +1,32 @@
-use crate::{CryptoError, CryptoResult, MlsConversation};
-use mls_crypto_provider::MlsCryptoProvider;
-use openmls_traits::OpenMlsCryptoProvider;
-use std::num::TryFromIntError;
-
-/// These constants intend to ramp up the delay and flatten the curve for later positions
-const DELAY_RAMP_UP_MULTIPLIER: f32 = 120.0;
-const DELAY_RAMP_UP_SUB: u64 = 106;
+use super::MlsConversation;
 
 impl MlsConversation {
-    /// Returns the tree index of the client owning this instance of the conversation.
-    ///
-    /// # Errors
-    /// [CryptoError::SelfKeypackageNotFound] if the [KeyPackage] can't be found. This shouldn't
-    /// happen and the conversation is in an invalid state.
-    pub fn get_self_tree_index(&self, backend: &MlsCryptoProvider) -> CryptoResult<usize> {
-        let myself = self
-            .group
-            .key_package_ref()
-            .ok_or(CryptoError::SelfKeypackageNotFound)?;
+    /// These constants intend to ramp up the delay and flatten the curve for later positions
+    const DELAY_RAMP_UP_MULTIPLIER: f32 = 120.0;
+    const DELAY_RAMP_UP_SUB: u64 = 106;
 
-        // TODO: switch to `try_find` when stabilized
-        self.group
-            .members()
-            .iter()
-            .enumerate()
-            .find_map(|(i, kp)| {
-                kp.hash_ref(backend.crypto())
-                    .ok()
-                    .filter(|kpr| kpr == myself)
-                    .map(|_| i)
-            })
-            .ok_or(CryptoError::SelfKeypackageNotFound)
+    /// Helps consumer by providing a deterministic delay for him to commit its pending proposal.
+    /// It depends on the index of the client in the ratchet tree
+    /// * `self_index` - ratchet tree index of self client
+    /// * `epoch` - current group epoch
+    /// * `nb_members` - number of clients in the group
+    pub fn compute_next_commit_delay(&self) -> u64 {
+        let epoch = self.group.epoch().as_u64();
+        let nb_members = self.group.members().len() as u64;
+        let own_index = self.group.own_leaf_index() as u64;
+        Self::calculate_delay(own_index, epoch, nb_members)
     }
-}
 
-pub(crate) fn calculate_delay(self_index: usize, epoch: u64, total_members: usize) -> Result<u64, TryFromIntError> {
-    let self_index: u64 = self_index.try_into()?;
-    let total_members: u64 = total_members.try_into()?;
-    let position = ((epoch % total_members) + (self_index % total_members)) % total_members + 1;
-    let result = match position {
-        1 => 0,
-        2 => 15,
-        3 => 30,
-        _ => (((position as f32).ln() * DELAY_RAMP_UP_MULTIPLIER) as u64).saturating_sub(DELAY_RAMP_UP_SUB),
-    };
-    Ok(result)
+    fn calculate_delay(self_index: u64, epoch: u64, nb_members: u64) -> u64 {
+        let position = ((epoch % nb_members) + (self_index % nb_members)) % nb_members + 1;
+        match position {
+            1 => 0,
+            2 => 15,
+            3 => 30,
+            _ => (((position as f32).ln() * Self::DELAY_RAMP_UP_MULTIPLIER) as u64)
+                .saturating_sub(Self::DELAY_RAMP_UP_SUB),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -52,69 +34,50 @@ pub mod tests {
     use super::*;
 
     #[test]
-    pub fn test_calculate_delay_single() {
-        let (self_index, epoch, total_members) = (0, 0, 1);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+    pub fn calculate_delay_single() {
+        let (self_index, epoch, nb_members) = (0, 0, 1);
+        let delay = MlsConversation::calculate_delay(self_index, epoch, nb_members);
         assert_eq!(delay, 0);
     }
 
     #[test]
-    pub fn test_calculate_delay_max() {
-        let (self_index, epoch, total_members) = (usize::MAX, u64::MAX, usize::MAX);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+    pub fn calculate_delay_max() {
+        let (self_index, epoch, nb_members) = (u64::MAX, u64::MAX, u64::MAX);
+        let delay = MlsConversation::calculate_delay(self_index, epoch, nb_members);
         assert_eq!(delay, 0);
     }
 
     #[test]
-    pub fn test_calculate_delay_min() {
-        let (self_index, epoch, total_members) = (usize::MIN, u64::MIN, usize::MAX);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+    pub fn calculate_delay_min() {
+        let (self_index, epoch, nb_members) = (u64::MIN, u64::MIN, u64::MAX);
+        let delay = MlsConversation::calculate_delay(self_index, epoch, nb_members);
         assert_eq!(delay, 0);
     }
 
     #[test]
     #[should_panic]
-    pub fn test_calculate_delay_panic() {
-        let (self_index, epoch, total_members) = (0, 0, usize::MIN);
+    pub fn calculate_delay_panic() {
+        let (self_index, epoch, nb_members) = (0, 0, u64::MIN);
         // total members can never be 0 as there's no group with 0 members and it will panic
         // when trying to calculate the remainder of 0
-        calculate_delay(self_index, epoch, total_members).unwrap();
+        MlsConversation::calculate_delay(self_index, epoch, nb_members);
     }
 
     #[test]
-    pub fn test_calculate_delay_min_max() {
-        let (self_index, epoch, total_members) = (usize::MIN, u64::MAX, usize::MAX);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+    pub fn calculate_delay_min_max() {
+        let (self_index, epoch, nb_members) = (u64::MIN, u64::MAX, u64::MAX);
+        let delay = MlsConversation::calculate_delay(self_index, epoch, nb_members);
         assert_eq!(delay, 0);
     }
 
     #[test]
-    pub fn test_calculate_delay_first() {
-        let (self_index, epoch, total_members) = (9, 1, 10);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
-        assert_eq!(delay, 0);
-    }
-
-    #[test]
-    pub fn test_calculate_delay_second() {
-        let (self_index, epoch, total_members) = (0, 1, 10);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
-        assert_eq!(delay, 15);
-    }
-
-    #[test]
-    pub fn test_calculate_delay_third() {
-        let (self_index, epoch, total_members) = (1, 1, 10);
-        let delay = calculate_delay(self_index, epoch, total_members).unwrap();
-        assert_eq!(delay, 30);
-    }
-
-    #[test]
-    pub fn test_calculate_delay_n() {
+    pub fn calculate_delay_n() {
         let epoch = 1;
-        let total_members = 10;
+        let nb_members = 10;
 
         let indexes_delays = [
+            (0, 15),
+            (1, 30),
             (2, 60),
             (3, 87),
             (4, 109),
@@ -122,12 +85,13 @@ pub mod tests {
             (6, 143),
             (7, 157),
             (8, 170),
+            (9, 0),
             // wrong but it shouldn't cause problems
             (10, 15),
         ];
 
         for (self_index, expected_delay) in indexes_delays {
-            let delay = calculate_delay(self_index, epoch, total_members).unwrap();
+            let delay = MlsConversation::calculate_delay(self_index, epoch, nb_members);
             assert_eq!(delay, expected_delay);
         }
     }

--- a/crypto/src/conversation/commit_delay.rs
+++ b/crypto/src/conversation/commit_delay.rs
@@ -10,11 +10,15 @@ impl MlsConversation {
     /// * `self_index` - ratchet tree index of self client
     /// * `epoch` - current group epoch
     /// * `nb_members` - number of clients in the group
-    pub fn compute_next_commit_delay(&self) -> u64 {
-        let epoch = self.group.epoch().as_u64();
-        let nb_members = self.group.members().len() as u64;
-        let own_index = self.group.own_leaf_index() as u64;
-        Self::calculate_delay(own_index, epoch, nb_members)
+    pub fn compute_next_commit_delay(&self) -> Option<u64> {
+        if self.group.pending_proposals().count() > 0 {
+            let epoch = self.group.epoch().as_u64();
+            let nb_members = self.group.members().len() as u64;
+            let own_index = self.group.own_leaf_index() as u64;
+            Some(Self::calculate_delay(own_index, epoch, nb_members))
+        } else {
+            None
+        }
     }
 
     fn calculate_delay(self_index: u64, epoch: u64, nb_members: u64) -> u64 {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

* refactor `commit_delay` mod
* return a delay when decrypting a commit and there are pending proposals

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
