### PR TITLE
feat: use 128 bytes of padding when encrypting messages instead of 16

### DIFF
--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -70,6 +70,7 @@ pub struct MlsConversationConfiguration {
 impl MlsConversationConfiguration {
     // TODO: pending a long term solution with a real certificate
     const WIRE_SERVER_IDENTITY: &'static str = "wire-server";
+    const PADDING_SIZE: usize = 128;
 
     /// Generates an `MlsGroupConfig` from this configuration
     #[inline(always)]
@@ -77,7 +78,7 @@ impl MlsConversationConfiguration {
         Ok(openmls::group::MlsGroupConfig::builder()
             .wire_format_policy(openmls::group::MIXED_PLAINTEXT_WIRE_FORMAT_POLICY)
             .max_past_epochs(3)
-            .padding_size(16)
+            .padding_size(Self::PADDING_SIZE)
             .number_of_resumtion_secrets(1)
             .sender_ratchet_configuration(SenderRatchetConfiguration::new(2, 1000))
             .use_ratchet_tree_extension(true)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Use 128 bits of padding by default instead of 16 previously

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
