### PR TITLE
test: Reducing the sample size for debug configurations so that we avoid timeouts

### DIFF
--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -392,15 +392,14 @@ pub mod tests {
         pub async fn create_100_people_conversation(credential: CredentialSupplier) {
             run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
-                    const NB_FRIENDS: usize = 99;
                     let id = conversation_id();
                     alice_central
                         .new_conversation(id.clone(), MlsConversationConfiguration::default())
                         .await
                         .unwrap();
 
-                    let mut bob_and_friends = Vec::with_capacity(NB_FRIENDS);
-                    for _ in 0..NB_FRIENDS {
+                    let mut bob_and_friends = Vec::with_capacity(GROUP_SAMPLE_SIZE);
+                    for _ in 0..GROUP_SAMPLE_SIZE {
                         let uuid = uuid::Uuid::new_v4();
                         let name = uuid.hyphenated().to_string();
                         let path = tmp_db_file();
@@ -438,7 +437,7 @@ pub mod tests {
                         bob_and_friends_groups.push(c);
                     }
 
-                    assert_eq!(bob_and_friends_groups.len(), NB_FRIENDS);
+                    assert_eq!(bob_and_friends_groups.len(), GROUP_SAMPLE_SIZE);
                 })
             })
             .await;

--- a/crypto/src/test_utils.rs
+++ b/crypto/src/test_utils.rs
@@ -26,6 +26,11 @@ use crate::{
 #[allow(non_snake_case)]
 pub fn all_credential_types(credential: crate::credential::CredentialSupplier) {}
 
+#[cfg(debug_assertions)]
+pub const GROUP_SAMPLE_SIZE: usize = 9;
+#[cfg(not(debug_assertions))]
+pub const GROUP_SAMPLE_SIZE: usize = 99;
+
 pub async fn run_test_with_central(
     credential: CredentialSupplier,
     test: impl FnOnce([MlsCentral; 1]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Reduce the sample size for debug configurations so that the tests don't fail locally because of timeouts.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
