### PR TITLE
expose external senders at conversation creation for external remove proposal support [CL-53]

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -120,7 +120,7 @@ export interface MemberAddedMessages {
 export interface CommitBundle {
     /**
      * TLS-serialized MLS Commit that needs to be fanned out to other (existing) members of the conversation
-     * 
+     *
      * @readonly
      */
     message: Uint8Array;
@@ -191,16 +191,16 @@ export class CoreCrypto {
 
     /**
      * This is your entrypoint to initialize {@link CoreCrypto}!
-     * 
+     *
      * @param params - {@link CoreCryptoParams}
-     * 
+     *
      * @example
      * ## Simple init
      * ```ts
      * const cc = await CoreCrypto.init({ databaseName: "test", key: "test", clientId: "test" });
      * // Do the rest with `cc`
      * ```
-     * 
+     *
      * ## Custom Entropy seed init & wasm file location
      * ```ts
      * // FYI, this is the IETF test vector #1
@@ -210,10 +210,10 @@ export class CoreCrypto {
      *   0x7c5941da, 0x8d485751, 0x3fe02477, 0x374ad8b8,
      *   0xf4b8436a, 0x1ca11815, 0x69b687c3, 0x8665eeb2,
      * ]);
-     * 
+     *
      * const wasmFilePath = "/long/complicated/path/on/webserver/whatever.wasm";
-     * 
-     * const cc = await CoreCrypto.init({ 
+     *
+     * const cc = await CoreCrypto.init({
      *   databaseName: "test",
      *   key: "test",
      *   clientId: "test",
@@ -257,9 +257,9 @@ export class CoreCrypto {
 
     /**
      * Checks if the Client is member of a given conversation and if the MLS Group is loaded up
-     * 
+     *
      * @returns Whether the given conversation ID exists
-     * 
+     *
      * @example
      * ```ts
      *  const cc = await CoreCrypto.init({ databaseName: "test", key: "test", clientId: "test" });
@@ -278,7 +278,7 @@ export class CoreCrypto {
     /**
      * Creates a new conversation with the current client being the sole member
      * You will want to use {@link CoreCrypto.addClientsToConversation} afterwards to add clients to this conversation
-     * 
+     *
      * @param conversationId - The conversation ID; You can either make them random or let the backend attribute MLS group IDs
      * @param configuration.ciphersuite - The {@link Ciphersuite} that is chosen to be the group's
      * @param configuration.keyRotationSpan - The amount of time in milliseconds after which the MLS Keypackages will be rotated
@@ -286,8 +286,7 @@ export class CoreCrypto {
      */
     async createConversation(
         conversationId: ConversationId,
-        { ciphersuite, keyRotationSpan, externalSenders }: ConversationConfiguration = { externalSenders: [] }
-    ) {
+        { ciphersuite, keyRotationSpan, externalSenders }: ConversationConfiguration) {
         const config = new CoreCrypto.#module.ConversationConfiguration(
             ciphersuite,
             keyRotationSpan,
@@ -299,10 +298,10 @@ export class CoreCrypto {
 
     /**
      * Decrypts a message for a given conversation
-     * 
+     *
      * @param conversationId - The ID of the conversation
      * @param payload - The encrypted message buffer
-     * 
+     *
      * @returns Either a decrypted message payload or `undefined` - This happens when the encrypted payload contains a system message such a proposal or commit
      */
     async decryptMessage(conversationId: ConversationId, payload: Uint8Array): Promise<Uint8Array | undefined> {
@@ -314,10 +313,10 @@ export class CoreCrypto {
 
     /**
      * Encrypts a message for a given conversation
-     * 
+     *
      * @param conversationId - The ID of the conversation
      * @param message - The plaintext message to encrypt
-     * 
+     *
      * @returns The encrypted payload for the given group. This needs to be fanned out to the other members of the group.
      */
     async encryptMessage(conversationId: ConversationId, message: Uint8Array): Promise<Uint8Array> {
@@ -329,7 +328,7 @@ export class CoreCrypto {
 
     /**
      * Ingest a TLS-serialized MLS welcome message to join a an existing MLS group
-     * 
+     *
      * @param welcomeMessage - TLS-serialized MLS Welcome message
      * @returns The conversation ID of the newly joined group. You can use the same ID to decrypt/encrypt messages
      */

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -140,17 +140,10 @@ pub struct ConversationConfiguration {
 impl TryInto<MlsConversationConfiguration> for ConversationConfiguration {
     type Error = CryptoError;
     fn try_into(mut self) -> CryptoResult<MlsConversationConfiguration> {
-        use tls_codec::Deserialize as _;
-        let external_senders = self
-            .external_senders
-            .into_iter()
-            .map(|s| Ok(Credential::tls_deserialize(&mut &s[..]).map_err(MlsError::from)?))
-            .filter_map(|r: CryptoResult<Credential>| r.ok())
-            .collect();
         let mut cfg = MlsConversationConfiguration {
             admins: self.admins,
             key_rotation_span: self.key_rotation_span,
-            external_senders,
+            external_senders: self.external_senders,
             ..Default::default()
         };
 

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -309,14 +309,10 @@ impl ConversationConfiguration {
 impl TryInto<MlsConversationConfiguration> for ConversationConfiguration {
     type Error = WasmCryptoError;
     fn try_into(mut self) -> WasmCryptoResult<MlsConversationConfiguration> {
-        use tls_codec::Deserialize as _;
         let external_senders = self
             .external_senders
             .iter()
-            .map(|s: JsValue| {
-                Ok(Credential::tls_deserialize(&mut &Uint8Array::new(&s).to_vec()[..]).map_err(MlsError::from)?)
-            })
-            .filter_map(|r: CryptoResult<Credential>| r.ok())
+            .map(|s: JsValue| Uint8Array::new(&s).to_vec())
             .collect();
         let key_rotation_span = self
             .key_rotation_span

--- a/crypto/src/conversation/decrypt.rs
+++ b/crypto/src/conversation/decrypt.rs
@@ -522,32 +522,28 @@ pub mod tests {
                     Box::pin(async move {
                         alice_central.callbacks(Box::new(ValidationCallbacks::default()));
                         bob_central.callbacks(Box::new(ValidationCallbacks::default()));
-                        let conversation_id = conversation_id();
+                        let id = conversation_id();
                         let configuration = MlsConversationConfiguration::default();
 
-                        alice_central
-                            .new_conversation(conversation_id.clone(), configuration)
-                            .await
-                            .unwrap();
-                        alice_central.invite(&conversation_id, &mut bob_central).await.unwrap();
+                        alice_central.new_conversation(id.clone(), configuration).await.unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
                         let kp = alice2_central.get_one_key_package().await;
-                        let alice_group = alice_central.group(&conversation_id);
-                        let epoch = alice_group.epoch();
+                        let epoch = alice_central[&id].group.epoch();
                         let message = alice2_central
-                            .new_external_add_proposal(conversation_id.clone(), epoch, kp)
+                            .new_external_add_proposal(id.clone(), epoch, kp)
                             .await
                             .unwrap();
 
                         let decrypted = alice_central
-                            .decrypt_message(&conversation_id, &message.to_bytes().unwrap())
+                            .decrypt_message(&id, &message.to_bytes().unwrap())
                             .await
                             .unwrap();
                         assert!(decrypted.app_msg.is_none());
                         assert!(decrypted.delay.is_some());
 
                         let decrypted = bob_central
-                            .decrypt_message(&conversation_id, &message.to_bytes().unwrap())
+                            .decrypt_message(&id, &message.to_bytes().unwrap())
                             .await
                             .unwrap();
                         assert!(decrypted.app_msg.is_none());
@@ -566,32 +562,28 @@ pub mod tests {
                 ["alice", "bob", "alice2"],
                 move |[mut alice_central, mut bob_central, alice2_central]| {
                     Box::pin(async move {
-                        let conversation_id = conversation_id();
+                        let id = conversation_id();
                         let configuration = MlsConversationConfiguration::default();
 
-                        alice_central
-                            .new_conversation(conversation_id.clone(), configuration)
-                            .await
-                            .unwrap();
-                        alice_central.invite(&conversation_id, &mut bob_central).await.unwrap();
+                        alice_central.new_conversation(id.clone(), configuration).await.unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
                         let kp = alice2_central.get_one_key_package().await;
-                        let alice_group = alice_central.group(&conversation_id);
-                        let epoch = alice_group.epoch();
+                        let epoch = alice_central[&id].group.epoch();
                         let message = alice2_central
-                            .new_external_add_proposal(conversation_id.clone(), epoch, kp)
+                            .new_external_add_proposal(id.clone(), epoch, kp)
                             .await
                             .unwrap();
 
                         let error = alice_central
-                            .decrypt_message(&conversation_id, &message.to_bytes().unwrap())
+                            .decrypt_message(&id, &message.to_bytes().unwrap())
                             .await
                             .unwrap_err();
 
                         assert!(matches!(error, CryptoError::CallbacksNotSet));
 
                         let error = bob_central
-                            .decrypt_message(&conversation_id, &message.to_bytes().unwrap())
+                            .decrypt_message(&id, &message.to_bytes().unwrap())
                             .await
                             .unwrap_err();
 
@@ -611,32 +603,28 @@ pub mod tests {
                 move |[mut alice_central, mut bob_central, alice2_central]| {
                     Box::pin(async move {
                         alice_central.callbacks(Box::new(ValidationCallbacks::new(true, false)));
-                        let conversation_id = conversation_id();
+                        let id = conversation_id();
                         let configuration = MlsConversationConfiguration::default();
 
-                        alice_central
-                            .new_conversation(conversation_id.clone(), configuration)
-                            .await
-                            .unwrap();
-                        alice_central.invite(&conversation_id, &mut bob_central).await.unwrap();
+                        alice_central.new_conversation(id.clone(), configuration).await.unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
                         let kp = alice2_central.get_one_key_package().await;
-                        let alice_group = alice_central.group(&conversation_id);
-                        let epoch = alice_group.epoch();
+                        let epoch = alice_central[&id].group.epoch();
                         let message = alice2_central
-                            .new_external_add_proposal(conversation_id.clone(), epoch, kp)
+                            .new_external_add_proposal(id.clone(), epoch, kp)
                             .await
                             .unwrap();
 
                         let error = alice_central
-                            .decrypt_message(&conversation_id, &message.to_bytes().unwrap())
+                            .decrypt_message(&id, &message.to_bytes().unwrap())
                             .await
                             .unwrap_err();
 
                         assert!(matches!(error, CryptoError::ExternalProposalError(_)));
 
                         let error = bob_central
-                            .decrypt_message(&conversation_id, &message.to_bytes().unwrap())
+                            .decrypt_message(&id, &message.to_bytes().unwrap())
                             .await
                             .unwrap_err();
 

--- a/crypto/src/conversation/renew.rs
+++ b/crypto/src/conversation/renew.rs
@@ -71,7 +71,7 @@ impl MlsConversation {
         proposals: impl Iterator<Item = QueuedProposal>,
     ) -> CryptoResult<Vec<MlsMessageOut>> {
         let mut result = vec![];
-        let is_external = |p: &QueuedProposal| matches!(p.sender(), Sender::Preconfigured(_) | Sender::NewMember);
+        let is_external = |p: &QueuedProposal| matches!(p.sender(), Sender::External(_) | Sender::NewMember);
         let proposals = proposals.filter(|p| !is_external(p));
         for proposal in proposals {
             let msg = match proposal.proposal() {

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -166,4 +166,7 @@ pub enum MlsError {
     /// External Commit error
     #[error(transparent)]
     MlsExternalCommitError(#[from] openmls::prelude::ExternalCommitError),
+    /// External Commit error
+    #[error(transparent)]
+    MlsCryptoError(#[from] openmls::prelude::CryptoError),
 }

--- a/crypto/src/external_commit.rs
+++ b/crypto/src/external_commit.rs
@@ -52,7 +52,7 @@ impl MlsCentral {
             &self.mls_backend,
             None,
             group_state,
-            &MlsConversationConfiguration::default().as_openmls_default_configuration(),
+            &MlsConversationConfiguration::default().as_openmls_default_configuration()?,
             &[],
             credentials,
         )

--- a/crypto/src/test_utils.rs
+++ b/crypto/src/test_utils.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use openmls::prelude::{
-    KeyPackage, KeyPackageBundle, MlsGroup, PublicGroupState, QueuedProposal, StagedCommit, VerifiablePublicGroupState,
+    KeyPackage, KeyPackageBundle, PublicGroupState, QueuedProposal, StagedCommit, VerifiablePublicGroupState,
 };
 pub use rstest::*;
 pub use rstest_reuse::{self, *};
@@ -96,10 +96,6 @@ impl MlsCentral {
 
     pub async fn get_one_key_package_bundle(&self) -> KeyPackageBundle {
         self.client_keypackages(1).await.unwrap().first().unwrap().clone()
-    }
-
-    pub fn group(&self, id: &ConversationId) -> &MlsGroup {
-        &self[id].group
     }
 
     pub async fn rnd_member(&self) -> ConversationMember {

--- a/crypto/src/test_utils.rs
+++ b/crypto/src/test_utils.rs
@@ -99,7 +99,7 @@ impl MlsCentral {
     }
 
     pub fn group(&self, id: &ConversationId) -> &MlsGroup {
-        &self[&id].group
+        &self[id].group
     }
 
     pub async fn rnd_member(&self) -> ConversationMember {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Consumers can now pass an Ed25519 public key when creating a conversation. This "remove key" is the backend's key which will be used to validate external remove proposals

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
