### PR TITLE
fix: sha2 on 32 bit Android [CL-83]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,6 @@ package = "hpke-rs-rust-crypto"
 git = "https://github.com/wireapp/rcgen"
 tag = "v1.0.0-pre.core-crypto-0.3.0"
 
-[patch.crates-io.sha2]
-git = "https://github.com/RustCrypto/hashes.git"
-tag = "sha2-v0.10.2"
-package = "sha2"
-
 # Needed for quick mode and (later) result comparison see (https://www.tweag.io/blog/2022-03-03-criterion-rs/)
 # TODO: remove once branch got merged in 0.4 release
 [patch.crates-io.criterion]

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -29,6 +29,10 @@ uniffi_macros = { version = "=0.19.3", optional = true }
 # C-API support
 libc = { version = "0.2", optional = true }
 
+# see https://github.com/RustCrypto/hashes/issues/404
+[target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")))'.dependencies]
+sha2 = { version = "0.10", features = ["force-soft"] }
+
 # Blocking APIs support
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 futures-lite = "1.12"


### PR DESCRIPTION
…ot supporting hardware implementation (i686 & armv7 in our case)

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Force software implementation for sha2 on target architectures not supporting hardware implementation (i686 & armv7 in our case).

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
