### PR TITLE
Fix android null pointer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ package = "hpke-rs-rust-crypto"
 git = "https://github.com/wireapp/rcgen"
 tag = "v1.0.0-pre.core-crypto-0.3.0"
 
+[patch.crates-io.sha2]
+git = "https://github.com/RustCrypto/hashes.git"
+tag = "sha2-v0.10.2"
+package = "sha2"
+
 # Needed for quick mode and (later) result comparison see (https://www.tweag.io/blog/2022-03-03-criterion-rs/)
 # TODO: remove once branch got merged in 0.4 release
 [patch.crates-io.criterion]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ branch = "otak/sodiumoxide-0.2.7"
 
 [patch.crates-io.openmls]
 git = "https://github.com/wireapp/openmls"
-#tag = "v0.5.1-pre.core-crypto-0.3.0"
-branch = "feat/async"
+tag = "v0.5.2-pre.core-crypto-0.4.2"
+#branch = "feat/async"
 package = "openmls"
 
 [patch.crates-io.openmls_traits]
 git = "https://github.com/wireapp/openmls"
-#tag = "v0.5.1-pre.core-crypto-0.3.0"
-branch = "feat/async"
+tag = "v0.5.2-pre.core-crypto-0.4.2"
+#branch = "feat/async"
 package = "openmls_traits"
 
 [patch.crates-io.hpke-rs]

--- a/crypto-attributes/Cargo.toml
+++ b/crypto-attributes/Cargo.toml
@@ -13,4 +13,3 @@ proc-macro = true
 syn = { version = "1", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
-paste = "1.0"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Running core-crypto on Android fails because of a null pointer error in the [sha2](https://github.com/RustCrypto/hashes/tree/master/sha2) crate. The regression was introduced by [this PR](https://github.com/RustCrypto/hashes/pull/388) which narrows down the supported architectures, excluding Android ones. It is likely the [sha2-asm](https://github.com/RustCrypto/asm-hashes) is supported on more targets than it claims.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
