### PR TITLE
fix: external_senders public key was not TLS deserialized

### DIFF
--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -29,12 +29,13 @@
 
 use std::collections::HashMap;
 
-use core_crypto_keystore::CryptoKeystoreMls;
 use openmls::prelude::{ExternalSender, SignaturePublicKey};
 use openmls::{group::MlsGroup, messages::Welcome, prelude::Credential, prelude::SenderRatchetConfiguration};
 use openmls_traits::types::SignatureScheme;
 use openmls_traits::OpenMlsCryptoProvider;
+use tls_codec::{Deserialize, TlsVecU16};
 
+use core_crypto_keystore::CryptoKeystoreMls;
 use mls_crypto_provider::MlsCryptoProvider;
 
 use crate::{
@@ -92,8 +93,9 @@ impl MlsConversationConfiguration {
             .external_senders
             .iter()
             .map(|key| {
-                SignaturePublicKey::new(key.clone(), SignatureScheme::ED25519)
+                TlsVecU16::tls_deserialize(&mut key.as_slice())
                     .map_err(MlsError::from)
+                    .and_then(|k| SignaturePublicKey::new(k.into(), SignatureScheme::ED25519).map_err(MlsError::from))
                     .map_err(CryptoError::from)
             })
             .filter_map(|r: CryptoResult<SignaturePublicKey>| r.ok())

--- a/crypto/src/external_proposal.rs
+++ b/crypto/src/external_proposal.rs
@@ -138,6 +138,7 @@ mod tests {
         credential::CredentialSupplier, prelude::handshake::MlsCommitBundle, test_utils::*, CryptoError,
         MlsConversationConfiguration, MlsError,
     };
+    use tls_codec::Serialize;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -210,8 +211,9 @@ mod tests {
                         let id = conversation_id();
 
                         let remove_key = ds.mls_client.credentials().credential().signature_key().clone();
+                        let remove_key = remove_key.tls_serialize_detached().unwrap();
                         let cfg = MlsConversationConfiguration {
-                            external_senders: vec![remove_key.as_slice().to_vec()],
+                            external_senders: vec![remove_key],
                             ..Default::default()
                         };
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
@@ -270,8 +272,9 @@ mod tests {
 
                         // Delivery service key is used in the group..
                         let remove_key = ds.mls_client.credentials().credential().signature_key().clone();
+                        let remove_key = remove_key.tls_serialize_detached().unwrap();
                         let cfg = MlsConversationConfiguration {
-                            external_senders: vec![remove_key.as_slice().to_vec()],
+                            external_senders: vec![remove_key],
                             ..Default::default()
                         };
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
@@ -328,6 +331,7 @@ mod tests {
                         let short_remove_key =
                             SignaturePublicKey::new(remove_key.as_slice()[1..].to_vec(), remove_key.signature_scheme())
                                 .unwrap();
+                        let short_remove_key = short_remove_key.tls_serialize_detached().unwrap();
                         let cfg = MlsConversationConfiguration {
                             external_senders: vec![short_remove_key.as_slice().to_vec()],
                             ..Default::default()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

external_senders public key was not TLS deserialized causing rejection of external remove proposals

### Causes (Optional)

The backend's key was not TLS deserialized

### Solutions

TLS deserialize the backend's key

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
