### PR TITLE
Verify our operations are durable [CL-63]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ branch = "otak/sodiumoxide-0.2.7"
 [patch.crates-io.openmls]
 git = "https://github.com/wireapp/openmls"
 #tag = "v0.5.1-pre.core-crypto-0.3.0"
- branch = "feat/async"
+branch = "feat/async"
 package = "openmls"
 
 [patch.crates-io.openmls_traits]
 git = "https://github.com/wireapp/openmls"
 #tag = "v0.5.1-pre.core-crypto-0.3.0"
- branch = "feat/async"
+ branch = "feat/cl-57"
 package = "openmls_traits"
 
 [patch.crates-io.hpke-rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ package = "openmls"
 [patch.crates-io.openmls_traits]
 git = "https://github.com/wireapp/openmls"
 #tag = "v0.5.1-pre.core-crypto-0.3.0"
- branch = "feat/cl-57"
+branch = "feat/async"
 package = "openmls_traits"
 
 [patch.crates-io.hpke-rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crypto", "crypto-ffi", "keystore", "mls-provider"]
+members = ["crypto", "crypto-ffi", "crypto-attributes", "keystore", "mls-provider"]
 exclude = ["xtask", "extras/anycrypto", "extras/core-ds", "extras/interop"]
 resolver = "2"
 

--- a/crypto-attributes/Cargo.toml
+++ b/crypto-attributes/Cargo.toml
@@ -13,3 +13,4 @@ proc-macro = true
 syn = { version = "1", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
+paste = "1.0"

--- a/crypto-attributes/Cargo.toml
+++ b/crypto-attributes/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "core-crypto-attributes"
+description = "Macros for core-crypto"
+repository = "https://github.com/wireapp/core-crypto"
+version = "0.3.0"
+edition = "2021"
+license = "GPL-3.0-only"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crypto-attributes/src/lib.rs
+++ b/crypto-attributes/src/lib.rs
@@ -39,9 +39,6 @@ pub fn durable(_attrs: TokenStream, item: TokenStream) -> TokenStream {
     let body = &ast.block;
     let attrs = &ast.attrs;
     let vis = &ast.vis;
-    if ast.sig.asyncness.is_none() {
-        return compile_error(item, syn::Error::new_spanned(ast, ASYNC_ERROR_MSG));
-    }
     let result: proc_macro2::TokenStream = quote::quote! {
         #(#doc_attributes)*
         #(#attrs)*

--- a/crypto-attributes/src/lib.rs
+++ b/crypto-attributes/src/lib.rs
@@ -1,0 +1,63 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+/// Will drop current MLS group in memory and replace it with the one in the keystore.
+/// This simulates an application crash. Once restarted, everything has to be loaded from the
+/// keystore, memory is lost.
+///
+/// This helps spotting:
+/// * when one has forgotten to call [core_crypto::MlsConversation::persist_group_when_changed]
+/// * if persisted fields are sufficient to pursue normally after a crash
+///
+/// **IF** you mark a method `#[durable]`, remove its call to
+/// [core_crypto::MlsConversation::persist_group_when_changed] and tests still pass, you either:
+/// * have unit tests not covering the method enough
+/// * do not require this method to be durable
+#[proc_macro_attribute]
+pub fn durable(_attrs: TokenStream, item: TokenStream) -> TokenStream {
+    const ASYNC_ERROR_MSG: &str = "Since a durable method requires persistence in the keystore, it has to be async";
+
+    let ast = match syn::parse2::<syn::ItemFn>(item.clone().into()) {
+        Ok(ast) => ast,
+        Err(e) => return compile_error(item, e),
+    };
+    if ast.sig.asyncness.is_none() {
+        return compile_error(item, syn::Error::new_spanned(ast, ASYNC_ERROR_MSG));
+    }
+
+    let doc_attributes = ast
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("doc"))
+        .cloned()
+        .collect::<Vec<syn::Attribute>>();
+
+    let ret = &ast.sig.output;
+    let name = &ast.sig.ident;
+    let inputs = &ast.sig.inputs;
+    let body = &ast.block;
+    let attrs = &ast.attrs;
+    let vis = &ast.vis;
+    if ast.sig.asyncness.is_none() {
+        return compile_error(item, syn::Error::new_spanned(ast, ASYNC_ERROR_MSG));
+    }
+    let result: proc_macro2::TokenStream = quote::quote! {
+        #(#doc_attributes)*
+        #(#attrs)*
+        #vis async fn #name(#inputs) #ret {
+            let _result = #body;
+            #[cfg(test)] {
+                self.drop_and_restore(backend).await;
+            }
+            _result
+        }
+    };
+    result.into()
+}
+
+fn compile_error(mut item: TokenStream, err: syn::Error) -> TokenStream {
+    let compile_err = TokenStream::from(err.to_compile_error());
+    item.extend(compile_err);
+    item
+}

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,7 +21,7 @@ openmls_traits = "0.1"
 # FIXME: This is being pulled only because of flaky error types from openmls
 tls_codec = "0.2"
 serde_json = "1.0"
-derive_more = { version = "0.99", features = ["deref", "from", "display"] }
+derive_more = { version = "0.99", features = ["deref"] }
 
 [dependencies.core-crypto-keystore]
 version = "0.3"
@@ -30,10 +30,6 @@ path = "../keystore"
 [dependencies.mls-crypto-provider]
 version = "0.3"
 path = "../mls-provider"
-
-[dependencies.core-crypto-attributes]
-version = "0.3"
-path = "../crypto-attributes"
 
 [dev-dependencies]
 uuid = { version = "1.0", features = ["v4", "v5"] }
@@ -45,6 +41,10 @@ rstest_reuse = "0.4"
 rcgen = { version = "0.9", features = ["x509-parser"] }
 async-std = { version = "1.12", features = ["attributes"] }
 futures-util = { version = "0.3", features = ["std", "alloc"] }
+
+[dev-dependencies.core-crypto-attributes]
+version = "0.3"
+path = "../crypto-attributes"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,7 +21,7 @@ openmls_traits = "0.1"
 # FIXME: This is being pulled only because of flaky error types from openmls
 tls_codec = "0.2"
 serde_json = "1.0"
-derive_more = { version = "0.99", features = ["deref"] }
+derive_more = { version = "0.99", features = ["deref", "from", "display"] }
 
 [dependencies.core-crypto-keystore]
 version = "0.3"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -31,6 +31,10 @@ path = "../keystore"
 version = "0.3"
 path = "../mls-provider"
 
+[dependencies.core-crypto-attributes]
+version = "0.3"
+path = "../crypto-attributes"
+
 [dev-dependencies]
 uuid = { version = "1.0", features = ["v4", "v5"] }
 rand = "0.8"

--- a/crypto/src/conversation/durability.rs
+++ b/crypto/src/conversation/durability.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use crate::MlsConversation;
 
 impl MlsConversation {
@@ -16,6 +14,35 @@ impl MlsConversation {
             .map(|mut groups| groups.remove(group_id.as_slice()).unwrap())
             .unwrap();
         let group = MlsConversation::from_serialized_state(group).unwrap();
+        *self = group;
+    }
+
+    /// see [crate::durable]
+    pub async fn hold(&mut self, backend: &mls_crypto_provider::MlsCryptoProvider) -> Vec<u8> {
+        use core_crypto_keystore::CryptoKeystoreMls as _;
+        use openmls_traits::OpenMlsCryptoProvider as _;
+
+        let group_id = self.group.group_id();
+        backend
+            .key_store()
+            .mls_groups_restore()
+            .await
+            .map(|mut groups| groups.remove(group_id.as_slice()).unwrap())
+            .unwrap()
+    }
+
+    /// see [crate::durable]
+    pub async fn crush(&mut self, backend: &mls_crypto_provider::MlsCryptoProvider, previous: Vec<u8>) {
+        use core_crypto_keystore::CryptoKeystoreMls as _;
+        use openmls_traits::OpenMlsCryptoProvider as _;
+
+        let group = MlsConversation::from_serialized_state(previous.clone()).unwrap();
+        let group_id = self.group.group_id();
+        backend
+            .key_store()
+            .mls_group_persist(group_id.as_slice(), previous.as_slice())
+            .await
+            .unwrap();
         *self = group;
     }
 }

--- a/crypto/src/conversation/durability.rs
+++ b/crypto/src/conversation/durability.rs
@@ -1,0 +1,21 @@
+#![cfg(test)]
+
+use crate::MlsConversation;
+
+impl MlsConversation {
+    /// see [crate::durable]
+    pub async fn drop_and_restore(&mut self, backend: &mls_crypto_provider::MlsCryptoProvider) {
+        use core_crypto_keystore::CryptoKeystoreMls as _;
+        use openmls_traits::OpenMlsCryptoProvider as _;
+
+        let group_id = self.group.group_id();
+        let group = backend
+            .key_store()
+            .mls_groups_restore()
+            .await
+            .map(|mut groups| groups.remove(group_id.as_slice()).unwrap())
+            .unwrap();
+        let group = MlsConversation::from_serialized_state(group).unwrap();
+        *self = group;
+    }
+}

--- a/crypto/src/conversation/merge.rs
+++ b/crypto/src/conversation/merge.rs
@@ -126,8 +126,6 @@ pub mod tests {
         credential::CredentialSupplier, prelude::MlsProposal, prelude::MlsProposalBundle, test_utils::*,
         MlsConversationConfiguration,
     };
-    use openmls::prelude::AddProposal;
-    use openmls::prelude::Proposal;
 
     use super::*;
     use crate::{

--- a/crypto/src/conversation/merge.rs
+++ b/crypto/src/conversation/merge.rs
@@ -126,6 +126,14 @@ pub mod tests {
         credential::CredentialSupplier, prelude::MlsProposal, prelude::MlsProposalBundle, test_utils::*,
         MlsConversationConfiguration,
     };
+    use openmls::prelude::AddProposal;
+    use openmls::prelude::Proposal;
+
+    use super::*;
+    use crate::{
+        credential::CredentialSupplier, prelude::MlsProposal, prelude::MlsProposalBundle, test_utils::*,
+        MlsConversationConfiguration,
+    };
 
     use super::*;
 

--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -43,6 +43,7 @@ use crate::{
 
 mod commit_delay;
 pub mod decrypt;
+mod durability;
 pub mod encrypt;
 pub mod handshake;
 pub mod merge;

--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -43,6 +43,7 @@ use crate::{
 
 mod commit_delay;
 pub mod decrypt;
+#[cfg(test)]
 mod durability;
 pub mod encrypt;
 pub mod handshake;

--- a/crypto/src/conversation/renew.rs
+++ b/crypto/src/conversation/renew.rs
@@ -1,4 +1,4 @@
-use openmls::prelude::{Proposal, QueuedProposal, Sender, StagedCommit};
+use openmls::prelude::{KeyPackageRef, Proposal, QueuedProposal, Sender, StagedCommit};
 
 use mls_crypto_provider::MlsCryptoProvider;
 
@@ -12,30 +12,52 @@ pub(crate) struct Renew;
 impl Renew {
     /// Renews proposals:
     /// * in pending_proposals but not in valid commit
-    /// * in pending commit but not in valid commit
+    /// * in pending_commit but not in valid commit
     ///
+    /// NB: we do not deal with partial commit (commit which do not contain all pending proposals)
+    /// because they cannot be created at the moment by core-crypto
+    ///
+    /// * `self_kpr` - own client [KeyPackageRef] in current MLS group
     /// * `pending_proposals` - local pending proposals in group's proposal store
     /// * `pending_commit` - local pending commit which is now invalid
     /// * `valid_commit` - commit accepted by the backend which will now supersede our local pending commit
     pub(crate) fn renew<'a>(
+        self_kpr: Option<KeyPackageRef>,
         pending_proposals: impl Iterator<Item = QueuedProposal> + 'a,
         pending_commit: Option<&'a StagedCommit>,
         valid_commit: &'a StagedCommit,
-    ) -> Vec<QueuedProposal> {
-        // present locally but not in valid commit
-        let renewed_pending_proposals =
-            pending_proposals.filter_map(|p| Self::is_proposal_renewable(p, Some(valid_commit)));
+    ) -> (Vec<QueuedProposal>, bool) {
+        // indicates if we need to renew an update proposal.
+        // true only if we have an empty pending commit or the valid commit does not contain one of our update proposal
+        // otherwise, local orphan update proposal will be renewed regularly, without this flag
+        let mut update_self = false;
 
-        if let Some(pending_commit) = pending_commit {
+        let renewed_pending_proposals = if let Some(pending_commit) = pending_commit {
             // present in pending commit but not in valid commit
-            let renewed_from_pending_commit = pending_commit
-                .staged_proposal_queue()
-                .cloned()
-                .filter_map(|p| Self::is_proposal_renewable(p, Some(valid_commit)));
-            renewed_pending_proposals.chain(renewed_from_pending_commit).collect()
+            let commit_proposals = pending_commit.staged_proposal_queue().cloned().collect::<Vec<_>>();
+
+            // if our own pending commit is empty it means we were attempting to update
+            let empty_commit = commit_proposals.is_empty();
+
+            // does the valid commit contains one of our update proposal ?
+            let valid_commit_has_self_update_proposal = valid_commit.update_proposals().any(|p| match p.sender() {
+                Sender::Member(sender_kpr) => self_kpr.as_ref() == Some(sender_kpr),
+                _ => false,
+            });
+            update_self = empty_commit && !valid_commit_has_self_update_proposal;
+
+            // local proposals present in local pending commit but not in valid commit
+            commit_proposals
+                .into_iter()
+                .filter_map(|p| Self::is_proposal_renewable(p, Some(valid_commit)))
+                .collect::<Vec<_>>()
         } else {
-            renewed_pending_proposals.collect()
-        }
+            // local pending proposals present locally but not in valid commit
+            pending_proposals
+                .filter_map(|p| Self::is_proposal_renewable(p, Some(valid_commit)))
+                .collect::<Vec<_>>()
+        };
+        (renewed_pending_proposals, update_self)
     }
 
     /// A proposal has to be renewed if it is absent from supplied commit
@@ -48,7 +70,9 @@ impl Renew {
                 Proposal::Remove(ref remove) => commit
                     .remove_proposals()
                     .any(|p| p.remove_proposal().removed() == remove.removed()),
-                Proposal::Update(_) => false,
+                Proposal::Update(ref update) => commit
+                    .update_proposals()
+                    .any(|p| p.update_proposal().key_package() == update.key_package()),
                 _ => true,
             };
             if in_commit {
@@ -70,6 +94,7 @@ impl MlsConversation {
         &mut self,
         backend: &MlsCryptoProvider,
         proposals: impl Iterator<Item = QueuedProposal>,
+        update_self: bool,
     ) -> CryptoResult<Vec<MlsProposalBundle>> {
         let mut result = vec![];
         let is_external = |p: &QueuedProposal| matches!(p.sender(), Sender::External(_) | Sender::NewMember);
@@ -83,7 +108,17 @@ impl MlsConversation {
             };
             result.push(msg);
         }
+        if update_self {
+            result.push(self.propose_self_update(backend).await?);
+        }
         Ok(result)
+    }
+
+    pub(crate) fn self_pending_proposals(&self) -> impl Iterator<Item = &QueuedProposal> {
+        self.group.pending_proposals().filter(|&p| match p.sender() {
+            Sender::Member(sender_kpr) => self.group.key_package_ref() == Some(sender_kpr),
+            _ => false,
+        })
     }
 }
 
@@ -93,106 +128,58 @@ pub mod tests {
 
     use crate::{credential::CredentialSupplier, prelude::MlsProposal, test_utils::*, MlsConversationConfiguration};
 
-    use super::*;
-
-    mod is_renewable {
+    mod update {
         use super::*;
 
         #[apply(all_credential_types)]
         #[wasm_bindgen_test]
-        pub async fn is_renewable_when_commit_absent(credential: CredentialSupplier) {
-            run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
-
-                    alice_central.new_proposal(&id, MlsProposal::Update).await.unwrap();
-                    let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
-
-                    assert!(Renew::is_proposal_renewable(proposal, None).is_some())
-                })
-            })
-            .await
-        }
-
-        #[apply(all_credential_types)]
-        #[wasm_bindgen_test]
-        pub async fn update_is_always_renewable(credential: CredentialSupplier) {
-            run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
-                    alice_central.new_proposal(&id, MlsProposal::Update).await.unwrap();
-                    let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
-                    alice_central[&id].group.clear_pending_proposals();
-
-                    alice_central.update_keying_material(&id).await.unwrap();
-                    let commit = alice_central.pending_commit(&id).unwrap().clone();
-                    assert!(Renew::is_proposal_renewable(proposal, Some(&commit)).is_some())
-                })
-            })
-            .await
-        }
-
-        #[apply(all_credential_types)]
-        #[wasm_bindgen_test]
-        pub async fn add_is_not_renewable_when_commit_already_adds_same(credential: CredentialSupplier) {
-            run_test_with_client_ids(credential, ["alice", "bob"], move |[mut alice_central, bob_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
-
-                    let bob_kp = bob_central.get_one_key_package().await;
-                    alice_central.new_proposal(&id, MlsProposal::Add(bob_kp)).await.unwrap();
-                    let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
-                    alice_central[&id].group.clear_pending_proposals();
-                    assert!(alice_central.pending_proposals(&id).is_empty());
-
-                    alice_central
-                        .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
-                        .await
-                        .unwrap();
-                    let commit = alice_central.pending_commit(&id).unwrap().clone();
-                    assert!(Renew::is_proposal_renewable(proposal, Some(&commit)).is_none())
-                })
-            })
-            .await
-        }
-
-        #[apply(all_credential_types)]
-        #[wasm_bindgen_test]
-        pub async fn add_is_renewable_when_commit_doesnt_adds_same(credential: CredentialSupplier) {
+        pub async fn renewable_when_created_by_self(credential: CredentialSupplier) {
             run_test_with_client_ids(
                 credential,
-                ["alice", "bob", "charlie"],
-                move |[mut alice_central, bob_central, charlie_central]| {
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
                             .new_conversation(id.clone(), MlsConversationConfiguration::default())
                             .await
                             .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
-                        let bob_kp = bob_central.get_one_key_package().await;
-                        alice_central.new_proposal(&id, MlsProposal::Add(bob_kp)).await.unwrap();
-                        let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
-                        alice_central[&id].group.clear_pending_proposals();
-
+                        assert!(alice_central.pending_proposals(&id).is_empty());
                         alice_central
-                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .new_proposal(&id, MlsProposal::Update)
                             .await
-                            .unwrap();
-                        let commit = alice_central.pending_commit(&id).unwrap().clone();
-                        assert!(Renew::is_proposal_renewable(proposal, Some(&commit)).is_some())
+                            .unwrap()
+                            .proposal;
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // Bob hasn't Alice's proposal but creates a commit
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.commit_accepted(&id).await.unwrap();
+
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice should renew the proposal because its her's
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+
+                        // It should also renew the proposal when in pending_commit
+                        alice_central.commit_pending_proposals(&id).await.unwrap();
+                        assert!(alice_central.pending_commit(&id).is_some());
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice should renew the proposal because its her's
+                        // It should also replace existing one
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
                     })
                 },
             )
@@ -201,70 +188,655 @@ pub mod tests {
 
         #[apply(all_credential_types)]
         #[wasm_bindgen_test]
-        pub async fn remove_is_not_renewable_when_commit_already_removes_same(credential: CredentialSupplier) {
-            run_test_with_client_ids(credential, ["alice", "bob"], move |[mut alice_central, bob_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
-                    alice_central
-                        .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
-                        .await
-                        .unwrap();
-                    alice_central.commit_accepted(&id).await.unwrap();
-                    assert_eq!(alice_central[&id].group.members().len(), 2);
-
-                    alice_central
-                        .new_proposal(&id, MlsProposal::Remove(b"bob"[..].into()))
-                        .await
-                        .unwrap();
-                    let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
-                    alice_central[&id].group.clear_pending_proposals();
-
-                    alice_central
-                        .remove_members_from_conversation(&id, &["bob".into()])
-                        .await
-                        .unwrap();
-                    let commit = alice_central.pending_commit(&id).unwrap().clone();
-                    assert!(Renew::is_proposal_renewable(proposal, Some(&commit)).is_none())
-                })
-            })
-            .await
-        }
-
-        #[apply(all_credential_types)]
-        #[wasm_bindgen_test]
-        pub async fn remove_is_renewable_when_commit_doesnt_removes_same(credential: CredentialSupplier) {
+        pub async fn renews_pending_commit_when_created_by_self(credential: CredentialSupplier) {
             run_test_with_client_ids(
                 credential,
-                ["alice", "bob", "charlie"],
-                move |[mut alice_central, bob_central, charlie_central]| {
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
                             .new_conversation(id.clone(), MlsConversationConfiguration::default())
                             .await
                             .unwrap();
-                        let members = &mut [bob_central.rnd_member().await, charlie_central.rnd_member().await];
-                        alice_central.add_members_to_conversation(&id, members).await.unwrap();
-                        alice_central.commit_accepted(&id).await.unwrap();
-                        assert_eq!(alice_central[&id].group.members().len(), 3);
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
+                        alice_central.update_keying_material(&id).await.unwrap();
+                        assert!(alice_central.pending_commit(&id).is_some());
+
+                        // but Bob creates a commit meanwhile
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice should renew the proposal because its her's
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_when_in_valid_commit(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
                         alice_central
-                            .new_proposal(&id, MlsProposal::Remove(b"bob"[..].into()))
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
                             .await
                             .unwrap();
-                        let proposal = alice_central.pending_proposals(&id).first().unwrap().clone();
-                        alice_central[&id].group.clear_pending_proposals();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
 
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        let proposal = alice_central
+                            .new_proposal(&id, MlsProposal::Update)
+                            .await
+                            .unwrap()
+                            .proposal;
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // Bob has Alice's update proposal
+                        bob_central
+                            .decrypt_message(&id, proposal.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.commit_accepted(&id).await.unwrap();
+
+                        // Bob's commit has Alice's proposal
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice proposal should not be renew as it was in valid commit
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+
+                        // Same if proposal is also in pending commit
+                        let proposal = alice_central
+                            .new_proposal(&id, MlsProposal::Update)
+                            .await
+                            .unwrap()
+                            .proposal;
+                        alice_central.commit_pending_proposals(&id).await.unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert!(alice_central.pending_commit(&id).is_some());
+                        bob_central
+                            .decrypt_message(&id, proposal.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice should not be renew as it was in valid commit
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_by_ref(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+
+                        let proposal = bob_central
+                            .new_proposal(&id, MlsProposal::Update)
+                            .await
+                            .unwrap()
+                            .proposal;
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .decrypt_message(&id, proposal.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // Charlie does not have other proposals, it creates a commit
+                        let commit = charlie_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice should not renew Bob's update proposal
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+    }
+
+    mod add {
+        use super::*;
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_when_valid_commit_adds_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+
+                        let charlie_kp = charlie_central.get_one_key_package().await;
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .new_proposal(&id, MlsProposal::Add(charlie_kp))
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        let commit = bob_central
+                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .await
+                            .unwrap()
+                            .commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice proposal is not renewed since she also wanted to add Charlie
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_in_pending_commit_when_valid_commit_adds_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+
+                        let charlie_kp = charlie_central.get_one_key_package().await;
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .new_proposal(&id, MlsProposal::Add(charlie_kp))
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // Here Alice also creates a commit
+                        alice_central.commit_pending_proposals(&id).await.unwrap();
+                        assert!(alice_central.pending_commit(&id).is_some());
+
+                        let commit = bob_central
+                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .await
+                            .unwrap()
+                            .commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Alice proposal is not renewed since she also wanted to add Charlie
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_by_ref(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie", "debbie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central, debbie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+
+                        // Bob will propose adding Debbie
+                        let debbie_kp = debbie_central.get_one_key_package().await;
+                        let proposal = bob_central
+                            .new_proposal(&id, MlsProposal::Add(debbie_kp))
+                            .await
+                            .unwrap()
+                            .proposal;
+                        alice_central
+                            .decrypt_message(&id, proposal.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // But Charlie will commit meanwhile
+                        let commit = charlie_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // which Alice should not renew since it's not hers
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn renewable_when_valid_commit_doesnt_adds_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+
+                        // Alice proposes adding Charlie
+                        let charlie_kp = charlie_central.get_one_key_package().await;
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .new_proposal(&id, MlsProposal::Add(charlie_kp))
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // But meanwhile Bob will create a commit without Alice's proposal
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.commit_accepted(&id).await.unwrap();
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // So Alice proposal should be renewed
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+
+                        // And same should happen when proposal is in pending commit
+                        alice_central.commit_pending_proposals(&id).await.unwrap();
+                        assert!(alice_central.pending_commit(&id).is_some());
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // So Alice proposal should also be renewed
+                        // It should also replace existing one
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn renews_pending_commit_when_valid_commit_doesnt_adds_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+
+                        // Alice commits adding Charlie
+                        alice_central
+                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .await
+                            .unwrap();
+                        assert!(alice_central.pending_commit(&id).is_some());
+
+                        // But meanwhile Bob will create a commit
+                        let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // So Alice proposal should be renewed
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+    }
+
+    mod remove {
+        use super::*;
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_when_valid_commit_removes_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        let commit = bob_central
+                            .remove_members_from_conversation(&id, &["charlie".into()])
+                            .await
+                            .unwrap()
+                            .commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Remove proposal is not renewed since commit does same
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn not_renewable_by_ref(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+
+                        let proposal = bob_central
+                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .await
+                            .unwrap()
+                            .proposal;
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .decrypt_message(&id, proposal.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        let commit = charlie_central.update_keying_material(&id).await.unwrap().commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Remove proposal is not renewed since by ref
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn renewable_when_valid_commit_doesnt_remove_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie", "debbie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central, mut debbie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        debbie_central
+                            .try_join_from_public_group_state(
+                                &id,
+                                pgs,
+                                vec![&mut alice_central, &mut bob_central, &mut charlie_central],
+                            )
+                            .await
+                            .unwrap();
+
+                        // Alice wants to remove Charlie
+                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        alice_central
+                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+
+                        // Whereas Bob wants to remove Debbie
+                        let commit = bob_central
+                            .remove_members_from_conversation(&id, &["debbie".into()])
+                            .await
+                            .unwrap()
+                            .commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Remove is renewed since valid commit removes another
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn renews_pending_commit_when_commit_doesnt_remove_same(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie", "debbie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central, mut debbie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        debbie_central
+                            .try_join_from_public_group_state(
+                                &id,
+                                pgs,
+                                vec![&mut alice_central, &mut bob_central, &mut charlie_central],
+                            )
+                            .await
+                            .unwrap();
+
+                        // Alice wants to remove Charlie
                         alice_central
                             .remove_members_from_conversation(&id, &["charlie".into()])
                             .await
                             .unwrap();
-                        let commit = alice_central.pending_commit(&id).unwrap().clone();
-                        assert!(Renew::is_proposal_renewable(proposal, Some(&commit)).is_some())
+                        assert!(alice_central.pending_commit(&id).is_some());
+
+                        // Whereas Bob wants to remove Debbie
+                        let commit = bob_central
+                            .remove_members_from_conversation(&id, &["debbie".into()])
+                            .await
+                            .unwrap()
+                            .commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Remove is renewed since valid commit removes another
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn renews_pending_commit_from_proposal_when_commit_doesnt_remove_same(
+            credential: CredentialSupplier,
+        ) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob", "charlie", "debbie"],
+                move |[mut alice_central, mut bob_central, mut charlie_central, mut debbie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        charlie_central
+                            .try_join_from_public_group_state(&id, pgs, vec![&mut alice_central, &mut bob_central])
+                            .await
+                            .unwrap();
+                        let pgs = alice_central.public_group_state(&id).await;
+                        debbie_central
+                            .try_join_from_public_group_state(
+                                &id,
+                                pgs,
+                                vec![&mut alice_central, &mut bob_central, &mut charlie_central],
+                            )
+                            .await
+                            .unwrap();
+
+                        // Alice wants to remove Charlie
+                        alice_central
+                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .await
+                            .unwrap();
+                        alice_central.commit_pending_proposals(&id).await.unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert!(alice_central.pending_commit(&id).is_some());
+
+                        // Whereas Bob wants to remove Debbie
+                        let commit = bob_central
+                            .remove_members_from_conversation(&id, &["debbie".into()])
+                            .await
+                            .unwrap()
+                            .commit;
+                        let proposals = alice_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap()
+                            .proposals;
+                        // Remove is renewed since valid commit removes another
+                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
                     })
                 },
             )

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -90,6 +90,11 @@ pub enum CryptoError {
     /// A supplied [`HashReference`] is not of the expected size: 16
     #[error("A supplied reference is not of the expected size: 16")]
     InvalidHashReference,
+    /// The client who created this message is likely to have reused a ratchet generation or
+    /// we are trying to decrypt the same message twice. For the former, this client MLS
+    /// implementation has a loophole and it'd better be evicted from the group.
+    #[error("Decrypted an application message twice")]
+    GenerationOutOfBound,
 }
 
 /// A simpler definition for Result types that the Error is a [CryptoError]

--- a/crypto/src/external_proposal.rs
+++ b/crypto/src/external_proposal.rs
@@ -217,7 +217,6 @@ mod tests {
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
 
                         owner_central.invite(&id, &mut guest_central).await.unwrap();
-                        owner_central.commit_accepted(&id).await.unwrap();
                         assert_eq!(owner_central[&id].members().len(), 2);
 
                         // now, as e.g. a Delivery Service, let's create an external remove proposal
@@ -277,7 +276,6 @@ mod tests {
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
 
                         owner_central.invite(&id, &mut guest_central).await.unwrap();
-                        owner_central.commit_accepted(&id).await.unwrap();
                         assert_eq!(owner_central[&id].members().len(), 2);
 
                         // now, attacker will try to remove guest from the group, and should fail
@@ -336,7 +334,6 @@ mod tests {
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
 
                         owner_central.invite(&id, &mut guest_central).await.unwrap();
-                        owner_central.commit_accepted(&id).await.unwrap();
                         assert_eq!(owner_central[&id].members().len(), 2);
 
                         // now, as e.g. a Delivery Service, let's create an external remove proposal

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -47,6 +47,8 @@ use credential::CertificateBundle;
 use mls_crypto_provider::{MlsCryptoProvider, MlsCryptoProviderConfiguration};
 
 pub use self::error::*;
+
+#[cfg(test)]
 pub use core_crypto_attributes::durable;
 
 mod client;

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -43,10 +43,11 @@ use tls_codec::{Deserialize, Serialize};
 use client::{Client, ClientId};
 use config::MlsCentralConfiguration;
 use conversation::{ConversationId, MlsConversation, MlsConversationConfiguration};
+use credential::CertificateBundle;
 use mls_crypto_provider::{MlsCryptoProvider, MlsCryptoProviderConfiguration};
 
 pub use self::error::*;
-use crate::credential::CertificateBundle;
+pub use core_crypto_attributes::durable;
 
 mod client;
 mod conversation;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes, we might forget to persist a MLS group after an operation. This macro will erase the current in memory group and restore it from keystore. If the methods is tested enough and forgets to persist the group (while it should) then the unit tests will catch that

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
