### PR TITLE
chore: remove unneeded `map_err(CryptoError::from)`

### DIFF
--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -642,10 +642,7 @@ impl CoreCrypto<'_> {
         )?;
         Ok(MlsConversationInitMessage {
             conversation_id,
-            commit: commit
-                .tls_serialize_detached()
-                .map_err(MlsError::from)
-                .map_err(CryptoError::from)?,
+            commit: commit.tls_serialize_detached().map_err(MlsError::from)?,
         })
     }
 

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -950,9 +950,7 @@ impl CoreCrypto {
         let this = self.0.clone();
         future_to_promise(
             async move {
-                let kp = KeyPackage::try_from(&keypackage[..])
-                    .map_err(MlsError::from)
-                    .map_err(CryptoError::from)?;
+                let kp = KeyPackage::try_from(&keypackage[..]).map_err(MlsError::from)?;
                 let proposal: ProposalBundle = this
                     .write()
                     .await
@@ -1017,8 +1015,7 @@ impl CoreCrypto {
                     .await?
                     .to_bytes()
                     .map(|bytes| Uint8Array::from(bytes.as_slice()))
-                    .map_err(MlsError::from)
-                    .map_err(CryptoError::from)?;
+                    .map_err(MlsError::from)?;
 
                 WasmCryptoResult::Ok(proposal_bytes.into())
             }
@@ -1049,8 +1046,7 @@ impl CoreCrypto {
                     .await?
                     .to_bytes()
                     .map(|bytes| Uint8Array::from(bytes.as_slice()))
-                    .map_err(MlsError::from)
-                    .map_err(CryptoError::from)?;
+                    .map_err(MlsError::from)?;
 
                 WasmCryptoResult::Ok(proposal_bytes.into())
             }
@@ -1094,10 +1090,7 @@ impl CoreCrypto {
                 let (conversation_id, commit) = this.read().await.join_by_external_commit(group_state).await?;
                 let result = MlsConversationInitMessage {
                     conversation_id,
-                    commit: commit
-                        .tls_serialize_detached()
-                        .map_err(MlsError::from)
-                        .map_err(CryptoError::from)?,
+                    commit: commit.tls_serialize_detached().map_err(MlsError::from)?,
                 };
                 WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&result)?)
             }

--- a/crypto/src/client.rs
+++ b/crypto/src/client.rs
@@ -411,8 +411,7 @@ impl Client {
                     .map_err(CryptoKeystoreError::from)?
                     .as_slice()
                     .try_into()
-                    .map_err(CryptoKeystoreError::from)
-                    .map_err(CryptoError::from)?;
+                    .map_err(CryptoKeystoreError::from)?;
                 let href = KeyPackageRef::from(href);
                 is_expired = refs.contains(&href);
             }

--- a/crypto/src/conversation/encrypt.rs
+++ b/crypto/src/conversation/encrypt.rs
@@ -9,7 +9,7 @@
 
 use mls_crypto_provider::MlsCryptoProvider;
 
-use crate::{ConversationId, CryptoError, CryptoResult, MlsCentral, MlsError};
+use crate::{ConversationId, CryptoResult, MlsCentral, MlsError};
 
 use super::MlsConversation;
 
@@ -28,8 +28,7 @@ impl MlsConversation {
             .create_message(backend, message.as_ref())
             .await
             .map_err(MlsError::from)
-            .and_then(|m| m.to_bytes().map_err(MlsError::from))
-            .map_err(CryptoError::from)?;
+            .and_then(|m| m.to_bytes().map_err(MlsError::from))?;
         self.persist_group_when_changed(backend, false).await?;
         Ok(encrypted)
     }

--- a/crypto/src/conversation/handshake.rs
+++ b/crypto/src/conversation/handshake.rs
@@ -67,7 +67,6 @@ impl MlsConversation {
             .propose_add_member(backend, key_package)
             .await
             .map_err(MlsError::from)
-            .map_err(CryptoError::from)
             .map(MlsProposalBundle::from)?;
         self.persist_group_when_changed(backend, false).await?;
         Ok(proposal)
@@ -81,7 +80,6 @@ impl MlsConversation {
             .propose_self_update(backend, None)
             .await
             .map_err(MlsError::from)
-            .map_err(CryptoError::from)
             .map(MlsProposalBundle::from)?;
         self.persist_group_when_changed(backend, false).await?;
         Ok(proposal)

--- a/crypto/src/external_commit.rs
+++ b/crypto/src/external_commit.rs
@@ -21,7 +21,7 @@ use core_crypto_keystore::CryptoKeystoreMls;
 
 use crate::{
     prelude::{MlsConversation, MlsConversationConfiguration},
-    ConversationId, CryptoError, CryptoResult, MlsCentral, MlsError,
+    ConversationId, CryptoResult, MlsCentral, MlsError,
 };
 
 impl MlsCentral {
@@ -54,8 +54,7 @@ impl MlsCentral {
             credentials,
         )
         .await
-        .map_err(MlsError::from)
-        .map_err(CryptoError::from)?;
+        .map_err(MlsError::from)?;
 
         let mut group_serialized = vec![];
         group.save(&mut group_serialized)?;
@@ -63,8 +62,7 @@ impl MlsCentral {
         self.mls_backend
             .key_store()
             .mls_pending_groups_save(group.group_id().as_slice(), &group_serialized)
-            .await
-            .map_err(CryptoError::from)?;
+            .await?;
         Ok((group.group_id().to_vec(), message))
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

remove unneeded `map_err(CryptoError::from)`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
