### PR TITLE
fix: Fixed iOS SQLCipher salt handling within keychain [CL-84]

### DIFF
--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -34,6 +34,7 @@ zeroize = { version = "1.5", features = ["zeroize_derive"] }
 async-trait = "0.1"
 async-lock = "2.5"
 serde_json = "1.0"
+sha2 = "0.10"
 
 lru = { version = "0.7", optional = true }
 
@@ -76,7 +77,6 @@ wasm-bindgen-futures = "0.4"
 aes-gcm = "0.10"
 rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
-sha2 = "0.10"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/keystore/tests/general.rs
+++ b/keystore/tests/general.rs
@@ -37,6 +37,10 @@ pub mod tests {
     #[cfg(feature = "ios-wal-compat")]
     #[cfg_attr(not(target_family = "wasm"), async_std::test)]
     async fn can_preserve_wal_compat_for_ios() {
-        let _store = setup("ios-wal-compat").await;
+        let store1 = setup("ios-wal-compat", false).await;
+        store1.close().await.unwrap();
+        let store2 = setup("ios-wal-compat-2", true).await;
+        store2.close().await.unwrap();
+        let store1 = setup("ios-wal-compat", false).await;
     }
 }


### PR DESCRIPTION
Closes #95 

Basically it wasnt working at all anyway because of a syntax error. I have no idea how we could compile for ios before?