### PR TITLE
build(tooling): Added semver version bumper

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,10 +68,16 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - uses: taiki-e/install-action@nextest
-      - uses: actions-rs/cargo@v1
+      - name: "Test CoreCrypto"
+        uses: actions-rs/cargo@v1
         with:
           command: nextest
           args: run --verbose --release
+      - name: "Test CoreCrypto xtask tooling"
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --verbose --manifest-path xtask/Cargo.toml
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Platform support legends:
 * ❌ = tier 3 support. It doesn't work just yet, but we plan to make it work.
 
 
-## [0.3.0] - TBD
+## [0.3.0] - 2022-08-12
 
 <details>
     <summary>git-conventional changelog</summary>
@@ -66,6 +66,7 @@ Platform support legends:
 
 ### Miscellaneous Tasks
 
+- Bump WASM bundle version to 0.3.0
 - Added Changelog generator
 - Fix nits on CHANGELOG-HUMAN.md
 - Add changelog generator configuration + human changelog

--- a/CHANGELOG.tpl
+++ b/CHANGELOG.tpl
@@ -8,11 +8,11 @@ Platform support legends:
 * ❌ = tier 3 support. It doesn't work just yet, but we plan to make it work.
 
 
-## [0.3.0] - TBD
+## [0.3.0] - 2022-08-12
 
 <details>
     <summary>git-conventional changelog</summary>
-{{git-cliff tag="v0.3.0" unreleased=true}}
+{{git-cliff tag="v0.3.0"}}
 </details>
 
 This second major release focuses on expanding our platform support and featureset

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -18,6 +18,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,12 +77,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "cargo"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7019448b7d0ffe19d4ab26a340d2efe6da8cf86c8cc01a352b90853e31cd8f7c"
+dependencies = [
+ "anyhow",
+ "atty",
+ "bytesize",
+ "cargo-platform",
+ "cargo-util",
+ "clap",
+ "crates-io",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "env_logger",
+ "filetime",
+ "flate2",
+ "fwdansi",
+ "git2",
+ "git2-curl",
+ "glob",
+ "hex 0.4.3",
+ "home",
+ "humantime",
+ "ignore",
+ "im-rc",
+ "indexmap",
+ "itertools",
+ "jobserver",
+ "lazy_static",
+ "lazycell",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "memchr",
+ "num_cpus",
+ "opener",
+ "os_info",
+ "pathdiff",
+ "percent-encoding",
+ "rustc-workspace-hack",
+ "rustfix",
+ "semver",
+ "serde",
+ "serde_ignored",
+ "serde_json",
+ "shell-escape",
+ "strip-ansi-escapes",
+ "tar",
+ "tempfile",
+ "termcolor",
+ "toml_edit",
+ "unicode-width",
+ "unicode-xid",
+ "url",
+ "walkdir",
+ "winapi",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb66f33d96c58d1eef3a4744556ce0fae012b01165a3f171169a15cb4efc9633"
+dependencies = [
+ "anyhow",
+ "core-foundation",
+ "crypto-hash",
+ "filetime",
+ "hex 0.4.3",
+ "jobserver",
+ "libc",
+ "log",
+ "miow",
+ "same-file",
+ "shell-escape",
+ "tempfile",
+ "walkdir",
+ "winapi",
 ]
 
 [[package]]
@@ -146,12 +297,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "commoncrypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+dependencies = [
+ "commoncrypto-sys",
+]
+
+[[package]]
+name = "commoncrypto-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crates-io"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4a87459133b2e708195eaab34be55039bc30e0d120658bd40794bb00b6328d"
+dependencies = [
+ "anyhow",
+ "curl",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -165,6 +393,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-hash"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
+dependencies = [
+ "commoncrypto",
+ "hex 0.3.2",
+ "openssl",
+ "winapi",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.56+curl-7.83.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093e169dd4de29e468fa649fbae11cdcd5551c81fe5bf1b0677adad7ef3d26f"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +453,34 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003000e712ad0f95857bd4d2ef8d1890069e06554101697d12050668b2f6f020"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -185,6 +494,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "femme"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "libz-sys",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +570,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fwdansi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c1f5787fe85505d1f7777268db5103d80a7a374d2316a7ce262e57baf8f208"
+dependencies = [
+ "memchr",
+ "termcolor",
 ]
 
 [[package]]
@@ -212,9 +600,9 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
  "bitflags",
  "libc",
@@ -223,6 +611,37 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "git2-curl"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee51709364c341fbb6fe2a385a290fb9196753bdde2fc45447d27cd31b11b13"
+dependencies = [
+ "curl",
+ "git2",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -261,6 +680,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +715,38 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -288,6 +766,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,10 +799,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -316,9 +836,9 @@ checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.0+1.5.0"
+version = "0.13.4+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
@@ -326,6 +846,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.7+1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -361,6 +891,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "serde",
+ "value-bag",
 ]
 
 [[package]]
@@ -385,6 +917,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +949,42 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "opener"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
+dependencies = [
+ "bstr",
+ "winapi",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -419,6 +1006,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5209b2162b2c140df493a93689e04f8deab3a67634f5bc7a553c0a98e5b8d399"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +1027,12 @@ name = "owo-colors"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -535,10 +1139,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-workspace-hack"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
+
+[[package]]
+name = "rustfix"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd2853d9e26988467753bd9912c3a126f642d05d229a4b53f5752ee36c56481"
+dependencies = [
+ "anyhow",
+ "log",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "ryu"
@@ -547,10 +1225,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_fmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2963a69a2b3918c1dc75a45a18bd3fcd1120e31d3f59deb1b2f9b5d5ffb8baa4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b3da7eedd967647a866f67829d1c79d184d7c4521126e9cc2c46a9585c6d21"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde_json"
@@ -584,10 +1322,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "sval"
+version = "1.0.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "syn"
@@ -598,6 +1386,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -658,6 +1470,19 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "kstring",
+ "serde",
+]
 
 [[package]]
 name = "tracing"
@@ -735,6 +1560,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,10 +1584,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+ "sval",
+ "version_check",
+]
 
 [[package]]
 name = "vcpkg"
@@ -763,6 +1620,104 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+
+[[package]]
+name = "web-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -796,6 +1751,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
 name = "xshell"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,10 +1812,15 @@ checksum = "88301b56c26dd9bf5c43d858538f82d6f3f7764767defbc5d34e59459901c41a"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "cargo",
  "clap",
  "color-eyre",
+ "femme",
  "git2",
  "handlebars",
+ "log",
+ "semver",
  "serde_json",
+ "toml_edit",
  "xshell",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,11 +6,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-git2 = "0.15"
-xshell = "0.2"
-handlebars = "4.3"
+femme = "2.2"
+log = "0.4"
 color-eyre = "0.6"
 clap = { version = "3.2", features = ["derive"] }
+git2 = "0.14"
+xshell = "0.2"
+handlebars = "4.3"
 serde_json = "1.0"
+semver = "1.0"
+toml_edit = "0.14"
+cargo = "0.64"
 
 

--- a/xtask/src/documentation/mod.rs
+++ b/xtask/src/documentation/mod.rs
@@ -2,3 +2,16 @@ mod build;
 pub use build::build;
 mod changelog;
 pub use changelog::changelog;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum DocumentationCommands {
+    Build {
+        // TODO: Add platforms to build documentation for
+        #[clap(value_parser)]
+        platforms: Option<String>,
+    },
+    Changelog {
+        #[clap(long, action)]
+        dry_run: bool,
+    },
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,10 @@ use clap::{Parser, Subcommand};
 use color_eyre::eyre::Result;
 
 mod documentation;
+mod release;
+
+use crate::documentation::DocumentationCommands;
+use crate::release::ReleaseCommands;
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -15,31 +19,25 @@ struct Xtask {
 enum Commands {
     #[clap(subcommand)]
     Documentation(DocumentationCommands),
+    #[clap(subcommand)]
+    Release(ReleaseCommands),
 }
 
-#[derive(Debug, Subcommand)]
-enum DocumentationCommands {
-    Build {
-        // TODO: Add platforms to build documentation for
-        #[clap(value_parser)]
-        platforms: Option<String>,
-    },
-    Changelog {
-        #[clap(long, action)]
-        dry_run: bool,
-    },
-}
 
 fn main() -> Result<()> {
     color_eyre::install()?;
+    femme::start();
 
     let cli = Xtask::parse();
 
     match cli.command {
-        Commands::Documentation(doc_command) => match &doc_command {
+        Commands::Documentation(doc_command) => match doc_command {
             DocumentationCommands::Build { .. } => documentation::build()?,
-            DocumentationCommands::Changelog { dry_run } => documentation::changelog(*dry_run)?,
+            DocumentationCommands::Changelog { dry_run } => documentation::changelog(dry_run)?,
         },
+        Commands::Release(release_command) => match release_command {
+            ReleaseCommands::Bump { version, dry_run } => release::bump(version, dry_run)?,
+        }
     }
 
     Ok(())

--- a/xtask/src/release/bump.rs
+++ b/xtask/src/release/bump.rs
@@ -1,0 +1,303 @@
+use color_eyre::eyre::{eyre, Result};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum BumpLevel {
+    Major,
+    Minor,
+    Patch,
+    Rc,
+    Pre,
+}
+
+fn increment_pre_version(pre_kind: &str, pre: &semver::Prerelease) -> Result<semver::Prerelease> {
+    let pre_str = pre.as_str();
+    let components: Vec<&str> = pre_str.split('.').collect();
+
+    let pre_kind_actual = components[0];
+    let mut pre_target_version = 0;
+    if pre_kind_actual == pre_kind {
+        if components.len() == 2 {
+            let pre_version: u64 = components[1].parse()?;
+            pre_target_version = pre_version;
+        } else {
+            pre_target_version = 1;
+        }
+    }
+
+    Ok(semver::Prerelease::new(&format!(
+        "{pre_kind}.{}",
+        pre_target_version + 1
+    ))?)
+}
+
+fn bump_semver(bump_level: BumpLevel, old_version: &semver::Version) -> Result<semver::Version> {
+    let mut version = old_version.clone();
+    match bump_level {
+        BumpLevel::Major => {
+            version.major += 1;
+            version.minor = 0;
+            version.patch = 0;
+            version.pre = semver::Prerelease::EMPTY;
+            version.build = semver::BuildMetadata::EMPTY;
+        }
+        BumpLevel::Minor => {
+            version.minor += 1;
+            version.patch = 0;
+            version.pre = semver::Prerelease::EMPTY;
+            version.build = semver::BuildMetadata::EMPTY;
+        }
+        BumpLevel::Patch => {
+            if version.pre.is_empty() {
+                version.patch += 1;
+            }
+            version.pre = semver::Prerelease::EMPTY;
+            version.build = semver::BuildMetadata::EMPTY;
+        }
+        BumpLevel::Rc => {
+            version.pre = increment_pre_version("rc", &version.pre)?;
+        }
+        BumpLevel::Pre => {
+            version.pre = increment_pre_version("pre", &version.pre)?;
+        }
+    }
+
+    Ok(version)
+}
+
+pub fn bump(bump_version: BumpLevel, dry_run: bool) -> Result<()> {
+    let cargo_config = cargo::util::Config::default().map_err(|e| eyre!(e.to_string()))?;
+    let ws = cargo::core::Workspace::new(&Path::new("./Cargo.toml").canonicalize()?, &cargo_config)
+        .map_err(|e| eyre!(e.to_string()))?;
+
+    for package in ws.members() {
+        let package_name = package.name();
+        log::debug!("Found workspace member {package_name}");
+        let manifest_path = package.manifest_path();
+        log::debug!("Opening {manifest_path:?}...");
+        let toml_raw_doc = std::fs::read_to_string(manifest_path)?;
+
+        let mut manifest = toml_raw_doc.parse::<toml_edit::Document>()?;
+        let semver_version = semver::Version::parse(
+            manifest["package"]["version"]
+                .as_str()
+                .ok_or_else(|| eyre!("Could not parse version"))?,
+        )?;
+
+        log::info!("Found workspace member {package_name}@{semver_version}");
+
+        let new_semver_version = bump_semver(bump_version, &semver_version)?;
+        log::info!("Bumping {package_name}: {semver_version} -> {new_semver_version}");
+
+        if !dry_run {
+            manifest["package"]["version"] = toml_edit::value(new_semver_version.to_string());
+            std::fs::write(manifest_path, manifest.to_string())?;
+            log::debug!("Wrote new manifest");
+        } else {
+            log::info!("Dry run selected, doing nothing");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bumps_major_version_correctly() {
+        let version = semver::Version::parse("0.0.8").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+
+        let version = semver::Version::parse("0.0.8-pre.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+
+        let version = semver::Version::parse("0.0.8-rc.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+
+        let version = semver::Version::parse("0.1.0-pre").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+
+        let version = semver::Version::parse("0.1.1-pre.2").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+
+        let version = semver::Version::parse("0.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+
+        let version = semver::Version::parse("1.1.1-pre.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "2.0.0");
+
+        let version = semver::Version::parse("1.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "2.0.0");
+
+        let version = semver::Version::parse("1.0.0-rc.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Major, &version).unwrap();
+        assert_eq!(new_version.to_string(), "2.0.0");
+    }
+
+    #[test]
+    fn bumps_minor_version_correctly() {
+        let version = semver::Version::parse("0.0.8").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.0");
+
+        let version = semver::Version::parse("0.0.8-pre.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.0");
+
+        let version = semver::Version::parse("0.0.8-rc.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.0");
+
+        let version = semver::Version::parse("0.1.0-pre").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.2.0");
+
+        let version = semver::Version::parse("0.1.1-pre.2").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.2.0");
+
+        let version = semver::Version::parse("0.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.2.0");
+
+        let version = semver::Version::parse("1.1.1-pre.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.2.0");
+
+        let version = semver::Version::parse("1.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.2.0");
+
+        let version = semver::Version::parse("1.0.0-rc.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Minor, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.0");
+    }
+
+    #[test]
+    fn bumps_patch_version_correctly() {
+        let version = semver::Version::parse("0.0.8").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.9");
+
+        let version = semver::Version::parse("0.0.8-pre.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8");
+
+        let version = semver::Version::parse("0.0.8-rc.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8");
+
+        let version = semver::Version::parse("0.1.0-pre").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.0");
+
+        let version = semver::Version::parse("0.1.1-pre.2").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.1");
+
+        let version = semver::Version::parse("0.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.2");
+
+        let version = semver::Version::parse("1.1.1-pre.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.1");
+
+        let version = semver::Version::parse("1.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.2");
+
+        let version = semver::Version::parse("1.0.0-rc.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Patch, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0");
+    }
+
+    #[test]
+    fn bumps_rc_version_correctly() {
+        let version = semver::Version::parse("0.0.8").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8-rc.1");
+
+        let version = semver::Version::parse("0.0.8-pre.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8-rc.1");
+
+        let version = semver::Version::parse("0.0.8-rc.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8-rc.5");
+
+        let version = semver::Version::parse("0.1.0-pre").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.0-rc.1");
+
+        let version = semver::Version::parse("0.1.1-pre.2").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.1-rc.1");
+
+        let version = semver::Version::parse("0.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.1-rc.1");
+
+        let version = semver::Version::parse("1.1.1-pre.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.1-rc.1");
+
+        let version = semver::Version::parse("1.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.1-rc.1");
+
+        let version = semver::Version::parse("1.0.0-rc.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Rc, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0-rc.2");
+    }
+
+    #[test]
+    fn bumps_pre_version_correctly() {
+        let version = semver::Version::parse("0.0.8").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8-pre.1");
+
+        let version = semver::Version::parse("0.0.8-pre.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8-pre.5");
+
+        let version = semver::Version::parse("0.0.8-rc.4").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.0.8-pre.1");
+
+        let version = semver::Version::parse("0.1.0-pre").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.0-pre.2");
+
+        let version = semver::Version::parse("0.1.1-pre.2").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.1-pre.3");
+
+        let version = semver::Version::parse("0.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "0.1.1-pre.1");
+
+        let version = semver::Version::parse("1.1.1-pre.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.1-pre.2");
+
+        let version = semver::Version::parse("1.1.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.1.1-pre.1");
+
+        let version = semver::Version::parse("1.0.0-rc.1").unwrap();
+        let new_version = bump_semver(BumpLevel::Pre, &version).unwrap();
+        assert_eq!(new_version.to_string(), "1.0.0-pre.1");
+    }
+}

--- a/xtask/src/release/mod.rs
+++ b/xtask/src/release/mod.rs
@@ -1,0 +1,14 @@
+
+mod bump;
+pub use bump::*;
+
+#[derive(Debug, clap::Subcommand)]
+pub enum ReleaseCommands {
+    Bump {
+        #[clap(value_parser)]
+        version: bump::BumpLevel,
+        #[clap(long, action)]
+        dry_run: bool,
+    }
+}
+


### PR DESCRIPTION
Added a new `xtask` to sync bumping up crates versions. Will be useful later on.
