### PR TITLE
feat!: 'decrypt_message' returns the sender client id [CL-81]

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -48,10 +48,16 @@ export interface ConversationConfiguration {
 }
 
 /**
- * Alias for convesation IDs.
+ * Alias for conversation IDs.
  * This is a freeform, uninspected buffer.
  */
 export type ConversationId = Uint8Array;
+
+/**
+ * Alias for client identifier.
+ * This is a freeform, uninspected buffer.
+ */
+export type ClientId = Uint8Array;
 
 /**
  * Alias for proposal reference. It is a byte array of size 16.
@@ -95,7 +101,7 @@ export interface Invitee {
     /**
      * Client ID as a byte array
      */
-    id: Uint8Array;
+    id: ClientId;
     /**
      * MLS KeyPackage belonging to the aforementioned client
      */
@@ -185,6 +191,10 @@ export interface DecryptedMessage {
      * Commit delay hint (in milliseconds) to prevent clients from hammering the server with epoch changes
      */
     commitDelay?: number;
+    /**
+     * Client identifier of the sender of the message being decrypted. Only present for application messages.
+     */
+    senderClientId?: ClientId;
 }
 
 /**
@@ -250,7 +260,7 @@ export interface RemoveProposalArgs extends ProposalArgs {
     /**
      * Client ID to be removed from the conversation
      */
-    clientId: Uint8Array;
+    clientId: ClientId;
 }
 
 /**
@@ -571,7 +581,7 @@ export class CoreCrypto {
      */
     async removeClientsFromConversation(
         conversationId: ConversationId,
-        clientIds: Uint8Array[]
+        clientIds: ClientId[]
     ): Promise<CommitBundle> {
         const ffiRet: CoreCryptoFfiTypes.CommitBundle = await this.#cc.remove_clients_from_conversation(
             conversationId,

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -55,15 +55,17 @@ extension CoreCryptoSwift.ProposalBundle {
     }
 }
 
-/// Alias for convesation IDs.
+/// Alias for conversation IDs.
 /// This is a freeform, uninspected buffer.
 public typealias ConversationId = [UInt8]
+
+/// Alias for ClientId within a conversation.
 public typealias MemberId = [UInt8]
 
 /// Conversation ciphersuite variants
 public enum CiphersuiteName: ConvertToInner {
     typealias Inner = CoreCryptoSwift.CiphersuiteName
-    
+
     case mls128Dhkemx25519Aes128gcmSha256Ed25519
     case mls128Dhkemp256Aes128gcmSha256P256
     case mls128Dhkemx25519Chacha20poly1305Sha256Ed25519
@@ -100,7 +102,7 @@ public struct ConversationConfiguration: ConvertToInner {
     func convert() -> Inner {
         return CoreCryptoSwift.ConversationConfiguration(admins: self.admins, ciphersuite: self.ciphersuite?.convert(), keyRotationSpan: self.keyRotationSpan, externalSenders: self.externalSenders)
     }
-    
+
     ///  List of client IDs with administrative permissions
     public var admins: [MemberId]
     /// Conversation ciphersuite
@@ -131,7 +133,7 @@ public struct Invitee: ConvertToInner {
         self.id = id
         self.kp = kp
     }
-    
+
     func convert() -> Inner {
         return CoreCryptoSwift.Invitee(id: self.id, kp: self.kp)
     }
@@ -152,7 +154,7 @@ public struct MemberAddedMessages: ConvertToInner {
         self.welcome = welcome
         self.publicGroupState = publicGroupState
     }
-    
+
     func convert() -> Inner {
         return CoreCryptoSwift.MemberAddedMessages(commit: self.commit, welcome: self.welcome, publicGroupState: self.publicGroupState)
     }
@@ -173,18 +175,21 @@ public struct DecryptedMessage: ConvertToInner {
     public var isActive: Bool
     /// delay time in seconds to feed caller timer for committing
     public var commitDelay: UInt64?
+    /// Client identifier of the sender of the message being decrypted. Only present for application messages.
+    public var senderClientId: ClientId?
 
-    public init(message: [UInt8]?, proposals: [ProposalBundle], isActive: Bool, commitDelay: UInt64?) {
+    public init(message: [UInt8]?, proposals: [ProposalBundle], isActive: Bool, commitDelay: UInt64?, senderClientId: ClientId?) {
         self.message = message
         self.proposals = proposals
         self.isActive = isActive
         self.commitDelay = commitDelay
+        self.senderClientId = senderClientId
     }
 
     func convert() -> Inner {
         return CoreCryptoSwift.DecryptedMessage(message: self.message, proposals: self.proposals.map({ (bundle) -> CoreCryptoSwift.ProposalBundle in
             bundle.convert()
-        }), isActive: self.isActive, commitDelay: self.commitDelay)
+        }), isActive: self.isActive, commitDelay: self.commitDelay, senderClientId: self.senderClientId)
     }
 }
 
@@ -200,7 +205,7 @@ public struct ProposalBundle: ConvertToInner {
         self.proposal = proposal
         self.proposalRef = proposalRef
     }
-    
+
     func convert() -> Inner {
         return CoreCryptoSwift.ProposalBundle(proposal: self.proposal, proposalRef: self.proposalRef)
     }

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -50,6 +50,7 @@ dictionary DecryptedMessage {
     sequence<ProposalBundle> proposals;
     boolean is_active;
     u64? commit_delay;
+    ClientId? sender_client_id;
 };
 
 dictionary MemberAddedMessages {

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -113,6 +113,7 @@ pub struct DecryptedMessage {
     pub proposals: Vec<ProposalBundle>,
     pub is_active: bool,
     pub commit_delay: Option<u64>,
+    pub sender_client_id: Option<ClientId>,
 }
 
 impl TryFrom<MlsConversationDecryptMessage> for DecryptedMessage {
@@ -130,6 +131,7 @@ impl TryFrom<MlsConversationDecryptMessage> for DecryptedMessage {
             proposals,
             is_active: from.is_active,
             commit_delay: from.delay,
+            sender_client_id: from.sender_client_id,
         })
     }
 }

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -244,6 +244,7 @@ pub struct DecryptedMessage {
     proposals: Vec<ProposalBundle>,
     is_active: bool,
     commit_delay: Option<u32>,
+    sender_client_id: Option<FfiClientId>,
 }
 
 impl TryFrom<MlsConversationDecryptMessage> for DecryptedMessage {
@@ -267,6 +268,7 @@ impl TryFrom<MlsConversationDecryptMessage> for DecryptedMessage {
             proposals,
             is_active: from.is_active,
             commit_delay,
+            sender_client_id: from.sender_client_id.map(ClientId::into),
         })
     }
 }

--- a/crypto/src/client.rs
+++ b/crypto/src/client.rs
@@ -60,6 +60,12 @@ impl From<Box<[u8]>> for ClientId {
     }
 }
 
+impl From<ClientId> for Box<[u8]> {
+    fn from(value: ClientId) -> Self {
+        value.0.into_boxed_slice()
+    }
+}
+
 #[cfg(test)]
 impl From<&str> for ClientId {
     fn from(value: &str) -> Self {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Return sender client id when decrypting a message to help AVS

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
