### PR TITLE
fix: wire-server removal key

### DIFF
--- a/crypto/src/conversation/mod.rs
+++ b/crypto/src/conversation/mod.rs
@@ -33,7 +33,6 @@ use openmls::prelude::{ExternalSender, SignaturePublicKey};
 use openmls::{group::MlsGroup, messages::Welcome, prelude::Credential, prelude::SenderRatchetConfiguration};
 use openmls_traits::types::SignatureScheme;
 use openmls_traits::OpenMlsCryptoProvider;
-use tls_codec::{Deserialize, TlsVecU16};
 
 use core_crypto_keystore::CryptoKeystoreMls;
 use mls_crypto_provider::MlsCryptoProvider;
@@ -93,9 +92,8 @@ impl MlsConversationConfiguration {
             .external_senders
             .iter()
             .map(|key| {
-                TlsVecU16::tls_deserialize(&mut key.as_slice())
+                SignaturePublicKey::new(key.clone(), SignatureScheme::ED25519)
                     .map_err(MlsError::from)
-                    .and_then(|k| SignaturePublicKey::new(k.into(), SignatureScheme::ED25519).map_err(MlsError::from))
                     .map_err(CryptoError::from)
             })
             .filter_map(|r: CryptoResult<SignaturePublicKey>| r.ok())

--- a/crypto/src/external_proposal.rs
+++ b/crypto/src/external_proposal.rs
@@ -210,8 +210,13 @@ mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
 
-                        let remove_key = ds.mls_client.credentials().credential().signature_key().clone();
-                        let remove_key = remove_key.tls_serialize_detached().unwrap();
+                        let remove_key = ds
+                            .mls_client
+                            .credentials()
+                            .credential()
+                            .signature_key()
+                            .as_slice()
+                            .to_vec();
                         let cfg = MlsConversationConfiguration {
                             external_senders: vec![remove_key],
                             ..Default::default()
@@ -271,8 +276,13 @@ mod tests {
                         let id = conversation_id();
 
                         // Delivery service key is used in the group..
-                        let remove_key = ds.mls_client.credentials().credential().signature_key().clone();
-                        let remove_key = remove_key.tls_serialize_detached().unwrap();
+                        let remove_key = ds
+                            .mls_client
+                            .credentials()
+                            .credential()
+                            .signature_key()
+                            .as_slice()
+                            .to_vec();
                         let cfg = MlsConversationConfiguration {
                             external_senders: vec![remove_key],
                             ..Default::default()
@@ -327,7 +337,7 @@ mod tests {
                         guest_central.callbacks(Box::new(ValidationCallbacks::default()));
                         let id = conversation_id();
 
-                        let remove_key = ds.mls_client.credentials().credential().signature_key().clone();
+                        let remove_key = ds.mls_client.credentials().credential().signature_key();
                         let short_remove_key =
                             SignaturePublicKey::new(remove_key.as_slice()[1..].to_vec(), remove_key.signature_scheme())
                                 .unwrap();


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

wire-server sends a base64 encoded ed25519 key afterall. Consumers are in charge of base64 decoding it and pass it to core-crypto

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
