### PR TITLE
feat: Exporting secret key derived from the group and client ids from the members - CL-97 - CL-98

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1009,8 +1009,8 @@ export class CoreCrypto {
      *
      * @returns A `Uint8Array` representing the derived key
      */
-    async exportSecretKey(conversationId: ConversationId, label: string, keyLength: number): Promise<Uint8Array> {
-        return await this.#cc.exportSecretKey(conversationId, label, keyLength);
+    async exportSecretKey(conversationId: ConversationId, keyLength: number): Promise<Uint8Array> {
+        return await this.#cc.export_secret_key(conversationId, keyLength);
     }
 
     /**
@@ -1021,7 +1021,7 @@ export class CoreCrypto {
      * @returns A list of clients from the members of the group
      */
     async exportClients(conversationId: ConversationId): Promise<ClientId[]> {
-        return await this.#cc.exportClients(conversationId);
+        return await this.#cc.export_clients(conversationId);
     }
 
     /**

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1001,6 +1001,30 @@ export class CoreCrypto {
     }
 
     /**
+     * Derives a new key from the group
+     *
+     * @param conversationId - The group's ID
+     * @param label - the label to be used. Intended to describe the purpose for the key
+     * @param keyLength - the length of the key to be derived
+     *
+     * @returns A `Uint8Array` representing the derived key
+     */
+    async exportSecretKey(conversationId: ConversationId, label: string, keyLength: number): Promise<Uint8Array> {
+        return await this.#cc.exportSecretKey(conversationId, label, keyLength);
+    }
+
+    /**
+     * Exports all clients from group's members
+     *
+     * @param conversationId - The group's ID
+     *
+     * @returns A list of clients from the members of the group
+     */
+    async exportClients(conversationId: ConversationId): Promise<ClientId[]> {
+        return await this.#cc.exportClients(conversationId);
+    }
+
+    /**
      * Allows {@link CoreCrypto} to act as a CSPRNG provider
      * @note The underlying CSPRNG algorithm is ChaCha20 and takes in account the external seed provider either at init time or provided with {@link CoreCrypto.reseedRng}
      *

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -14,43 +14,42 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-
 // @ts-ignore
 import wasm from "../../../crypto-ffi/Cargo.toml";
 
 import type * as CoreCryptoFfiTypes from "./wasm/core-crypto-ffi";
 
 /**
-* see [core_crypto::prelude::CiphersuiteName]
-*/
+ * see [core_crypto::prelude::CiphersuiteName]
+ */
 export enum Ciphersuite {
     /**
-    * DH KEM x25519 | AES-GCM 128 | SHA2-256 | Ed25519
-    */
+     * DH KEM x25519 | AES-GCM 128 | SHA2-256 | Ed25519
+     */
     MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 0x0001,
     /**
-    * DH KEM P256 | AES-GCM 128 | SHA2-256 | EcDSA P256
-    */
+     * DH KEM P256 | AES-GCM 128 | SHA2-256 | EcDSA P256
+     */
     MLS_128_DHKEMP256_AES128GCM_SHA256_P256 = 0x0002,
     /**
-    * DH KEM x25519 | Chacha20Poly1305 | SHA2-256 | Ed25519
-    */
+     * DH KEM x25519 | Chacha20Poly1305 | SHA2-256 | Ed25519
+     */
     MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003,
     /**
-    * DH KEM x448 | AES-GCM 256 | SHA2-512 | Ed448
-    */
+     * DH KEM x448 | AES-GCM 256 | SHA2-512 | Ed448
+     */
     MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448 = 0x0004,
     /**
-    * DH KEM P521 | AES-GCM 256 | SHA2-512 | EcDSA P521
-    */
+     * DH KEM P521 | AES-GCM 256 | SHA2-512 | EcDSA P521
+     */
     MLS_256_DHKEMP521_AES256GCM_SHA512_P521 = 0x0005,
     /**
-    * DH KEM x448 | Chacha20Poly1305 | SHA2-512 | Ed448
-    */
+     * DH KEM x448 | Chacha20Poly1305 | SHA2-512 | Ed448
+     */
     MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006,
     /**
-    * DH KEM P384 | AES-GCM 256 | SHA2-384 | EcDSA P384
-    */
+     * DH KEM P384 | AES-GCM 256 | SHA2-384 | EcDSA P384
+     */
     MLS_256_DHKEMP384_AES256GCM_SHA384_P384 = 0x0007,
 }
 
@@ -373,7 +372,11 @@ export interface CoreCryptoCallbacks {
      * @param existingClients - all the clients currently within the MLS group
      * @returns true if the external client is authorized to write to the conversation
      */
-    userAuthorize: (conversationId: Uint8Array, externalClientId: Uint8Array, existingClients: Uint8Array[]) => boolean;
+    userAuthorize: (
+        conversationId: Uint8Array,
+        externalClientId: Uint8Array,
+        existingClients: Uint8Array[]
+    ) => boolean;
 
     /**
      * Callback to ensure that the given `clientId` belongs to one of the provided `existingClients`
@@ -382,7 +385,10 @@ export interface CoreCryptoCallbacks {
      * @param clientId - id of a client
      * @param existingClients - all the clients currently within the MLS group
      */
-    clientIsExistingGroupUser: (clientId: Uint8Array, existingClients: Uint8Array[]) => boolean;
+    clientIsExistingGroupUser: (
+        clientId: Uint8Array,
+        existingClients: Uint8Array[]
+    ) => boolean;
 }
 
 /**
@@ -427,13 +433,28 @@ export class CoreCrypto {
      * });
      * ````
      */
-    static async init({databaseName, key, clientId, wasmFilePath, entropySeed}: CoreCryptoParams): Promise<CoreCrypto> {
+    static async init({
+        databaseName,
+        key,
+        clientId,
+        wasmFilePath,
+        entropySeed,
+    }: CoreCryptoParams): Promise<CoreCrypto> {
         if (!this.#module) {
-            const wasmImportArgs = wasmFilePath ? {importHook: () => wasmFilePath} : undefined;
-            const exports = (await wasm(wasmImportArgs)) as typeof CoreCryptoFfiTypes;
+            const wasmImportArgs = wasmFilePath
+                ? { importHook: () => wasmFilePath }
+                : undefined;
+            const exports = (await wasm(
+                wasmImportArgs
+            )) as typeof CoreCryptoFfiTypes;
             this.#module = exports;
         }
-        const cc = await this.#module.CoreCrypto._internal_new(databaseName, key, clientId, entropySeed);
+        const cc = await this.#module.CoreCrypto._internal_new(
+            databaseName,
+            key,
+            clientId,
+            entropySeed
+        );
         return new this(cc);
     }
 
@@ -459,7 +480,6 @@ export class CoreCrypto {
     async close() {
         await this.#cc.close();
     }
-
 
     /**
      * Registers the callbacks for CoreCrypto to use in order to gain additional information
@@ -534,12 +554,13 @@ export class CoreCrypto {
         conversationId: ConversationId,
         configuration: ConversationConfiguration = {}
     ) {
-        const {admins, ciphersuite, keyRotationSpan, externalSenders} = configuration || {};
+        const { admins, ciphersuite, keyRotationSpan, externalSenders } =
+            configuration || {};
         const config = new CoreCrypto.#module.ConversationConfiguration(
             admins,
             ciphersuite,
             keyRotationSpan,
-            externalSenders,
+            externalSenders
         );
         const ret = await this.#cc.create_conversation(conversationId, config);
         return ret;
@@ -553,15 +574,16 @@ export class CoreCrypto {
      *
      * @returns a {@link DecryptedMessage}. Note that {@link DecryptedMessage#message} is `undefined` when the encrypted payload contains a system message such a proposal or commit
      */
-    async decryptMessage(conversationId: ConversationId, payload: Uint8Array): Promise<DecryptedMessage> {
-        const ffiDecryptedMessage: CoreCryptoFfiTypes.DecryptedMessage = await this.#cc.decrypt_message(
-            conversationId,
-            payload
-        );
+    async decryptMessage(
+        conversationId: ConversationId,
+        payload: Uint8Array
+    ): Promise<DecryptedMessage> {
+        const ffiDecryptedMessage: CoreCryptoFfiTypes.DecryptedMessage =
+            await this.#cc.decrypt_message(conversationId, payload);
 
-        const commitDelay = ffiDecryptedMessage.commit_delay ?
-            ffiDecryptedMessage.commit_delay * 1000 :
-            undefined;
+        const commitDelay = ffiDecryptedMessage.commit_delay
+            ? ffiDecryptedMessage.commit_delay * 1000
+            : undefined;
 
         const ret: DecryptedMessage = {
             message: ffiDecryptedMessage.message,
@@ -582,11 +604,11 @@ export class CoreCrypto {
      *
      * @returns The encrypted payload for the given group. This needs to be fanned out to the other members of the group.
      */
-    async encryptMessage(conversationId: ConversationId, message: Uint8Array): Promise<Uint8Array> {
-        return await this.#cc.encrypt_message(
-            conversationId,
-            message
-        );
+    async encryptMessage(
+        conversationId: ConversationId,
+        message: Uint8Array
+    ): Promise<Uint8Array> {
+        return await this.#cc.encrypt_message(conversationId, message);
     }
 
     /**
@@ -595,7 +617,9 @@ export class CoreCrypto {
      * @param welcomeMessage - TLS-serialized MLS Welcome message
      * @returns The conversation ID of the newly joined group. You can use the same ID to decrypt/encrypt messages
      */
-    async processWelcomeMessage(welcomeMessage: Uint8Array): Promise<ConversationId> {
+    async processWelcomeMessage(
+        welcomeMessage: Uint8Array
+    ): Promise<ConversationId> {
         return await this.#cc.process_welcome_message(welcomeMessage);
     }
 
@@ -619,7 +643,9 @@ export class CoreCrypto {
      * @param amountRequested - The amount of keypackages requested
      * @returns An array of length `amountRequested` containing TLS-serialized KeyPackages
      */
-    async clientKeypackages(amountRequested: number): Promise<Array<Uint8Array>> {
+    async clientKeypackages(
+        amountRequested: number
+    ): Promise<Array<Uint8Array>> {
         return await this.#cc.client_keypackages(amountRequested);
     }
 
@@ -643,12 +669,13 @@ export class CoreCrypto {
             (invitee) => new CoreCrypto.#module.Invitee(invitee.id, invitee.kp)
         );
 
-        const ffiRet: CoreCryptoFfiTypes.MemberAddedMessages = await this.#cc.add_clients_to_conversation(
-            conversationId,
-            ffiClients
-        );
+        const ffiRet: CoreCryptoFfiTypes.MemberAddedMessages =
+            await this.#cc.add_clients_to_conversation(
+                conversationId,
+                ffiClients
+            );
 
-        ffiClients.forEach(c => c.free());
+        ffiClients.forEach((c) => c.free());
 
         const ret: MemberAddedMessages = {
             welcome: ffiRet.welcome,
@@ -676,10 +703,11 @@ export class CoreCrypto {
         conversationId: ConversationId,
         clientIds: ClientId[]
     ): Promise<CommitBundle> {
-        const ffiRet: CoreCryptoFfiTypes.CommitBundle = await this.#cc.remove_clients_from_conversation(
-            conversationId,
-            clientIds
-        );
+        const ffiRet: CoreCryptoFfiTypes.CommitBundle =
+            await this.#cc.remove_clients_from_conversation(
+                conversationId,
+                clientIds
+            );
 
         const ret: CommitBundle = {
             welcome: ffiRet.welcome,
@@ -701,10 +729,11 @@ export class CoreCrypto {
      *
      * @returns A {@link CommitBundle}
      */
-    async updateKeyingMaterial(conversationId: ConversationId): Promise<CommitBundle> {
-        const ffiRet: CoreCryptoFfiTypes.CommitBundle = await this.#cc.update_keying_material(
-            conversationId
-        );
+    async updateKeyingMaterial(
+        conversationId: ConversationId
+    ): Promise<CommitBundle> {
+        const ffiRet: CoreCryptoFfiTypes.CommitBundle =
+            await this.#cc.update_keying_material(conversationId);
 
         const ret: CommitBundle = {
             welcome: ffiRet.welcome,
@@ -726,16 +755,19 @@ export class CoreCrypto {
      *
      * @returns A {@link CommitBundle} or `undefined` when there was no pending proposal to commit
      */
-    async commitPendingProposals(conversationId: ConversationId): Promise<CommitBundle | undefined> {
-        const ffiCommitBundle: CoreCryptoFfiTypes.CommitBundle | undefined = await this.#cc.commit_pending_proposals(
-            conversationId
-        );
+    async commitPendingProposals(
+        conversationId: ConversationId
+    ): Promise<CommitBundle | undefined> {
+        const ffiCommitBundle: CoreCryptoFfiTypes.CommitBundle | undefined =
+            await this.#cc.commit_pending_proposals(conversationId);
 
-            return ffiCommitBundle ? {
-                welcome: ffiCommitBundle.welcome,
-                commit: ffiCommitBundle.commit,
-                publicGroupState: ffiCommitBundle.public_group_state,
-            } : undefined;
+        return ffiCommitBundle
+            ? {
+                  welcome: ffiCommitBundle.welcome,
+                  commit: ffiCommitBundle.commit,
+                  publicGroupState: ffiCommitBundle.public_group_state,
+              }
+            : undefined;
     }
 
     /**
@@ -761,9 +793,12 @@ export class CoreCrypto {
             (invitee) => new CoreCrypto.#module.Invitee(invitee.id, invitee.kp)
         );
 
-        const ret: TlsCommitBundle = await this.#cc.add_clients_to_conversation(conversationId, ffiClients);
+        const ret: TlsCommitBundle = await this.#cc.add_clients_to_conversation(
+            conversationId,
+            ffiClients
+        );
 
-        ffiClients.forEach(c => c.free());
+        ffiClients.forEach((c) => c.free());
 
         return ret;
     }
@@ -789,7 +824,10 @@ export class CoreCrypto {
         conversationId: ConversationId,
         clientIds: ClientId[]
     ): Promise<TlsCommitBundle> {
-        return await this.#cc.remove_clients_from_conversation(conversationId, clientIds);
+        return await this.#cc.remove_clients_from_conversation(
+            conversationId,
+            clientIds
+        );
     }
 
     /**
@@ -807,7 +845,9 @@ export class CoreCrypto {
      *
      * @returns A {@link CommitBundle} byte array to fan out to the Delivery Service
      */
-    async finalUpdateKeyingMaterial(conversationId: ConversationId): Promise<TlsCommitBundle> {
+    async finalUpdateKeyingMaterial(
+        conversationId: ConversationId
+    ): Promise<TlsCommitBundle> {
         return await this.#cc.update_keying_material(conversationId);
     }
 
@@ -826,7 +866,9 @@ export class CoreCrypto {
      *
      * @returns A {@link CommitBundle} byte array to fan out to the Delivery Service or `undefined` when there was no pending proposal to commit
      */
-    async finalCommitPendingProposals(conversationId: ConversationId): Promise<TlsCommitBundle | undefined> {
+    async finalCommitPendingProposals(
+        conversationId: ConversationId
+    ): Promise<TlsCommitBundle | undefined> {
         return await this.#cc.commit_pending_proposals(conversationId);
     }
 
@@ -845,7 +887,9 @@ export class CoreCrypto {
         switch (proposalType) {
             case ProposalType.Add: {
                 if (!(args as AddProposalArgs).kp) {
-                    throw new Error("kp is not contained in the proposal arguments");
+                    throw new Error(
+                        "kp is not contained in the proposal arguments"
+                    );
                 }
                 return await this.#cc.new_add_proposal(
                     args.conversationId,
@@ -864,9 +908,7 @@ export class CoreCrypto {
                 );
             }
             case ProposalType.Update: {
-                return await this.#cc.new_update_proposal(
-                    args.conversationId
-                );
+                return await this.#cc.new_update_proposal(args.conversationId);
             }
             default:
                 throw new Error("Invalid proposal type!");
@@ -879,11 +921,16 @@ export class CoreCrypto {
     ): Promise<Uint8Array> {
         switch (externalProposalType) {
             case ExternalProposalType.Add: {
-                return await this.#cc.new_external_add_proposal(args.conversationId, args.epoch);
+                return await this.#cc.new_external_add_proposal(
+                    args.conversationId,
+                    args.epoch
+                );
             }
             case ExternalProposalType.Remove: {
                 if (!(args as ExternalRemoveProposalArgs).keyPackageRef) {
-                    throw new Error("keyPackageRef is not contained in the external proposal arguments");
+                    throw new Error(
+                        "keyPackageRef is not contained in the external proposal arguments"
+                    );
                 }
 
                 return await this.#cc.new_external_remove_proposal(
@@ -903,7 +950,9 @@ export class CoreCrypto {
      * @param conversationId - MLS Conversation ID
      * @returns TLS-serialized MLS public group state
      */
-    async exportGroupState(conversationId: ConversationId): Promise<Uint8Array> {
+    async exportGroupState(
+        conversationId: ConversationId
+    ): Promise<Uint8Array> {
         return await this.#cc.export_group_state(conversationId);
     }
 
@@ -920,8 +969,11 @@ export class CoreCrypto {
      * @param publicGroupState - The public group state that can be fetched from the backend for a given conversation
      * @returns see {@link ConversationInitBundle}
      */
-    async joinByExternalCommit(publicGroupState: Uint8Array): Promise<ConversationInitBundle> {
-        const ffiInitMessage: CoreCryptoFfiTypes.ConversationInitBundle = await this.#cc.join_by_external_commit(publicGroupState);
+    async joinByExternalCommit(
+        publicGroupState: Uint8Array
+    ): Promise<ConversationInitBundle> {
+        const ffiInitMessage: CoreCryptoFfiTypes.ConversationInitBundle =
+            await this.#cc.join_by_external_commit(publicGroupState);
 
         const ret: ConversationInitBundle = {
             conversationId: ffiInitMessage.conversation_id,
@@ -939,15 +991,22 @@ export class CoreCrypto {
      * @param conversationId - The ID of the conversation
      * @param configuration - Configuration of the group, see {@link ConversationConfiguration}
      */
-    async mergePendingGroupFromExternalCommit(conversationId: ConversationId, configuration: ConversationConfiguration): Promise<void> {
-        const {admins, ciphersuite, keyRotationSpan, externalSenders} = configuration || {};
+    async mergePendingGroupFromExternalCommit(
+        conversationId: ConversationId,
+        configuration: ConversationConfiguration
+    ): Promise<void> {
+        const { admins, ciphersuite, keyRotationSpan, externalSenders } =
+            configuration || {};
         const config = new CoreCrypto.#module.ConversationConfiguration(
             admins,
             ciphersuite,
             keyRotationSpan,
-            externalSenders,
+            externalSenders
         );
-        return await this.#cc.merge_pending_group_from_external_commit(conversationId, config);
+        return await this.#cc.merge_pending_group_from_external_commit(
+            conversationId,
+            config
+        );
     }
 
     /**
@@ -957,8 +1016,12 @@ export class CoreCrypto {
      *
      * @param conversationId - The ID of the conversation
      */
-    async clearPendingGroupFromExternalCommit(conversationId: ConversationId): Promise<void> {
-        return await this.#cc.clear_pending_group_from_external_commit(conversationId);
+    async clearPendingGroupFromExternalCommit(
+        conversationId: ConversationId
+    ): Promise<void> {
+        return await this.#cc.clear_pending_group_from_external_commit(
+            conversationId
+        );
     }
 
     /**
@@ -981,8 +1044,14 @@ export class CoreCrypto {
      * @param conversationId - The group's ID
      * @param proposalRef - A reference to the proposal to delete. You get one when using {@link CoreCrypto.newProposal}
      */
-    async clearPendingProposal(conversationId: ConversationId, proposalRef: ProposalRef): Promise<void> {
-        return await this.#cc.clear_pending_proposal(conversationId, proposalRef);
+    async clearPendingProposal(
+        conversationId: ConversationId,
+        proposalRef: ProposalRef
+    ): Promise<void> {
+        return await this.#cc.clear_pending_proposal(
+            conversationId,
+            proposalRef
+        );
     }
 
     /**
@@ -1004,23 +1073,27 @@ export class CoreCrypto {
      * Derives a new key from the group
      *
      * @param conversationId - The group's ID
-     * @param keyLength - the length of the key to be derived
+     * @param keyLength - the length of the key to be derived. If the value is higher than the
+     * bounds of `u16` or the context hash * 255, an error will be returned
      *
      * @returns A `Uint8Array` representing the derived key
      */
-    async exportSecretKey(conversationId: ConversationId, keyLength: number): Promise<Uint8Array> {
+    async exportSecretKey(
+        conversationId: ConversationId,
+        keyLength: number
+    ): Promise<Uint8Array> {
         return await this.#cc.export_secret_key(conversationId, keyLength);
     }
 
     /**
-     * Exports all clients from group's members
+     * Returns all clients from group's members
      *
      * @param conversationId - The group's ID
      *
      * @returns A list of clients from the members of the group
      */
-    async exportClients(conversationId: ConversationId): Promise<ClientId[]> {
-        return await this.#cc.export_clients(conversationId);
+    async getClientIds(conversationId: ConversationId): Promise<ClientId[]> {
+        return await this.#cc.get_client_ids(conversationId);
     }
 
     /**
@@ -1042,7 +1115,9 @@ export class CoreCrypto {
      */
     async reseedRng(seed: Uint8Array): Promise<void> {
         if (seed.length !== 32) {
-            throw new Error(`The seed length needs to be exactly 32 bytes. ${seed.length} bytes provided.`);
+            throw new Error(
+                `The seed length needs to be exactly 32 bytes. ${seed.length} bytes provided.`
+            );
         }
 
         return await this.#cc.reseed_rng(seed);
@@ -1061,7 +1136,10 @@ export class CoreCrypto {
      * @param sessionId - ID of the Proteus session
      * @param prekey - CBOR-encoded Proteus prekey of the other client
      */
-    async proteusSessionFromPrekey(sessionId: string, prekey: Uint8Array): Promise<void> {
+    async proteusSessionFromPrekey(
+        sessionId: string,
+        prekey: Uint8Array
+    ): Promise<void> {
         return await this.#cc.proteus_session_from_prekey(sessionId, prekey);
     }
 
@@ -1071,7 +1149,10 @@ export class CoreCrypto {
      * @param sessionId - ID of the Proteus session
      * @param envelope - CBOR-encoded Proteus message
      */
-    async proteusSessionFromMessage(sessionId: string, envelope: Uint8Array): Promise<void> {
+    async proteusSessionFromMessage(
+        sessionId: string,
+        envelope: Uint8Array
+    ): Promise<void> {
         return await this.#cc.proteus_session_from_message(sessionId, envelope);
     }
 
@@ -1101,7 +1182,10 @@ export class CoreCrypto {
      * @param ciphertext - CBOR encoded, encrypted proteus message
      * @returns The decrypted payload contained within the message
      */
-    async proteusDecrypt(sessionId: string, ciphertext: Uint8Array): Promise<Uint8Array> {
+    async proteusDecrypt(
+        sessionId: string,
+        ciphertext: Uint8Array
+    ): Promise<Uint8Array> {
         return await this.#cc.proteus_decrypt(sessionId, ciphertext);
     }
 
@@ -1112,7 +1196,10 @@ export class CoreCrypto {
      * @param plaintext - payload to encrypt
      * @returns The CBOR-serialized encrypted message
      */
-    async proteusEncrypt(sessionId: string, plaintext: Uint8Array): Promise<Uint8Array> {
+    async proteusEncrypt(
+        sessionId: string,
+        plaintext: Uint8Array
+    ): Promise<Uint8Array> {
         return await this.#cc.proteus_encrypt(sessionId, plaintext);
     }
 
@@ -1124,7 +1211,10 @@ export class CoreCrypto {
      * @param plaintext - payload to encrypt
      * @returns A map indexed by each session ID and the corresponding CBOR-serialized encrypted message for this session
      */
-    async proteusEncryptBatched(sessions: string[], plaintext: Uint8Array): Promise<Map<string, Uint8Array>> {
+    async proteusEncryptBatched(
+        sessions: string[],
+        plaintext: Uint8Array
+    ): Promise<Map<string, Uint8Array>> {
         return await this.#cc.proteus_encrypt_batched(sessions, plaintext);
     }
 

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1004,7 +1004,6 @@ export class CoreCrypto {
      * Derives a new key from the group
      *
      * @param conversationId - The group's ID
-     * @param label - the label to be used. Intended to describe the purpose for the key
      * @param keyLength - the length of the key to be derived
      *
      * @returns A `Uint8Array` representing the derived key

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,19 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_24ee_rustbuffer_alloc(size, status).also {
-||||||| parent of ac2d23e (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
-=======
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -64,19 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_24ee_rustbuffer_free(buf, status)
-||||||| parent of ac2d23e (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
-=======
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_free(buf, status)
         }
     }
 
@@ -288,727 +264,223 @@ internal interface _UniFFILib : Library {
         }
     }
 
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_24ee_CoreCrypto_object_free(`ptr`: Pointer,
-||||||| parent of ac2d23e (Adding bindings)
-    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ec77_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_client_public_key(`ptr`: Pointer,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_e3ae_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_ec77_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_proteus_init(`ptr`: Pointer,
-||||||| parent of ac2d23e (Adding bindings)
-    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_24ee_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_24ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-<<<<<<< HEAD
-    fun CoreCrypto_24ee_version(
-||||||| parent of ac2d23e (Adding bindings)
-    fun CoreCrypto_ff56_version(
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_version(
-=======
-    fun CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun CoreCrypto_ec77_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_24ee_rustbuffer_alloc(`size`: Int,
-||||||| parent of ac2d23e (Adding bindings)
-    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
-=======
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ec77_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_24ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ec77_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_24ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
-||||||| parent of ac2d23e (Adding bindings)
-    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ec77_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_24ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-||||||| parent of ac2d23e (Adding bindings)
-    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ec77_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -1512,19 +984,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1537,19 +997,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_24ee_CoreCrypto_object_free(this.pointer, status)
-||||||| parent of ac2d23e (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
-=======
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1557,19 +1005,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1577,19 +1013,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_client_public_key(it,  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1598,19 +1022,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1619,19 +1031,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1640,19 +1040,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1660,19 +1048,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1680,19 +1056,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1701,19 +1065,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1722,19 +1074,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1743,19 +1083,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1764,19 +1092,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1785,19 +1101,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1806,19 +1110,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalAddClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1827,19 +1119,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalRemoveClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1848,19 +1128,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalUpdateKeyingMaterial`(`conversationId`: ConversationId): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1869,19 +1137,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalCommitPendingProposals`(`conversationId`: ConversationId): TlsCommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeTlsCommitBundle.lift(it)
@@ -1890,19 +1146,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1910,19 +1154,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1931,19 +1163,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1952,19 +1172,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1973,19 +1181,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1994,19 +1190,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -2015,19 +1199,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2036,19 +1208,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2057,19 +1217,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -2078,19 +1226,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2099,19 +1235,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -2119,19 +1243,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -2139,7 +1251,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `label`: String, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2148,7 +1260,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportClients`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -2157,19 +1269,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2178,19 +1278,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -2198,19 +1286,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -2218,19 +1294,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -2238,8 +1302,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -2247,7 +1310,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -2255,7 +1318,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -2263,7 +1326,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2272,7 +1335,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -2280,7 +1343,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -2288,7 +1351,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2297,7 +1360,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2306,7 +1369,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -2315,7 +1378,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2324,7 +1387,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -2333,18 +1396,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
@@ -2809,17 +1861,9 @@ public abstract class FfiConverterCallbackInterface<CallbackInterface>(
 // Declaration and FfiConverters for CoreCryptoCallbacks Callback Interface
 
 public interface CoreCryptoCallbacks {
-<<<<<<< HEAD
     fun `authorize`(`conversationId`: ConversationId, `clientId`: ClientId): Boolean
     fun `userAuthorize`(`conversationId`: ConversationId, `externalClientId`: ClientId, `existingClients`: List<ClientId>): Boolean
     fun `clientIsExistingGroupUser`(`clientId`: ClientId, `existingClients`: List<ClientId>): Boolean
-||||||| parent of e5e4538 (Adding bindings)
-    fun `authorize`(`conversationId`: List<UByte>, `clientId`: List<UByte>): Boolean
-    fun `clientIdBelongsToOneOf`(`clientId`: List<UByte>, `otherClients`: List<List<UByte>>): Boolean
-=======
-    fun `authorize`(`conversationId`: List<UByte>, `clientId`: List<UByte>): Boolean
-    fun `clientIsExistingGroupUser`(`clientId`: List<UByte>, `existingClients`: List<List<UByte>>): Boolean
->>>>>>> e5e4538 (Adding bindings)
     
 }
 
@@ -2843,7 +1887,6 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
                 1
             }
             2 -> {
-<<<<<<< HEAD
                 val buffer = this.`invokeUserAuthorize`(cb, args)
                 outBuf.setValue(buffer)
                 // Value written to out buffer.
@@ -2852,11 +1895,6 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
             }
             3 -> {
                 val buffer = this.`invokeClientIsExistingGroupUser`(cb, args)
-||||||| parent of e5e4538 (Adding bindings)
-                val buffer = this.`invokeClientIdBelongsToOneOf`(cb, args)
-=======
-                val buffer = this.`invokeClientIsExistingGroupUser`(cb, args)
->>>>>>> e5e4538 (Adding bindings)
                 outBuf.setValue(buffer)
                 // Value written to out buffer.
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
@@ -2891,16 +1929,9 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
         }
 
     
-<<<<<<< HEAD
     private fun `invokeUserAuthorize`(kotlinCallbackInterface: CoreCryptoCallbacks, args: RustBuffer.ByValue): RustBuffer.ByValue =
-||||||| parent of e5e4538 (Adding bindings)
-    private fun `invokeClientIdBelongsToOneOf`(kotlinCallbackInterface: CoreCryptoCallbacks, args: RustBuffer.ByValue): RustBuffer.ByValue =
-=======
-    private fun `invokeClientIsExistingGroupUser`(kotlinCallbackInterface: CoreCryptoCallbacks, args: RustBuffer.ByValue): RustBuffer.ByValue =
->>>>>>> e5e4538 (Adding bindings)
         try {
             val buf = args.asByteBuffer() ?: throw InternalException("No ByteBuffer in RustBuffer; this is a Uniffi bug")
-<<<<<<< HEAD
             kotlinCallbackInterface.`userAuthorize`(
                     FfiConverterTypeConversationId.read(buf), 
                     FfiConverterTypeClientId.read(buf), 
@@ -2921,15 +1952,6 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
             kotlinCallbackInterface.`clientIsExistingGroupUser`(
                     FfiConverterTypeClientId.read(buf), 
                     FfiConverterSequenceTypeClientId.read(buf)
-||||||| parent of e5e4538 (Adding bindings)
-            kotlinCallbackInterface.`clientIdBelongsToOneOf`(
-                    FfiConverterSequenceUByte.read(buf), 
-                    FfiConverterSequenceSequenceUByte.read(buf)
-=======
-            kotlinCallbackInterface.`clientIsExistingGroupUser`(
-                    FfiConverterSequenceUByte.read(buf), 
-                    FfiConverterSequenceSequenceUByte.read(buf)
->>>>>>> e5e4538 (Adding bindings)
                     )
             .let {
                     FfiConverterBoolean.lowerIntoRustBuffer(it)
@@ -2948,19 +1970,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-<<<<<<< HEAD
-            lib.ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-||||||| parent of ac2d23e (Adding bindings)
-            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-<<<<<<< HEAD
-            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-||||||| parent of e5e4538 (Adding bindings)
-            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+            lib.ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -3423,19 +2433,7 @@ public typealias FfiConverterTypeTlsCommitBundle = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -3444,19 +2442,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_24ee_version( _status)
-||||||| parent of ac2d23e (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
-=======
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ec77_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -45,6 +45,7 @@ open class RustBuffer : Structure() {
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
 <<<<<<< HEAD
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_alloc(size, status).also {
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -69,6 +70,23 @@ open class RustBuffer : Structure() {
             _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_alloc(size, status).also {
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_alloc(size, status).also {
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_2704_rustbuffer_alloc(size, status).also {
+>>>>>>> 6f20d8e (Fix conflicts)
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -76,6 +94,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_free(buf, status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -101,6 +120,23 @@ open class RustBuffer : Structure() {
             _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_free(buf, status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_free(buf, status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_2704_rustbuffer_free(buf, status)
+>>>>>>> 6f20d8e (Fix conflicts)
         }
     }
 
@@ -313,6 +349,7 @@ internal interface _UniFFILib : Library {
     }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_CoreCrypto_object_free(`ptr`: Pointer,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -337,9 +374,27 @@ internal interface _UniFFILib : Library {
     fun ffi_CoreCrypto_7cc0_CoreCrypto_object_free(`ptr`: Pointer,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+    fun ffi_CoreCrypto_7cc0_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun ffi_CoreCrypto_2704_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -365,9 +420,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -393,9 +466,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_client_public_key(`ptr`: Pointer,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -421,9 +512,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_client_public_key(`ptr`: Pointer,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -449,9 +558,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -477,9 +604,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Long
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -505,9 +650,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -533,9 +696,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Long
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -561,9 +742,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Byte
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -589,9 +788,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -617,9 +834,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -645,9 +880,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -673,9 +926,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -701,9 +972,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -729,9 +1018,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -757,9 +1064,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -785,9 +1110,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -813,9 +1156,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -841,9 +1202,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -869,9 +1248,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -897,9 +1294,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -925,9 +1340,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -953,9 +1386,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -981,9 +1432,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1009,9 +1478,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1037,9 +1524,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1065,9 +1570,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1093,9 +1616,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1121,9 +1662,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1149,9 +1708,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1177,9 +1754,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1203,9 +1798,26 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1213,9 +1825,15 @@ internal interface _UniFFILib : Library {
 =======
     fun CoreCrypto_7cc0_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+    fun CoreCrypto_7cc0_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+    fun CoreCrypto_2704_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1231,9 +1849,22 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1259,9 +1890,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1287,9 +1936,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1315,9 +1982,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_proteus_init(`ptr`: Pointer,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1343,9 +2028,27 @@ internal interface _UniFFILib : Library {
     fun ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+    fun ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
@@ -1415,9 +2118,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun CoreCrypto_ec77_version(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1443,9 +2164,27 @@ internal interface _UniFFILib : Library {
     fun CoreCrypto_7cc0_version(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_version(
+=======
+    fun CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_version(
+=======
+    fun CoreCrypto_7cc0_version(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun CoreCrypto_2704_version(
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_alloc(`size`: Int,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1471,9 +2210,27 @@ internal interface _UniFFILib : Library {
     fun ffi_CoreCrypto_7cc0_rustbuffer_alloc(`size`: Int,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_alloc(`size`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun ffi_CoreCrypto_2704_rustbuffer_alloc(`size`: Int,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1499,9 +2256,27 @@ internal interface _UniFFILib : Library {
     fun ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun ffi_CoreCrypto_2704_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_free(`buf`: RustBuffer.ByValue,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1527,9 +2302,27 @@ internal interface _UniFFILib : Library {
     fun ffi_CoreCrypto_7cc0_rustbuffer_free(`buf`: RustBuffer.ByValue,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun ffi_CoreCrypto_2704_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1555,6 +2348,23 @@ internal interface _UniFFILib : Library {
     fun ffi_CoreCrypto_7cc0_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    fun ffi_CoreCrypto_2704_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> 6f20d8e (Fix conflicts)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -2059,6 +2869,7 @@ class CoreCrypto(
         this(
     rustCallWithError(CryptoException) { _status ->
 <<<<<<< HEAD
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -2083,6 +2894,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 })
 
     /**
@@ -2095,6 +2923,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_CoreCrypto_object_free(this.pointer, status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2120,6 +2949,23 @@ class CoreCrypto(
             _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_CoreCrypto_object_free(this.pointer, status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_2704_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> 6f20d8e (Fix conflicts)
         }
     }
 
@@ -2127,6 +2973,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2152,6 +2999,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -2159,6 +3023,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_public_key(it,  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2184,6 +3049,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_public_key(it,  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2192,6 +3074,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2217,6 +3100,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -2225,6 +3125,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(it,  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2250,6 +3151,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(it,  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -2258,6 +3176,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2283,6 +3202,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -2290,6 +3226,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2315,6 +3252,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -2322,6 +3276,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2347,6 +3302,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -2355,6 +3327,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2380,6 +3353,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -2388,6 +3378,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2413,6 +3404,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -2421,6 +3429,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2446,6 +3455,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -2454,6 +3480,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2479,6 +3506,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -2487,6 +3531,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2512,6 +3557,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -2520,6 +3582,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalAddClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2545,6 +3608,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -2553,6 +3633,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalRemoveClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2578,6 +3659,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -2586,6 +3684,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalUpdateKeyingMaterial`(`conversationId`: ConversationId): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2611,6 +3710,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -2619,6 +3735,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalCommitPendingProposals`(`conversationId`: ConversationId): TlsCommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2644,6 +3761,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterOptionalTypeTlsCommitBundle.lift(it)
@@ -2652,6 +3786,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2677,6 +3812,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -2684,6 +3836,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2709,6 +3862,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -2717,6 +3887,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2742,6 +3913,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2750,6 +3938,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2775,6 +3964,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -2783,6 +3989,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2808,6 +4015,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -2816,6 +4040,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2841,6 +4066,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -2849,6 +4091,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2874,6 +4117,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2882,6 +4142,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2907,6 +4168,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2915,6 +4193,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2940,6 +4219,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -2948,6 +4244,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -2973,6 +4270,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2981,6 +4295,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3006,6 +4321,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -3013,6 +4345,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3038,6 +4371,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -3046,12 +4396,18 @@ class CoreCrypto(
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
 <<<<<<< HEAD
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
     _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
 =======
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -3061,12 +4417,18 @@ class CoreCrypto(
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
 <<<<<<< HEAD
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
     _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 =======
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -3075,6 +4437,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3100,6 +4463,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -3108,6 +4488,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3133,6 +4514,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -3140,6 +4538,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3165,6 +4564,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -3172,6 +4588,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3197,6 +4614,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -3204,6 +4638,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
@@ -3323,6 +4758,23 @@ class CoreCrypto(
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
         }
     
@@ -3897,6 +5349,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
 <<<<<<< HEAD
+<<<<<<< HEAD
             lib.ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -3921,6 +5374,23 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
             lib.ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+||||||| parent of e5e4538 (Adding bindings)
+            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+            lib.ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+            lib.ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> 6f20d8e (Fix conflicts)
         }
     }
 }
@@ -4384,6 +5854,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
 <<<<<<< HEAD
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -4408,6 +5879,23 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 })
 }
 
@@ -4416,6 +5904,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
+<<<<<<< HEAD
 <<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_version( _status)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -4441,6 +5930,23 @@ fun `version`(): String {
     _UniFFILib.INSTANCE.CoreCrypto_7cc0_version( _status)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_version( _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_2704_version( _status)
+>>>>>>> 6f20d8e (Fix conflicts)
 })
 }
 

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,19 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_24ee_rustbuffer_alloc(size, status).also {
+||||||| parent of ac2d23e (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
+=======
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +64,19 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_24ee_rustbuffer_free(buf, status)
+||||||| parent of ac2d23e (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
+=======
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         }
     }
 
@@ -264,150 +288,591 @@ internal interface _UniFFILib : Library {
         }
     }
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_24ee_CoreCrypto_object_free(`ptr`: Pointer,
+||||||| parent of ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_client_public_key(`ptr`: Pointer,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Long
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Long
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Byte
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_e3ae_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_proteus_init(`ptr`: Pointer,
+||||||| parent of ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
@@ -453,26 +918,97 @@ internal interface _UniFFILib : Library {
     ): Unit
 
     fun CoreCrypto_24ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
+<<<<<<< HEAD
     fun CoreCrypto_24ee_version(
+||||||| parent of ac2d23e (Adding bindings)
+    fun CoreCrypto_ff56_version(
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_version(
+=======
+    fun CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_24ee_rustbuffer_alloc(`size`: Int,
+||||||| parent of ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
+=======
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_24ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_24ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
+||||||| parent of ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_24ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+||||||| parent of ac2d23e (Adding bindings)
+    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -915,6 +1451,12 @@ public interface CoreCryptoInterface {
     fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId)
     
     @Throws(CryptoException::class)
+    fun `exportSecretKey`(`conversationId`: ConversationId, `label`: String, `keyLength`: UInt): List<UByte>
+    
+    @Throws(CryptoException::class)
+    fun `exportClients`(`conversationId`: ConversationId): List<ClientId>
+    
+    @Throws(CryptoException::class)
     fun `randomBytes`(`length`: UInt): List<UByte>
     
     @Throws(CryptoException::class)
@@ -970,7 +1512,19 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 })
 
     /**
@@ -983,7 +1537,19 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_24ee_CoreCrypto_object_free(this.pointer, status)
+||||||| parent of ac2d23e (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
+=======
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         }
     }
 
@@ -991,7 +1557,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -999,7 +1577,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_client_public_key(it,  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1008,7 +1598,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1017,7 +1619,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1026,7 +1640,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1034,7 +1660,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1042,7 +1680,19 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1051,7 +1701,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1060,7 +1722,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1069,7 +1743,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1078,7 +1764,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1087,7 +1785,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1096,7 +1806,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalAddClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1105,7 +1827,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalRemoveClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1114,7 +1848,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalUpdateKeyingMaterial`(`conversationId`: ConversationId): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1123,7 +1869,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalCommitPendingProposals`(`conversationId`: ConversationId): TlsCommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterOptionalTypeTlsCommitBundle.lift(it)
@@ -1132,7 +1890,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1140,7 +1910,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1149,7 +1931,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1158,7 +1952,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1167,7 +1973,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1176,7 +1994,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1185,7 +2015,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1194,7 +2036,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1203,7 +2057,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1212,7 +2078,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1221,7 +2099,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1229,15 +2119,57 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
     
+    @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `label`: String, `keyLength`: UInt): List<UByte> =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
+}
+        }.let {
+            FfiConverterSequenceUByte.lift(it)
+        }
+    
+    @Throws(CryptoException::class)override fun `exportClients`(`conversationId`: ConversationId): List<ClientId> =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+}
+        }.let {
+            FfiConverterSequenceTypeClientId.lift(it)
+        }
+    
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1246,7 +2178,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1254,7 +2198,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1262,7 +2218,19 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1270,6 +2238,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
@@ -1365,6 +2334,17 @@ class CoreCrypto(
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
     _UniFFILib.INSTANCE.CoreCrypto_24ee_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
         }
     
@@ -1829,9 +2809,17 @@ public abstract class FfiConverterCallbackInterface<CallbackInterface>(
 // Declaration and FfiConverters for CoreCryptoCallbacks Callback Interface
 
 public interface CoreCryptoCallbacks {
+<<<<<<< HEAD
     fun `authorize`(`conversationId`: ConversationId, `clientId`: ClientId): Boolean
     fun `userAuthorize`(`conversationId`: ConversationId, `externalClientId`: ClientId, `existingClients`: List<ClientId>): Boolean
     fun `clientIsExistingGroupUser`(`clientId`: ClientId, `existingClients`: List<ClientId>): Boolean
+||||||| parent of e5e4538 (Adding bindings)
+    fun `authorize`(`conversationId`: List<UByte>, `clientId`: List<UByte>): Boolean
+    fun `clientIdBelongsToOneOf`(`clientId`: List<UByte>, `otherClients`: List<List<UByte>>): Boolean
+=======
+    fun `authorize`(`conversationId`: List<UByte>, `clientId`: List<UByte>): Boolean
+    fun `clientIsExistingGroupUser`(`clientId`: List<UByte>, `existingClients`: List<List<UByte>>): Boolean
+>>>>>>> e5e4538 (Adding bindings)
     
 }
 
@@ -1855,6 +2843,7 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
                 1
             }
             2 -> {
+<<<<<<< HEAD
                 val buffer = this.`invokeUserAuthorize`(cb, args)
                 outBuf.setValue(buffer)
                 // Value written to out buffer.
@@ -1863,6 +2852,11 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
             }
             3 -> {
                 val buffer = this.`invokeClientIsExistingGroupUser`(cb, args)
+||||||| parent of e5e4538 (Adding bindings)
+                val buffer = this.`invokeClientIdBelongsToOneOf`(cb, args)
+=======
+                val buffer = this.`invokeClientIsExistingGroupUser`(cb, args)
+>>>>>>> e5e4538 (Adding bindings)
                 outBuf.setValue(buffer)
                 // Value written to out buffer.
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
@@ -1897,9 +2891,16 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
         }
 
     
+<<<<<<< HEAD
     private fun `invokeUserAuthorize`(kotlinCallbackInterface: CoreCryptoCallbacks, args: RustBuffer.ByValue): RustBuffer.ByValue =
+||||||| parent of e5e4538 (Adding bindings)
+    private fun `invokeClientIdBelongsToOneOf`(kotlinCallbackInterface: CoreCryptoCallbacks, args: RustBuffer.ByValue): RustBuffer.ByValue =
+=======
+    private fun `invokeClientIsExistingGroupUser`(kotlinCallbackInterface: CoreCryptoCallbacks, args: RustBuffer.ByValue): RustBuffer.ByValue =
+>>>>>>> e5e4538 (Adding bindings)
         try {
             val buf = args.asByteBuffer() ?: throw InternalException("No ByteBuffer in RustBuffer; this is a Uniffi bug")
+<<<<<<< HEAD
             kotlinCallbackInterface.`userAuthorize`(
                     FfiConverterTypeConversationId.read(buf), 
                     FfiConverterTypeClientId.read(buf), 
@@ -1920,6 +2921,15 @@ internal class ForeignCallbackTypeCoreCryptoCallbacks : ForeignCallback {
             kotlinCallbackInterface.`clientIsExistingGroupUser`(
                     FfiConverterTypeClientId.read(buf), 
                     FfiConverterSequenceTypeClientId.read(buf)
+||||||| parent of e5e4538 (Adding bindings)
+            kotlinCallbackInterface.`clientIdBelongsToOneOf`(
+                    FfiConverterSequenceUByte.read(buf), 
+                    FfiConverterSequenceSequenceUByte.read(buf)
+=======
+            kotlinCallbackInterface.`clientIsExistingGroupUser`(
+                    FfiConverterSequenceUByte.read(buf), 
+                    FfiConverterSequenceSequenceUByte.read(buf)
+>>>>>>> e5e4538 (Adding bindings)
                     )
             .let {
                     FfiConverterBoolean.lowerIntoRustBuffer(it)
@@ -1938,7 +2948,19 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
+<<<<<<< HEAD
             lib.ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+||||||| parent of ac2d23e (Adding bindings)
+            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+<<<<<<< HEAD
+            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+||||||| parent of e5e4538 (Adding bindings)
+            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         }
     }
 }
@@ -2401,7 +3423,19 @@ public typealias FfiConverterTypeTlsCommitBundle = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 })
 }
 
@@ -2410,7 +3444,19 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_24ee_version( _status)
+||||||| parent of ac2d23e (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
+=======
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 })
 }
 

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_272d_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c1e3_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_272d_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c1e3_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,223 +264,223 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_272d_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_c1e3_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_272d_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_c1e3_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_c1e3_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_c1e3_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_c1e3_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_272d_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_272d_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_272d_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+    fun CoreCrypto_c1e3_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_c1e3_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_c1e3_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_c1e3_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_272d_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_c1e3_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_272d_version(
+    fun CoreCrypto_c1e3_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_272d_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_c1e3_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_272d_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_c1e3_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_272d_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_c1e3_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_272d_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_c1e3_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -926,7 +926,7 @@ public interface CoreCryptoInterface {
     fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte>
     
     @Throws(CryptoException::class)
-    fun `exportClients`(`conversationId`: ConversationId): List<ClientId>
+    fun `getClientIds`(`conversationId`: ConversationId): List<ClientId>
     
     @Throws(CryptoException::class)
     fun `randomBytes`(`length`: UInt): List<UByte>
@@ -984,7 +984,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -997,7 +997,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_272d_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c1e3_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1005,7 +1005,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1013,7 +1013,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1022,7 +1022,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1031,7 +1031,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1040,7 +1040,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1048,7 +1048,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1056,7 +1056,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1065,7 +1065,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1074,7 +1074,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1083,7 +1083,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1092,7 +1092,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1101,7 +1101,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1110,7 +1110,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalAddClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1119,7 +1119,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalRemoveClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1128,7 +1128,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalUpdateKeyingMaterial`(`conversationId`: ConversationId): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1137,7 +1137,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalCommitPendingProposals`(`conversationId`: ConversationId): TlsCommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeTlsCommitBundle.lift(it)
@@ -1146,7 +1146,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1154,7 +1154,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1163,7 +1163,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1172,7 +1172,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1181,7 +1181,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1190,7 +1190,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1199,7 +1199,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1208,7 +1208,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1217,7 +1217,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1226,7 +1226,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1235,7 +1235,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1243,7 +1243,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1251,16 +1251,16 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(CryptoException::class)override fun `exportClients`(`conversationId`: ConversationId): List<ClientId> =
+    @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1269,7 +1269,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1278,7 +1278,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1286,7 +1286,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1294,7 +1294,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1302,7 +1302,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1310,7 +1310,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1318,7 +1318,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1326,7 +1326,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1335,7 +1335,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1343,7 +1343,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1351,7 +1351,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1360,7 +1360,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1369,7 +1369,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1378,7 +1378,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1387,7 +1387,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1396,7 +1396,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
@@ -1970,7 +1970,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_c1e3_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -2433,7 +2433,7 @@ public typealias FfiConverterTypeTlsCommitBundle = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -2442,7 +2442,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_272d_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c1e3_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,31 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_alloc(size, status).also {
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_alloc(size, status).also {
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +76,31 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_free(buf, status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_free(buf, status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         }
     }
 
@@ -264,158 +312,1041 @@ internal interface _UniFFILib : Library {
         }
     }
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_CoreCrypto_object_free(`ptr`: Pointer,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
+=======
+    fun ffi_CoreCrypto_7cc0_CoreCrypto_object_free(`ptr`: Pointer,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_client_public_key(`ptr`: Pointer,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_client_public_key(`ptr`: Pointer,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Long
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Long
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Byte
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_proteus_init(`ptr`: Pointer,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+=======
+    fun ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
@@ -461,26 +1392,169 @@ internal interface _UniFFILib : Library {
     ): Unit
 
     fun CoreCrypto_ec77_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+=======
+    fun CoreCrypto_7cc0_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
+<<<<<<< HEAD
     fun CoreCrypto_ec77_version(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_version(
+=======
+    fun CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+    fun CoreCrypto_54ee_version(
+=======
+    fun CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun CoreCrypto_e3ae_version(
+=======
+    fun CoreCrypto_7cc0_version(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_alloc(`size`: Int,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_alloc(`size`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_free(`buf`: RustBuffer.ByValue,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_free(`buf`: RustBuffer.ByValue,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): Unit
 
+<<<<<<< HEAD
     fun ffi_CoreCrypto_ec77_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+||||||| parent of e5e4538 (Adding bindings)
+    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+=======
+    fun ffi_CoreCrypto_7cc0_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -923,7 +1997,7 @@ public interface CoreCryptoInterface {
     fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId)
     
     @Throws(CryptoException::class)
-    fun `exportSecretKey`(`conversationId`: ConversationId, `label`: String, `keyLength`: UInt): List<UByte>
+    fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte>
     
     @Throws(CryptoException::class)
     fun `exportClients`(`conversationId`: ConversationId): List<ClientId>
@@ -984,7 +2058,31 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 })
 
     /**
@@ -997,7 +2095,31 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
+<<<<<<< HEAD
             _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_CoreCrypto_object_free(this.pointer, status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
+||||||| parent of e5e4538 (Adding bindings)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
+=======
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_CoreCrypto_object_free(this.pointer, status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         }
     }
 
@@ -1005,7 +2127,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1013,7 +2159,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_public_key(it,  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_public_key(it,  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1022,7 +2192,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1031,7 +2225,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(it,  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(it,  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1040,7 +2258,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1048,7 +2290,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1056,7 +2322,31 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1065,7 +2355,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1074,7 +2388,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1083,7 +2421,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1092,7 +2454,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1101,7 +2487,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1110,7 +2520,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalAddClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1119,7 +2553,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalRemoveClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1128,7 +2586,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalUpdateKeyingMaterial`(`conversationId`: ConversationId): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -1137,7 +2619,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalCommitPendingProposals`(`conversationId`: ConversationId): TlsCommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterOptionalTypeTlsCommitBundle.lift(it)
@@ -1146,7 +2652,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1154,7 +2684,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1163,7 +2717,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1172,7 +2750,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1181,7 +2783,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1190,7 +2816,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1199,7 +2849,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1208,7 +2882,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1217,7 +2915,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1226,7 +2948,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1235,7 +2981,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1243,15 +3013,45 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
     
-    @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `label`: String, `keyLength`: UInt): List<UByte> =
+    @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1260,7 +3060,13 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportClients`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1269,7 +3075,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1278,7 +3108,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1286,7 +3140,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1294,7 +3172,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1302,6 +3204,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
@@ -1397,6 +3300,29 @@ class CoreCrypto(
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
     _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
         }
     
@@ -1970,7 +3896,31 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
+<<<<<<< HEAD
             lib.ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+||||||| parent of e5e4538 (Adding bindings)
+            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+||||||| parent of e5e4538 (Adding bindings)
+            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+=======
+            lib.ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         }
     }
 }
@@ -2433,7 +4383,31 @@ public typealias FfiConverterTypeTlsCommitBundle = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 })
 }
 
@@ -2442,7 +4416,31 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
+<<<<<<< HEAD
     _UniFFILib.INSTANCE.CoreCrypto_ec77_version( _status)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
+||||||| parent of e5e4538 (Adding bindings)
+    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
+=======
+    _UniFFILib.INSTANCE.CoreCrypto_7cc0_version( _status)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 })
 }
 

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,49 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_alloc(size, status).also {
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_alloc(size, status).also {
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_alloc(size, status).also {
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_alloc(size, status).also {
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_alloc(size, status).also {
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_alloc(size, status).also {
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2704_rustbuffer_alloc(size, status).also {
->>>>>>> 6f20d8e (Fix conflicts)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_272d_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -94,49 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_rustbuffer_free(buf, status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_free(buf, status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_rustbuffer_free(buf, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_rustbuffer_free(buf, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_rustbuffer_free(buf, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_rustbuffer_free(buf, status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2704_rustbuffer_free(buf, status)
->>>>>>> 6f20d8e (Fix conflicts)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_272d_rustbuffer_free(buf, status)
         }
     }
 
@@ -348,2023 +264,223 @@ internal interface _UniFFILib : Library {
         }
     }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ec77_CoreCrypto_object_free(`ptr`: Pointer,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-    fun ffi_CoreCrypto_7cc0_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCrypto_object_free(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_CoreCrypto_object_free(`ptr`: Pointer,
-=======
-    fun ffi_CoreCrypto_7cc0_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun ffi_CoreCrypto_2704_CoreCrypto_object_free(`ptr`: Pointer,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun ffi_CoreCrypto_272d_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_client_public_key(`ptr`: Pointer,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_public_key(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_client_public_key(`ptr`: Pointer,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_client_public_key(`ptr`: Pointer,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_final_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`label`: RustBuffer.ByValue,`keyLength`: Int,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_export_clients(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-    fun CoreCrypto_7cc0_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
-=======
-    fun CoreCrypto_2704_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_proteus_init(`ptr`: Pointer,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-    fun ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
-=======
-    fun ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_272d_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_272d_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_ec77_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
-=======
-    fun CoreCrypto_7cc0_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_init_with_path_and_key(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ec77_version(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_version(
-=======
-    fun CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_version(
-=======
-    fun CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_version(
-=======
-    fun CoreCrypto_7cc0_version(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-    fun CoreCrypto_54ee_version(
-=======
-    fun CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun CoreCrypto_e3ae_version(
-=======
-    fun CoreCrypto_7cc0_version(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun CoreCrypto_2704_version(
->>>>>>> 6f20d8e (Fix conflicts)
+    fun CoreCrypto_272d_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ec77_rustbuffer_alloc(`size`: Int,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_alloc(`size`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_alloc(`size`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_alloc(`size`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_alloc(`size`: Int,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_alloc(`size`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun ffi_CoreCrypto_2704_rustbuffer_alloc(`size`: Int,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun ffi_CoreCrypto_272d_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ec77_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun ffi_CoreCrypto_2704_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun ffi_CoreCrypto_272d_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ec77_rustbuffer_free(`buf`: RustBuffer.ByValue,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_free(`buf`: RustBuffer.ByValue,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_free(`buf`: RustBuffer.ByValue,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun ffi_CoreCrypto_2704_rustbuffer_free(`buf`: RustBuffer.ByValue,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun ffi_CoreCrypto_272d_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ec77_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    fun ffi_CoreCrypto_ff56_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-||||||| parent of e5e4538 (Adding bindings)
-    fun ffi_CoreCrypto_54ee_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    fun ffi_CoreCrypto_e3ae_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
-=======
-    fun ffi_CoreCrypto_7cc0_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    fun ffi_CoreCrypto_2704_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
->>>>>>> 6f20d8e (Fix conflicts)
+    fun ffi_CoreCrypto_272d_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -2868,49 +984,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -2923,49 +997,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ec77_CoreCrypto_object_free(this.pointer, status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_CoreCrypto_object_free(this.pointer, status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_ff56_CoreCrypto_object_free(this.pointer, status)
-||||||| parent of e5e4538 (Adding bindings)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_54ee_CoreCrypto_object_free(this.pointer, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_e3ae_CoreCrypto_object_free(this.pointer, status)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_7cc0_CoreCrypto_object_free(this.pointer, status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2704_CoreCrypto_object_free(this.pointer, status)
->>>>>>> 6f20d8e (Fix conflicts)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_272d_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -2973,49 +1005,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -3023,49 +1013,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_public_key(it,  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_public_key(it,  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_public_key(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_public_key(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_public_key(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_public_key(it,  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_client_public_key(it,  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -3074,49 +1022,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -3125,49 +1031,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(it,  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(it,  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(it,  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(it,  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -3176,49 +1040,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -3226,49 +1048,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -3276,49 +1056,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -3327,49 +1065,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -3378,49 +1074,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -3429,49 +1083,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -3480,49 +1092,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -3531,49 +1101,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -3582,49 +1110,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalAddClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -3633,49 +1119,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalRemoveClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -3684,49 +1128,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalUpdateKeyingMaterial`(`conversationId`: ConversationId): TlsCommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeTlsCommitBundle.lift(it)
@@ -3735,49 +1137,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `finalCommitPendingProposals`(`conversationId`: ConversationId): TlsCommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeTlsCommitBundle.lift(it)
@@ -3786,49 +1146,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -3836,49 +1154,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -3887,49 +1163,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -3938,49 +1172,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -3989,49 +1181,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -4040,49 +1190,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -4091,49 +1199,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4142,49 +1208,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4193,49 +1217,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -4244,49 +1226,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4295,49 +1235,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -4345,49 +1243,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -4395,19 +1251,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterString.lower(`label`), FfiConverterUInt.lower(`keyLength`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4416,19 +1260,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportClients`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_export_clients(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -4437,49 +1269,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4488,49 +1278,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -4538,49 +1286,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -4588,49 +1294,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -4638,9 +1302,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -4648,7 +1310,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -4656,7 +1318,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -4664,7 +1326,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4673,7 +1335,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -4681,7 +1343,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -4689,7 +1351,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4698,7 +1360,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4707,7 +1369,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -4716,7 +1378,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -4725,7 +1387,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -4734,47 +1396,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
@@ -5348,49 +1970,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-            lib.ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-||||||| parent of e5e4538 (Adding bindings)
-            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-||||||| parent of e5e4538 (Adding bindings)
-            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-            lib.ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-            lib.ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-||||||| parent of e5e4538 (Adding bindings)
-            lib.ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-            lib.ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
-=======
-            lib.ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-            lib.ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
->>>>>>> 6f20d8e (Fix conflicts)
+            lib.ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -5853,49 +2433,7 @@ public typealias FfiConverterTypeTlsCommitBundle = FfiConverterSequenceUByte
 fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `entropySeed`: List<UByte>?): CoreCrypto {
     return FfiConverterTypeCoreCrypto.lift(
     rustCallWithError(CryptoException) { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_init_with_path_and_key(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterString.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 }
 
@@ -5904,49 +2442,7 @@ fun `initWithPathAndKey`(`path`: String, `key`: String, `clientId`: String, `ent
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ec77_version( _status)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_version( _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    _UniFFILib.INSTANCE.CoreCrypto_ff56_version( _status)
-||||||| parent of e5e4538 (Adding bindings)
-    _UniFFILib.INSTANCE.CoreCrypto_54ee_version( _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    _UniFFILib.INSTANCE.CoreCrypto_e3ae_version( _status)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_7cc0_version( _status)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    _UniFFILib.INSTANCE.CoreCrypto_2704_version( _status)
->>>>>>> 6f20d8e (Fix conflicts)
+    _UniFFILib.INSTANCE.CoreCrypto_272d_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -596,7 +596,6 @@ public class CoreCryptoWrapper {
     /// Derives a new key from the group
     ///
     /// - parameter conversationId: conversation identifier
-    /// - parameter label: the label to be used. Intended to describe the purpose for the key
     /// - parameter keyLength: the length of the key to be derived
     /// - returns a byte array representing the derived key
     public func exportSecretKey(conversationId: ConversationId, keyLength: UInt32) throws -> [UInt8] {

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -596,18 +596,19 @@ public class CoreCryptoWrapper {
     /// Derives a new key from the group
     ///
     /// - parameter conversationId: conversation identifier
-    /// - parameter keyLength: the length of the key to be derived
+    /// - parameter keyLength: the length of the key to be derived. If the value is higher than the
+    /// bounds of `u16` or the context hash * 255, an error will be thrown
     /// - returns a byte array representing the derived key
     public func exportSecretKey(conversationId: ConversationId, keyLength: UInt32) throws -> [UInt8] {
         try self.coreCrypto.exportSecretKey(conversationId: conversationId, keyLength: keyLength)
     }
 
-    /// Exports all clients from group's members
+    /// Returns all clients from group's members
     ///
     /// - parameter conversationId: conversation identifier
     /// - returns a list of `ClientId` objects
-    public func exportClients(conversationId: ConversationId) throws -> [ClientId] {
-        try self.coreCrypto.exportClients(conversationId: conversationId)
+    public func getClientIds(conversationId: ConversationId) throws -> [ClientId] {
+        try self.coreCrypto.getClientIds(conversationId: conversationId)
     }
 
     /// Allows ``CoreCrypto`` to act as a CSPRNG provider

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -593,6 +593,24 @@ public class CoreCryptoWrapper {
         try self.coreCrypto.clearPendingGroupFromExternalCommit(conversationId: conversationId)
     }
 
+    /// Derives a new key from the group
+    ///
+    /// - parameter conversationId: conversation identifier
+    /// - parameter label: the label to be used. Intended to describe the purpose for the key
+    /// - parameter keyLength: the length of the key to be derived
+    /// - returns a byte array representing the derived key
+    public func exportSecretKey(conversationId: ConversationId, label: String, keyLength: UInt32) throws -> [UInt8] {
+        try self.coreCrypto.exportSecretKey(conversationId: conversationId, label: label, keyLength: keyLength)
+    }
+
+    /// Exports all clients from group's members
+    ///
+    /// - parameter conversationId: conversation identifier
+    /// - returns a list of `ClientId` objects
+    public func exportClients(conversationId: ConversationId) throws -> [ClientId] {
+        try self.coreCrypto.exportClients(conversationId: conversationId)
+    }
+
     /// Allows ``CoreCrypto`` to act as a CSPRNG provider
     /// - parameter length: The number of bytes to be returned in the `Uint8` array
     /// - returns: A ``Uint8`` array buffer that contains ``length`` cryptographically-secure random bytes

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -599,8 +599,8 @@ public class CoreCryptoWrapper {
     /// - parameter label: the label to be used. Intended to describe the purpose for the key
     /// - parameter keyLength: the length of the key to be derived
     /// - returns a byte array representing the derived key
-    public func exportSecretKey(conversationId: ConversationId, label: String, keyLength: UInt32) throws -> [UInt8] {
-        try self.coreCrypto.exportSecretKey(conversationId: conversationId, label: label, keyLength: keyLength)
+    public func exportSecretKey(conversationId: ConversationId, keyLength: UInt32) throws -> [UInt8] {
+        try self.coreCrypto.exportSecretKey(conversationId: conversationId, keyLength: keyLength)
     }
 
     /// Exports all clients from group's members

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_272d_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_c1e3_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_272d_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_c1e3_rustbuffer_free(self, $0) }
     }
 }
 
@@ -448,7 +448,7 @@ public protocol CoreCryptoProtocol {
     func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws
     func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws
     func exportSecretKey(conversationId: ConversationId, keyLength: UInt32) throws -> [UInt8]
-    func exportClients(conversationId: ConversationId) throws -> [ClientId]
+    func getClientIds(conversationId: ConversationId) throws -> [ClientId]
     func randomBytes(length: UInt32) throws -> [UInt8]
     func reseedRng(seed: [UInt8]) throws
     func commitAccepted(conversationId: ConversationId) throws
@@ -482,7 +482,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_272d_CoreCrypto_new(
+    CoreCrypto_c1e3_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -491,7 +491,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_272d_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_c1e3_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -500,7 +500,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -509,7 +509,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_c1e3_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -518,7 +518,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -528,7 +528,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_c1e3_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -536,7 +536,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -546,7 +546,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -557,7 +557,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_272d_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -567,7 +567,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -577,7 +577,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -588,7 +588,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -599,7 +599,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -609,7 +609,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -619,7 +619,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -630,7 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -641,7 +641,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_final_update_keying_material(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_final_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -651,7 +651,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_final_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -660,7 +660,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func wipeConversation(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -669,7 +669,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -680,7 +680,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -691,7 +691,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -702,7 +702,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -712,7 +712,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -723,7 +723,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), $0
     )
@@ -734,7 +734,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -746,7 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(publicGroupState), $0
     )
 }
@@ -756,7 +756,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -765,7 +765,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -774,7 +774,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -783,18 +783,18 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt32.lower(keyLength), $0
     )
 }
         )
     }
-    public func exportClients(conversationId: ConversationId) throws -> [ClientId] {
+    public func getClientIds(conversationId: ConversationId) throws -> [ClientId] {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_export_clients(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -804,7 +804,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -813,7 +813,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -821,7 +821,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func commitAccepted(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -829,7 +829,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(proposalRef), $0
     )
@@ -838,7 +838,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -846,14 +846,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusInit() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_c1e3_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func proteusSessionFromPrekey(sessionId: String, prekey: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(prekey), $0
     )
@@ -863,7 +863,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(envelope), $0
     )
@@ -873,7 +873,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusSessionSave(sessionId: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(sessionId), $0
     )
 }
@@ -881,7 +881,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusSessionDelete(sessionId: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(sessionId), $0
     )
 }
@@ -890,7 +890,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(ciphertext), $0
     )
@@ -901,7 +901,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(plaintext), $0
     )
@@ -912,7 +912,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(plaintext), $0
     )
@@ -923,7 +923,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(prekeyId), $0
     )
 }
@@ -933,7 +933,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_c1e3_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -941,7 +941,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusCryptoboxMigrate(path: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_c1e3_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(path), $0
     )
 }
@@ -1942,7 +1942,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_c1e3_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -2351,7 +2351,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_272d_init_with_path_and_key(
+    CoreCrypto_c1e3_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -2368,7 +2368,7 @@ public func version()  -> String {
     
     rustCall() {
     
-    CoreCrypto_272d_version($0)
+    CoreCrypto_c1e3_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,37 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_24ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-||||||| parent of ac2d23e (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_24ee_rustbuffer_free(self, $0) }
-||||||| parent of ac2d23e (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
-=======
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_free(self, $0) }
     }
 }
 
@@ -506,19 +482,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_new(
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_new(
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new(
-=======
-    CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -527,19 +491,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_24ee_CoreCrypto_object_free(pointer, $0) }
-||||||| parent of ac2d23e (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
-=======
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_ec77_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -548,19 +500,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_set_callbacks(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -569,19 +509,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_client_public_key(self.pointer, $0
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -590,19 +518,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_client_keypackages(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -612,19 +528,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -632,19 +536,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_create_conversation(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -654,19 +546,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_conversation_epoch(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -677,19 +557,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_conversation_exists(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -699,19 +567,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_process_welcome_message(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -721,19 +577,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -744,19 +588,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -767,19 +599,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_update_keying_material(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -789,19 +609,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -811,19 +619,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -834,19 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -857,19 +641,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_final_update_keying_material(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_final_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -879,19 +651,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -900,19 +660,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func wipeConversation(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_wipe_conversation(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -921,19 +669,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_decrypt_message(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -944,19 +680,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_encrypt_message(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -967,19 +691,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_new_add_proposal(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -990,19 +702,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_new_update_proposal(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1012,19 +712,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_new_remove_proposal(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -1035,19 +723,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), $0
     )
@@ -1058,19 +734,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -1082,19 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_join_by_external_commit(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(publicGroupState), $0
     )
 }
@@ -1104,19 +756,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_export_group_state(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1125,19 +765,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -1146,19 +774,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1167,7 +783,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_e3ae_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterString.lower(label), 
         FfiConverterUInt32.lower(keyLength), $0
@@ -1179,7 +795,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_e3ae_CoreCrypto_export_clients(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_export_clients(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1189,19 +805,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_random_bytes(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -1210,19 +814,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_reseed_rng(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -1230,19 +822,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func commitAccepted(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_commit_accepted(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1250,19 +830,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(proposalRef), $0
     )
@@ -1271,19 +839,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-    CoreCrypto_24ee_CoreCrypto_clear_pending_commit(self.pointer, 
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1291,14 +847,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusInit() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_ec77_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func proteusSessionFromPrekey(sessionId: String, prekey: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(prekey), $0
     )
@@ -1308,7 +864,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(envelope), $0
     )
@@ -1318,7 +874,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusSessionSave(sessionId: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(sessionId), $0
     )
 }
@@ -1326,7 +882,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusSessionDelete(sessionId: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(sessionId), $0
     )
 }
@@ -1335,7 +891,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(ciphertext), $0
     )
@@ -1346,7 +902,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(plaintext), $0
     )
@@ -1357,7 +913,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(plaintext), $0
     )
@@ -1368,7 +924,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(prekeyId), $0
     )
 }
@@ -1378,7 +934,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -1386,7 +942,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusCryptoboxMigrate(path: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_24ee_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(path), $0
     )
 }
@@ -2291,17 +1847,9 @@ private let IDX_CALLBACK_FREE: Int32 = 0
 // Declaration and FfiConverters for CoreCryptoCallbacks Callback Interface
 
 public protocol CoreCryptoCallbacks : AnyObject {
-<<<<<<< HEAD
     func authorize(conversationId: ConversationId, clientId: ClientId)  -> Bool
     func userAuthorize(conversationId: ConversationId, externalClientId: ClientId, existingClients: [ClientId])  -> Bool
     func clientIsExistingGroupUser(clientId: ClientId, existingClients: [ClientId])  -> Bool
-||||||| parent of e5e4538 (Adding bindings)
-    func authorize(conversationId: [UInt8], clientId: [UInt8])  -> Bool
-    func clientIdBelongsToOneOf(clientId: [UInt8], otherClients: [[UInt8]])  -> Bool
-=======
-    func authorize(conversationId: [UInt8], clientId: [UInt8])  -> Bool
-    func clientIsExistingGroupUser(clientId: [UInt8], existingClients: [[UInt8]])  -> Bool
->>>>>>> e5e4538 (Adding bindings)
     
 }
 
@@ -2322,17 +1870,10 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
                 // https://github.com/mozilla/uniffi-rs/issues/351
 
     }
-<<<<<<< HEAD
     func invokeUserAuthorize(_ swiftCallbackInterface: CoreCryptoCallbacks, _ args: RustBuffer) throws -> RustBuffer {
-||||||| parent of e5e4538 (Adding bindings)
-    func invokeClientIdBelongsToOneOf(_ swiftCallbackInterface: CoreCryptoCallbacks, _ args: RustBuffer) throws -> RustBuffer {
-=======
-    func invokeClientIsExistingGroupUser(_ swiftCallbackInterface: CoreCryptoCallbacks, _ args: RustBuffer) throws -> RustBuffer {
->>>>>>> e5e4538 (Adding bindings)
         defer { args.deallocate() }
 
             let reader = Reader(data: Data(rustBuffer: args))
-<<<<<<< HEAD
             let result = swiftCallbackInterface.userAuthorize(
                     conversationId:  try FfiConverterTypeConversationId.read(from: reader), 
                     externalClientId:  try FfiConverterTypeClientId.read(from: reader), 
@@ -2351,15 +1892,6 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
             let result = swiftCallbackInterface.clientIsExistingGroupUser(
                     clientId:  try FfiConverterTypeClientId.read(from: reader), 
                     existingClients:  try FfiConverterSequenceTypeClientId.read(from: reader)
-||||||| parent of e5e4538 (Adding bindings)
-            let result = swiftCallbackInterface.clientIdBelongsToOneOf(
-                    clientId:  try FfiConverterSequenceUInt8.read(from: reader), 
-                    otherClients:  try FfiConverterSequenceSequenceUInt8.read(from: reader)
-=======
-            let result = swiftCallbackInterface.clientIsExistingGroupUser(
-                    clientId:  try FfiConverterSequenceUInt8.read(from: reader), 
-                    existingClients:  try FfiConverterSequenceSequenceUInt8.read(from: reader)
->>>>>>> e5e4538 (Adding bindings)
                     )
             let writer = Writer()
                 FfiConverterBool.write(result, into: writer)
@@ -2383,7 +1915,6 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
                 return 1
             case 2:
-<<<<<<< HEAD
                 let buffer = try! invokeUserAuthorize(cb, args)
                 out_buf.pointee = buffer
                 // Value written to out buffer.
@@ -2391,11 +1922,6 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
                 return 1
             case 3:
                 let buffer = try! invokeClientIsExistingGroupUser(cb, args)
-||||||| parent of e5e4538 (Adding bindings)
-                let buffer = try! invokeClientIdBelongsToOneOf(cb, args)
-=======
-                let buffer = try! invokeClientIsExistingGroupUser(cb, args)
->>>>>>> e5e4538 (Adding bindings)
                 out_buf.pointee = buffer
                 // Value written to out buffer.
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
@@ -2417,19 +1943,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-<<<<<<< HEAD
-                ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-||||||| parent of ac2d23e (Adding bindings)
-                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-<<<<<<< HEAD
-                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-||||||| parent of e5e4538 (Adding bindings)
-                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+                ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -2838,19 +2352,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-<<<<<<< HEAD
-    CoreCrypto_24ee_init_with_path_and_key(
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_init_with_path_and_key(
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_init_with_path_and_key(
-=======
-    CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -2867,19 +2369,7 @@ public func version()  -> String {
     
     rustCall() {
     
-<<<<<<< HEAD
-    CoreCrypto_24ee_version($0)
-||||||| parent of ac2d23e (Adding bindings)
-    CoreCrypto_ff56_version($0)
-=======
-<<<<<<< HEAD
-    CoreCrypto_ff56_version($0)
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_version($0)
-=======
-    CoreCrypto_e3ae_version($0)
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+    CoreCrypto_ec77_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,97 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-        try! rustCall { ffi_CoreCrypto_2704_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
->>>>>>> 6f20d8e (Fix conflicts)
+        try! rustCall { ffi_CoreCrypto_272d_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_free(self, $0) }
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_free(self, $0) }
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_free(self, $0) }
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-        try! rustCall { ffi_CoreCrypto_2704_rustbuffer_free(self, $0) }
->>>>>>> 6f20d8e (Fix conflicts)
+        try! rustCall { ffi_CoreCrypto_272d_rustbuffer_free(self, $0) }
     }
 }
 
@@ -566,49 +482,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_new(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new(
-=======
-    CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new(
-=======
-    CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new(
-=======
-    CoreCrypto_7cc0_CoreCrypto_new(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new(
-=======
-    CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new(
-=======
-    CoreCrypto_7cc0_CoreCrypto_new(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_new(
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_new(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -617,49 +491,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ec77_CoreCrypto_object_free(pointer, $0) }
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_7cc0_CoreCrypto_object_free(pointer, $0) }
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
-||||||| parent of e5e4538 (Adding bindings)
-        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
-=======
-        try! rustCall { ffi_CoreCrypto_7cc0_CoreCrypto_object_free(pointer, $0) }
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-        try! rustCall { ffi_CoreCrypto_2704_CoreCrypto_object_free(pointer, $0) }
->>>>>>> 6f20d8e (Fix conflicts)
+        try! rustCall { ffi_CoreCrypto_272d_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -668,49 +500,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_set_callbacks(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_set_callbacks(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -719,49 +509,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_client_public_key(self.pointer, $0
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
-=======
-    CoreCrypto_7cc0_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
-=======
-    CoreCrypto_7cc0_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_client_public_key(self.pointer, $0
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -770,49 +518,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_client_keypackages(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_client_keypackages(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -822,49 +528,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-    CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
-=======
-    CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -872,49 +536,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_create_conversation(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_create_conversation(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -924,49 +546,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_conversation_epoch(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_conversation_epoch(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -977,49 +557,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_conversation_exists(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_conversation_exists(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1029,49 +567,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_process_welcome_message(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_process_welcome_message(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -1081,49 +577,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -1134,49 +588,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -1187,49 +599,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_update_keying_material(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_update_keying_material(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1239,49 +609,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_commit_pending_proposals(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1291,49 +619,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -1344,49 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -1397,49 +641,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_final_update_keying_material(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_final_update_keying_material(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_final_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1449,49 +651,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1500,49 +660,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func wipeConversation(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_wipe_conversation(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_wipe_conversation(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1551,49 +669,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_decrypt_message(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_decrypt_message(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -1604,49 +680,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_encrypt_message(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_encrypt_message(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -1657,49 +691,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_new_add_proposal(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_new_add_proposal(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -1710,49 +702,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_new_update_proposal(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_new_update_proposal(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1762,49 +712,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_new_remove_proposal(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_new_remove_proposal(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -1815,49 +723,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_new_external_add_proposal(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), $0
     )
@@ -1868,49 +734,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -1922,49 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_join_by_external_commit(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_join_by_external_commit(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(publicGroupState), $0
     )
 }
@@ -1974,49 +756,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_export_group_state(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_export_group_state(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -2025,49 +765,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -2076,49 +774,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -2127,19 +783,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_export_secret_key(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_export_secret_key(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_export_secret_key(self.pointer, 
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-    CoreCrypto_7cc0_CoreCrypto_export_secret_key(self.pointer, 
-=======
-    CoreCrypto_2704_CoreCrypto_export_secret_key(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt32.lower(keyLength), $0
     )
@@ -2150,19 +794,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_export_clients(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_export_clients(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_export_clients(self.pointer, 
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-    CoreCrypto_7cc0_CoreCrypto_export_clients(self.pointer, 
-=======
-    CoreCrypto_2704_CoreCrypto_export_clients(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_export_clients(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -2172,49 +804,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_random_bytes(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_random_bytes(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -2223,49 +813,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_reseed_rng(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_reseed_rng(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -2273,49 +821,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func commitAccepted(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_commit_accepted(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_commit_accepted(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -2323,49 +829,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_clear_pending_proposal(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(proposalRef), $0
     )
@@ -2374,49 +838,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_CoreCrypto_clear_pending_commit(self.pointer, 
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
-=======
-    CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_CoreCrypto_clear_pending_commit(self.pointer, 
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -2424,14 +846,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusInit() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_272d_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func proteusSessionFromPrekey(sessionId: String, prekey: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(prekey), $0
     )
@@ -2441,7 +863,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(envelope), $0
     )
@@ -2451,7 +873,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusSessionSave(sessionId: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(sessionId), $0
     )
 }
@@ -2459,7 +881,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusSessionDelete(sessionId: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(sessionId), $0
     )
 }
@@ -2468,7 +890,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(ciphertext), $0
     )
@@ -2479,7 +901,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(plaintext), $0
     )
@@ -2490,7 +912,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(sessionId), 
         FfiConverterSequenceUInt8.lower(plaintext), $0
     )
@@ -2501,7 +923,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(prekeyId), $0
     )
 }
@@ -2511,7 +933,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_272d_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -2519,7 +941,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func proteusCryptoboxMigrate(path: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(path), $0
     )
 }
@@ -3520,49 +1942,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-<<<<<<< HEAD
-<<<<<<< HEAD
-                ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-||||||| parent of e5e4538 (Adding bindings)
-                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-||||||| parent of e5e4538 (Adding bindings)
-                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-                ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-||||||| parent of e5e4538 (Adding bindings)
-                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
-=======
-                ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-                ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
->>>>>>> 6f20d8e (Fix conflicts)
+                ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3971,49 +2351,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_init_with_path_and_key(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_init_with_path_and_key(
-=======
-    CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_init_with_path_and_key(
-=======
-    CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_init_with_path_and_key(
-=======
-    CoreCrypto_7cc0_init_with_path_and_key(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_init_with_path_and_key(
-=======
-    CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_init_with_path_and_key(
-=======
-    CoreCrypto_7cc0_init_with_path_and_key(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_init_with_path_and_key(
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_init_with_path_and_key(
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -4030,49 +2368,7 @@ public func version()  -> String {
     
     rustCall() {
     
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ec77_version($0)
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-    CoreCrypto_ff56_version($0)
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_version($0)
-=======
-    CoreCrypto_e3ae_version($0)
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_version($0)
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_version($0)
-=======
-    CoreCrypto_e3ae_version($0)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_version($0)
-=======
-    CoreCrypto_7cc0_version($0)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CoreCrypto_ff56_version($0)
-||||||| parent of e5e4538 (Adding bindings)
-    CoreCrypto_54ee_version($0)
-=======
-    CoreCrypto_e3ae_version($0)
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-    CoreCrypto_e3ae_version($0)
-=======
-    CoreCrypto_7cc0_version($0)
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-    CoreCrypto_2704_version($0)
->>>>>>> 6f20d8e (Fix conflicts)
+    CoreCrypto_272d_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,37 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_24ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+||||||| parent of ac2d23e (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_24ee_rustbuffer_free(self, $0) }
+||||||| parent of ac2d23e (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
+=======
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     }
 }
 
@@ -447,6 +471,8 @@ public protocol CoreCryptoProtocol {
     func exportGroupState(conversationId: ConversationId) throws -> [UInt8]
     func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws
     func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws
+    func exportSecretKey(conversationId: ConversationId, label: String, keyLength: UInt32) throws -> [UInt8]
+    func exportClients(conversationId: ConversationId) throws -> [ClientId]
     func randomBytes(length: UInt32) throws -> [UInt8]
     func reseedRng(seed: [UInt8]) throws
     func commitAccepted(conversationId: ConversationId) throws
@@ -480,7 +506,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_new(
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_new(
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new(
+=======
+    CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -489,7 +527,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_24ee_CoreCrypto_object_free(pointer, $0) }
+||||||| parent of ac2d23e (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
+=======
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     }
 
     
@@ -498,7 +548,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_set_callbacks(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -507,7 +569,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_client_public_key(self.pointer, $0
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     )
 }
         )
@@ -516,7 +590,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_client_keypackages(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -526,7 +612,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
     )
 }
         )
@@ -534,7 +632,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_create_conversation(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -544,7 +654,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_conversation_epoch(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -555,7 +677,19 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_conversation_exists(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -565,7 +699,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_process_welcome_message(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -575,7 +721,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -586,7 +744,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -597,7 +767,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_update_keying_material(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -607,7 +789,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -617,7 +811,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -628,7 +834,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -639,7 +857,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_final_update_keying_material(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -649,7 +879,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -658,7 +900,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func wipeConversation(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_wipe_conversation(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -667,7 +921,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_decrypt_message(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -678,7 +944,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_encrypt_message(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -689,7 +967,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_new_add_proposal(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -700,7 +990,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_new_update_proposal(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -710,7 +1012,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_new_remove_proposal(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -721,7 +1035,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), $0
     )
@@ -732,7 +1058,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -744,7 +1082,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_join_by_external_commit(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterSequenceUInt8.lower(publicGroupState), $0
     )
 }
@@ -754,7 +1104,19 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_export_group_state(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -763,7 +1125,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -772,16 +1146,62 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
+    }
+    public func exportSecretKey(conversationId: ConversationId, label: String, keyLength: UInt32) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
+            try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_e3ae_CoreCrypto_export_secret_key(self.pointer, 
+        FfiConverterTypeConversationId.lower(conversationId), 
+        FfiConverterString.lower(label), 
+        FfiConverterUInt32.lower(keyLength), $0
+    )
+}
+        )
+    }
+    public func exportClients(conversationId: ConversationId) throws -> [ClientId] {
+        return try FfiConverterSequenceTypeClientId.lift(
+            try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_e3ae_CoreCrypto_export_clients(self.pointer, 
+        FfiConverterTypeConversationId.lower(conversationId), $0
+    )
+}
+        )
     }
     public func randomBytes(length: UInt32) throws -> [UInt8] {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_random_bytes(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -790,7 +1210,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_reseed_rng(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -798,7 +1230,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func commitAccepted(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_commit_accepted(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -806,7 +1250,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(proposalRef), $0
     )
@@ -815,7 +1271,19 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_24ee_CoreCrypto_clear_pending_commit(self.pointer, 
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1823,9 +2291,17 @@ private let IDX_CALLBACK_FREE: Int32 = 0
 // Declaration and FfiConverters for CoreCryptoCallbacks Callback Interface
 
 public protocol CoreCryptoCallbacks : AnyObject {
+<<<<<<< HEAD
     func authorize(conversationId: ConversationId, clientId: ClientId)  -> Bool
     func userAuthorize(conversationId: ConversationId, externalClientId: ClientId, existingClients: [ClientId])  -> Bool
     func clientIsExistingGroupUser(clientId: ClientId, existingClients: [ClientId])  -> Bool
+||||||| parent of e5e4538 (Adding bindings)
+    func authorize(conversationId: [UInt8], clientId: [UInt8])  -> Bool
+    func clientIdBelongsToOneOf(clientId: [UInt8], otherClients: [[UInt8]])  -> Bool
+=======
+    func authorize(conversationId: [UInt8], clientId: [UInt8])  -> Bool
+    func clientIsExistingGroupUser(clientId: [UInt8], existingClients: [[UInt8]])  -> Bool
+>>>>>>> e5e4538 (Adding bindings)
     
 }
 
@@ -1846,10 +2322,17 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
                 // https://github.com/mozilla/uniffi-rs/issues/351
 
     }
+<<<<<<< HEAD
     func invokeUserAuthorize(_ swiftCallbackInterface: CoreCryptoCallbacks, _ args: RustBuffer) throws -> RustBuffer {
+||||||| parent of e5e4538 (Adding bindings)
+    func invokeClientIdBelongsToOneOf(_ swiftCallbackInterface: CoreCryptoCallbacks, _ args: RustBuffer) throws -> RustBuffer {
+=======
+    func invokeClientIsExistingGroupUser(_ swiftCallbackInterface: CoreCryptoCallbacks, _ args: RustBuffer) throws -> RustBuffer {
+>>>>>>> e5e4538 (Adding bindings)
         defer { args.deallocate() }
 
             let reader = Reader(data: Data(rustBuffer: args))
+<<<<<<< HEAD
             let result = swiftCallbackInterface.userAuthorize(
                     conversationId:  try FfiConverterTypeConversationId.read(from: reader), 
                     externalClientId:  try FfiConverterTypeClientId.read(from: reader), 
@@ -1868,6 +2351,15 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
             let result = swiftCallbackInterface.clientIsExistingGroupUser(
                     clientId:  try FfiConverterTypeClientId.read(from: reader), 
                     existingClients:  try FfiConverterSequenceTypeClientId.read(from: reader)
+||||||| parent of e5e4538 (Adding bindings)
+            let result = swiftCallbackInterface.clientIdBelongsToOneOf(
+                    clientId:  try FfiConverterSequenceUInt8.read(from: reader), 
+                    otherClients:  try FfiConverterSequenceSequenceUInt8.read(from: reader)
+=======
+            let result = swiftCallbackInterface.clientIsExistingGroupUser(
+                    clientId:  try FfiConverterSequenceUInt8.read(from: reader), 
+                    existingClients:  try FfiConverterSequenceSequenceUInt8.read(from: reader)
+>>>>>>> e5e4538 (Adding bindings)
                     )
             let writer = Writer()
                 FfiConverterBool.write(result, into: writer)
@@ -1891,6 +2383,7 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
                 return 1
             case 2:
+<<<<<<< HEAD
                 let buffer = try! invokeUserAuthorize(cb, args)
                 out_buf.pointee = buffer
                 // Value written to out buffer.
@@ -1898,6 +2391,11 @@ fileprivate let foreignCallbackCallbackInterfaceCoreCryptoCallbacks : ForeignCal
                 return 1
             case 3:
                 let buffer = try! invokeClientIsExistingGroupUser(cb, args)
+||||||| parent of e5e4538 (Adding bindings)
+                let buffer = try! invokeClientIdBelongsToOneOf(cb, args)
+=======
+                let buffer = try! invokeClientIsExistingGroupUser(cb, args)
+>>>>>>> e5e4538 (Adding bindings)
                 out_buf.pointee = buffer
                 // Value written to out buffer.
                 // See docs of ForeignCallback in `uniffi/src/ffi/foreigncallbacks.rs`
@@ -1919,7 +2417,19 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
+<<<<<<< HEAD
                 ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+||||||| parent of ac2d23e (Adding bindings)
+                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+<<<<<<< HEAD
+                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+||||||| parent of e5e4538 (Adding bindings)
+                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -2328,7 +2838,19 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
+<<<<<<< HEAD
     CoreCrypto_24ee_init_with_path_and_key(
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_init_with_path_and_key(
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_init_with_path_and_key(
+=======
+    CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -2345,7 +2867,19 @@ public func version()  -> String {
     
     rustCall() {
     
+<<<<<<< HEAD
     CoreCrypto_24ee_version($0)
+||||||| parent of ac2d23e (Adding bindings)
+    CoreCrypto_ff56_version($0)
+=======
+<<<<<<< HEAD
+    CoreCrypto_ff56_version($0)
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_version($0)
+=======
+    CoreCrypto_e3ae_version($0)
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,61 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_free(self, $0) }
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_free(self, $0) }
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     }
 }
 
@@ -447,7 +495,7 @@ public protocol CoreCryptoProtocol {
     func exportGroupState(conversationId: ConversationId) throws -> [UInt8]
     func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws
     func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws
-    func exportSecretKey(conversationId: ConversationId, label: String, keyLength: UInt32) throws -> [UInt8]
+    func exportSecretKey(conversationId: ConversationId, keyLength: UInt32) throws -> [UInt8]
     func exportClients(conversationId: ConversationId) throws -> [ClientId]
     func randomBytes(length: UInt32) throws -> [UInt8]
     func reseedRng(seed: [UInt8]) throws
@@ -482,7 +530,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new(
+=======
+    CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new(
+=======
+    CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new(
+=======
+    CoreCrypto_7cc0_CoreCrypto_new(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -491,7 +563,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_ec77_CoreCrypto_object_free(pointer, $0) }
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_7cc0_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     }
 
     
@@ -500,7 +596,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_set_callbacks(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -509,7 +629,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_client_public_key(self.pointer, $0
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
+=======
+    CoreCrypto_7cc0_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     )
 }
         )
@@ -518,7 +662,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_client_keypackages(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -528,7 +696,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+    CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
     )
 }
         )
@@ -536,7 +728,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_create_conversation(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -546,7 +762,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_conversation_epoch(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -557,7 +797,31 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_conversation_exists(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -567,7 +831,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_process_welcome_message(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -577,7 +865,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -588,7 +900,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -599,7 +935,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_update_keying_material(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -609,7 +969,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -619,7 +1003,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -630,7 +1038,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -641,7 +1073,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_update_keying_material(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -651,7 +1107,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -660,7 +1140,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func wipeConversation(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_wipe_conversation(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -669,7 +1173,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_decrypt_message(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -680,7 +1208,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_encrypt_message(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -691,7 +1243,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_add_proposal(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -702,7 +1278,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_update_proposal(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -712,7 +1312,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_remove_proposal(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -723,7 +1347,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), $0
     )
@@ -734,7 +1382,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -746,7 +1418,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_join_by_external_commit(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterSequenceUInt8.lower(publicGroupState), $0
     )
 }
@@ -756,7 +1452,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_export_group_state(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -765,7 +1485,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -774,18 +1518,47 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
     }
-    public func exportSecretKey(conversationId: ConversationId, label: String, keyLength: UInt32) throws -> [UInt8] {
+    public func exportSecretKey(conversationId: ConversationId, keyLength: UInt32) throws -> [UInt8] {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_export_secret_key(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_export_secret_key(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_export_secret_key(self.pointer, 
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
-        FfiConverterString.lower(label), 
         FfiConverterUInt32.lower(keyLength), $0
     )
 }
@@ -795,7 +1568,13 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_export_clients(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_export_clients(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_export_clients(self.pointer, 
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -805,7 +1584,31 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_random_bytes(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -814,7 +1617,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_reseed_rng(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -822,7 +1649,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func commitAccepted(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_commit_accepted(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -830,7 +1681,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(proposalRef), $0
     )
@@ -839,7 +1714,31 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_clear_pending_commit(self.pointer, 
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1943,7 +2842,31 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
+<<<<<<< HEAD
                 ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+||||||| parent of e5e4538 (Adding bindings)
+                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+||||||| parent of e5e4538 (Adding bindings)
+                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+                ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -2352,7 +3275,31 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
+<<<<<<< HEAD
     CoreCrypto_ec77_init_with_path_and_key(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_init_with_path_and_key(
+=======
+    CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_init_with_path_and_key(
+=======
+    CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_init_with_path_and_key(
+=======
+    CoreCrypto_7cc0_init_with_path_and_key(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -2369,7 +3316,31 @@ public func version()  -> String {
     
     rustCall() {
     
+<<<<<<< HEAD
     CoreCrypto_ec77_version($0)
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+    CoreCrypto_ff56_version($0)
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_version($0)
+=======
+    CoreCrypto_e3ae_version($0)
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_version($0)
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_version($0)
+=======
+    CoreCrypto_e3ae_version($0)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_version($0)
+=======
+    CoreCrypto_7cc0_version($0)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -20,6 +20,7 @@ fileprivate extension RustBuffer {
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
 <<<<<<< HEAD
+<<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -44,11 +45,29 @@ fileprivate extension RustBuffer {
         try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+        try! rustCall { ffi_CoreCrypto_2704_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+>>>>>>> 6f20d8e (Fix conflicts)
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
+<<<<<<< HEAD
 <<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_ec77_rustbuffer_free(self, $0) }
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -74,6 +93,23 @@ fileprivate extension RustBuffer {
         try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_free(self, $0) }
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_rustbuffer_free(self, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_rustbuffer_free(self, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+        try! rustCall { ffi_CoreCrypto_e3ae_rustbuffer_free(self, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_7cc0_rustbuffer_free(self, $0) }
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+        try! rustCall { ffi_CoreCrypto_2704_rustbuffer_free(self, $0) }
+>>>>>>> 6f20d8e (Fix conflicts)
     }
 }
 
@@ -531,6 +567,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
 <<<<<<< HEAD
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -555,6 +592,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_new(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new(
+=======
+    CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new(
+=======
+    CoreCrypto_7cc0_CoreCrypto_new(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_new(
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -563,6 +617,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
+<<<<<<< HEAD
 <<<<<<< HEAD
         try! rustCall { ffi_CoreCrypto_ec77_CoreCrypto_object_free(pointer, $0) }
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -588,6 +643,23 @@ public class CoreCrypto: CoreCryptoProtocol {
         try! rustCall { ffi_CoreCrypto_7cc0_CoreCrypto_object_free(pointer, $0) }
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+        try! rustCall { ffi_CoreCrypto_ff56_CoreCrypto_object_free(pointer, $0) }
+||||||| parent of e5e4538 (Adding bindings)
+        try! rustCall { ffi_CoreCrypto_54ee_CoreCrypto_object_free(pointer, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+        try! rustCall { ffi_CoreCrypto_e3ae_CoreCrypto_object_free(pointer, $0) }
+=======
+        try! rustCall { ffi_CoreCrypto_7cc0_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+        try! rustCall { ffi_CoreCrypto_2704_CoreCrypto_object_free(pointer, $0) }
+>>>>>>> 6f20d8e (Fix conflicts)
     }
 
     
@@ -596,6 +668,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func setCallbacks(callbacks: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_set_callbacks(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -621,6 +694,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_set_callbacks(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_set_callbacks(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_set_callbacks(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_set_callbacks(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_set_callbacks(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(callbacks), $0
     )
 }
@@ -629,6 +719,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_client_public_key(self.pointer, $0
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -654,6 +745,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_client_public_key(self.pointer, $0
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_public_key(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_public_key(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_client_public_key(self.pointer, $0
+=======
+    CoreCrypto_7cc0_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_client_public_key(self.pointer, $0
+>>>>>>> 6f20d8e (Fix conflicts)
     )
 }
         )
@@ -662,6 +770,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_client_keypackages(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -687,6 +796,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_client_keypackages(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_keypackages(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_keypackages(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_client_keypackages(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_client_keypackages(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterUInt32.lower(amountRequested), $0
     )
 }
@@ -696,6 +822,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -721,6 +848,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+=======
+    CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+>>>>>>> 6f20d8e (Fix conflicts)
     )
 }
         )
@@ -728,6 +872,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_create_conversation(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -753,6 +898,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_create_conversation(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_create_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_create_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_create_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_create_conversation(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -762,6 +924,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_conversation_epoch(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -787,6 +950,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_conversation_epoch(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_epoch(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_conversation_epoch(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_conversation_epoch(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -797,6 +977,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_conversation_exists(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -822,6 +1003,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_conversation_exists(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_conversation_exists(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_conversation_exists(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_conversation_exists(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_conversation_exists(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -831,6 +1029,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_process_welcome_message(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -856,6 +1055,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_process_welcome_message(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_process_welcome_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_process_welcome_message(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_process_welcome_message(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterSequenceUInt8.lower(welcomeMessage), $0
     )
 }
@@ -865,6 +1081,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -890,6 +1107,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -900,6 +1134,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -925,6 +1160,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -935,6 +1187,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_update_keying_material(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -960,6 +1213,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_update_keying_material(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_update_keying_material(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -969,6 +1239,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -994,6 +1265,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_commit_pending_proposals(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1003,6 +1291,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1028,6 +1317,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeInvitee.lower(clients), $0
     )
@@ -1038,6 +1344,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1063,6 +1370,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceTypeClientId.lower(clients), $0
     )
@@ -1073,6 +1397,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_update_keying_material(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1098,6 +1423,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_update_keying_material(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_final_update_keying_material(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1107,6 +1449,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeTlsCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1132,6 +1475,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1140,6 +1500,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func wipeConversation(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_wipe_conversation(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1165,6 +1526,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_wipe_conversation(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_wipe_conversation(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_wipe_conversation(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_wipe_conversation(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1173,6 +1551,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_decrypt_message(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1198,6 +1577,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_decrypt_message(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_decrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_decrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_decrypt_message(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_decrypt_message(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(payload), $0
     )
@@ -1208,6 +1604,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_encrypt_message(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1233,6 +1630,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_encrypt_message(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_encrypt_message(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_encrypt_message(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_encrypt_message(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_encrypt_message(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(message), $0
     )
@@ -1243,6 +1657,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_add_proposal(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1268,6 +1683,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_new_add_proposal(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_add_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_new_add_proposal(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(keyPackage), $0
     )
@@ -1278,6 +1710,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_update_proposal(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1303,6 +1736,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_new_update_proposal(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_update_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_update_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_new_update_proposal(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1312,6 +1762,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_remove_proposal(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1337,6 +1788,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_new_remove_proposal(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeClientId.lower(clientId), $0
     )
@@ -1347,6 +1815,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1372,6 +1841,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_new_external_add_proposal(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), $0
     )
@@ -1382,6 +1868,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1407,6 +1894,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt64.lower(epoch), 
         FfiConverterSequenceUInt8.lower(keyPackageRef), $0
@@ -1418,6 +1922,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_join_by_external_commit(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1443,6 +1948,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_join_by_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_join_by_external_commit(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterSequenceUInt8.lower(publicGroupState), $0
     )
 }
@@ -1452,6 +1974,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_export_group_state(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1477,6 +2000,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_export_group_state(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_export_group_state(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_export_group_state(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_export_group_state(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_export_group_state(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1485,6 +2025,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId, config: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1510,6 +2051,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterTypeConversationConfiguration.lower(config), $0
     )
@@ -1518,6 +2076,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingGroupFromExternalCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1543,6 +2102,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1552,12 +2128,18 @@ public class CoreCrypto: CoreCryptoProtocol {
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
 <<<<<<< HEAD
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_export_secret_key(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
     CoreCrypto_e3ae_CoreCrypto_export_secret_key(self.pointer, 
 =======
     CoreCrypto_7cc0_CoreCrypto_export_secret_key(self.pointer, 
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+    CoreCrypto_7cc0_CoreCrypto_export_secret_key(self.pointer, 
+=======
+    CoreCrypto_2704_CoreCrypto_export_secret_key(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterUInt32.lower(keyLength), $0
     )
@@ -1569,12 +2151,18 @@ public class CoreCrypto: CoreCryptoProtocol {
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
 <<<<<<< HEAD
+<<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_export_clients(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
     CoreCrypto_e3ae_CoreCrypto_export_clients(self.pointer, 
 =======
     CoreCrypto_7cc0_CoreCrypto_export_clients(self.pointer, 
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+    CoreCrypto_7cc0_CoreCrypto_export_clients(self.pointer, 
+=======
+    CoreCrypto_2704_CoreCrypto_export_clients(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1584,6 +2172,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_random_bytes(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1609,6 +2198,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_random_bytes(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_random_bytes(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_random_bytes(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_random_bytes(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_random_bytes(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterUInt32.lower(length), $0
     )
 }
@@ -1617,6 +2223,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func reseedRng(seed: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_reseed_rng(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1642,6 +2249,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_reseed_rng(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_reseed_rng(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_reseed_rng(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_reseed_rng(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_reseed_rng(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterSequenceUInt8.lower(seed), $0
     )
 }
@@ -1649,6 +2273,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func commitAccepted(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_commit_accepted(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1674,6 +2299,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_commit_accepted(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_commit_accepted(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_commit_accepted(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_commit_accepted(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_commit_accepted(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -1681,6 +2323,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1706,6 +2349,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_clear_pending_proposal(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), 
         FfiConverterSequenceUInt8.lower(proposalRef), $0
     )
@@ -1714,6 +2374,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func clearPendingCommit(conversationId: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_CoreCrypto_clear_pending_commit(self.pointer, 
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1739,6 +2400,23 @@ public class CoreCrypto: CoreCryptoProtocol {
     CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(self.pointer, 
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_CoreCrypto_clear_pending_commit(self.pointer, 
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(self.pointer, 
+=======
+    CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_CoreCrypto_clear_pending_commit(self.pointer, 
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterTypeConversationId.lower(conversationId), $0
     )
 }
@@ -2843,6 +3521,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
 <<<<<<< HEAD
+<<<<<<< HEAD
                 ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -2867,6 +3546,23 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
                 ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+                ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+||||||| parent of e5e4538 (Adding bindings)
+                ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+                ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+=======
+                ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+                ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+>>>>>>> 6f20d8e (Fix conflicts)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3276,6 +3972,7 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
 <<<<<<< HEAD
+<<<<<<< HEAD
     CoreCrypto_ec77_init_with_path_and_key(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -3300,6 +3997,23 @@ public func initWithPathAndKey(path: String, key: String, clientId: String, entr
     CoreCrypto_7cc0_init_with_path_and_key(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_init_with_path_and_key(
+=======
+    CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_init_with_path_and_key(
+=======
+    CoreCrypto_7cc0_init_with_path_and_key(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_init_with_path_and_key(
+>>>>>>> 6f20d8e (Fix conflicts)
         FfiConverterString.lower(path), 
         FfiConverterString.lower(key), 
         FfiConverterString.lower(clientId), 
@@ -3316,6 +4030,7 @@ public func version()  -> String {
     
     rustCall() {
     
+<<<<<<< HEAD
 <<<<<<< HEAD
     CoreCrypto_ec77_version($0)
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -3341,6 +4056,23 @@ public func version()  -> String {
     CoreCrypto_7cc0_version($0)
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+    CoreCrypto_ff56_version($0)
+||||||| parent of e5e4538 (Adding bindings)
+    CoreCrypto_54ee_version($0)
+=======
+    CoreCrypto_e3ae_version($0)
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+    CoreCrypto_e3ae_version($0)
+=======
+    CoreCrypto_7cc0_version($0)
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+    CoreCrypto_2704_version($0)
+>>>>>>> 6f20d8e (Fix conflicts)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -47,6 +47,7 @@ typedef struct RustCallStatus {
 #endif // def UNIFFI_SHARED_H
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 void ffi_CoreCrypto_ec77_CoreCrypto_object_free(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
 <<<<<<< HEAD
@@ -71,9 +72,27 @@ void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
 void ffi_CoreCrypto_7cc0_CoreCrypto_object_free(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
+=======
+void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
+=======
+void ffi_CoreCrypto_7cc0_CoreCrypto_object_free(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void ffi_CoreCrypto_2704_CoreCrypto_object_free(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void*_Nonnull CoreCrypto_ec77_CoreCrypto_new(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -99,9 +118,27 @@ void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
 void*_Nonnull CoreCrypto_7cc0_CoreCrypto_new(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
+=======
+void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
+=======
+void*_Nonnull CoreCrypto_7cc0_CoreCrypto_new(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void*_Nonnull CoreCrypto_2704_CoreCrypto_new(
+>>>>>>> 6f20d8e (Fix conflicts)
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_set_callbacks(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -127,9 +164,27 @@ void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
 void CoreCrypto_7cc0_CoreCrypto_set_callbacks(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_set_callbacks(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_set_callbacks(
+=======
+void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
+=======
+void CoreCrypto_7cc0_CoreCrypto_set_callbacks(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_set_callbacks(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_client_public_key(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -155,9 +210,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_client_public_key(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_client_public_key(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_client_public_key(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_client_keypackages(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -183,9 +256,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_client_keypackages(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_client_keypackages(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_client_keypackages(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 uint64_t CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -211,9 +302,27 @@ uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
 uint64_t CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
+=======
+uint64_t CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+uint64_t CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_create_conversation(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -239,9 +348,27 @@ void CoreCrypto_e3ae_CoreCrypto_create_conversation(
 void CoreCrypto_7cc0_CoreCrypto_create_conversation(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_create_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_create_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_create_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_create_conversation(
+=======
+void CoreCrypto_7cc0_CoreCrypto_create_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_create_conversation(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 uint64_t CoreCrypto_ec77_CoreCrypto_conversation_epoch(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -267,9 +394,27 @@ uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
 uint64_t CoreCrypto_7cc0_CoreCrypto_conversation_epoch(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
+=======
+uint64_t CoreCrypto_7cc0_CoreCrypto_conversation_epoch(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+uint64_t CoreCrypto_2704_CoreCrypto_conversation_epoch(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 int8_t CoreCrypto_ec77_CoreCrypto_conversation_exists(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -295,9 +440,27 @@ int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
 int8_t CoreCrypto_7cc0_CoreCrypto_conversation_exists(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
+||||||| parent of e5e4538 (Adding bindings)
+int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
+=======
+int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
+=======
+int8_t CoreCrypto_7cc0_CoreCrypto_conversation_exists(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+int8_t CoreCrypto_2704_CoreCrypto_conversation_exists(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_process_welcome_message(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -323,9 +486,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_process_welcome_message(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_process_welcome_message(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_process_welcome_message(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -351,9 +532,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -379,9 +578,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_update_keying_material(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -407,9 +624,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_update_keying_material(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_update_keying_material(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_update_keying_material(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -435,9 +670,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_commit_pending_proposals(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -463,9 +716,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -491,9 +762,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_update_keying_material(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -519,9 +808,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_final_update_keying_material(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -547,9 +854,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_wipe_conversation(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -575,9 +900,27 @@ void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
 void CoreCrypto_7cc0_CoreCrypto_wipe_conversation(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
+=======
+void CoreCrypto_7cc0_CoreCrypto_wipe_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_wipe_conversation(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_decrypt_message(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -603,9 +946,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_decrypt_message(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_decrypt_message(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_decrypt_message(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_encrypt_message(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -631,9 +992,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_encrypt_message(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_encrypt_message(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_encrypt_message(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_add_proposal(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -659,9 +1038,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_new_add_proposal(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_add_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_new_add_proposal(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_update_proposal(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -687,9 +1084,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_new_update_proposal(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_update_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_new_update_proposal(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_remove_proposal(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -715,9 +1130,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_new_remove_proposal(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -743,9 +1176,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_new_external_add_proposal(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -771,9 +1222,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_join_by_external_commit(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -799,9 +1268,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_join_by_external_commit(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer public_group_state,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_export_group_state(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -827,9 +1314,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_export_group_state(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_export_group_state(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_export_group_state(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -855,9 +1360,27 @@ void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
 void CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+void CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -883,9 +1406,27 @@ void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
 void CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+void CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_export_secret_key(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -910,10 +1451,27 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
 =======
 RustBuffer CoreCrypto_7cc0_CoreCrypto_export_secret_key(
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_export_secret_key(
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_export_secret_key(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_export_clients(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -921,9 +1479,15 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_export_clients(
 =======
 RustBuffer CoreCrypto_7cc0_CoreCrypto_export_clients(
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_7cc0_CoreCrypto_export_clients(
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_export_clients(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_random_bytes(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -939,9 +1503,22 @@ RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
 RustBuffer CoreCrypto_7cc0_CoreCrypto_random_bytes(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_random_bytes(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_CoreCrypto_random_bytes(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_reseed_rng(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -967,9 +1544,27 @@ void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
 void CoreCrypto_7cc0_CoreCrypto_reseed_rng(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_reseed_rng(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_reseed_rng(
+=======
+void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
+=======
+void CoreCrypto_7cc0_CoreCrypto_reseed_rng(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_reseed_rng(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_commit_accepted(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -995,9 +1590,27 @@ void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
 void CoreCrypto_7cc0_CoreCrypto_commit_accepted(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_commit_accepted(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_commit_accepted(
+=======
+void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
+=======
+void CoreCrypto_7cc0_CoreCrypto_commit_accepted(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_commit_accepted(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1023,9 +1636,27 @@ void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
 void CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
+=======
+void CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_clear_pending_proposal(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_clear_pending_commit(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1051,9 +1682,27 @@ void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
 void CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
+=======
+void CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void CoreCrypto_2704_CoreCrypto_clear_pending_commit(
+>>>>>>> 6f20d8e (Fix conflicts)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
@@ -1123,9 +1772,27 @@ void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
 void ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
+=======
+void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
+=======
+void ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(
+>>>>>>> 6f20d8e (Fix conflicts)
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void*_Nonnull CoreCrypto_ec77_init_with_path_and_key(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1151,9 +1818,27 @@ void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
 void*_Nonnull CoreCrypto_7cc0_init_with_path_and_key(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
+=======
+void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
+=======
+void*_Nonnull CoreCrypto_7cc0_init_with_path_and_key(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void*_Nonnull CoreCrypto_2704_init_with_path_and_key(
+>>>>>>> 6f20d8e (Fix conflicts)
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_version(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1179,9 +1864,27 @@ RustBuffer CoreCrypto_e3ae_version(
 RustBuffer CoreCrypto_7cc0_version(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_version(
+=======
+RustBuffer CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_version(
+=======
+RustBuffer CoreCrypto_7cc0_version(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer CoreCrypto_2704_version(
+>>>>>>> 6f20d8e (Fix conflicts)
       
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_ec77_rustbuffer_alloc(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1207,9 +1910,27 @@ RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
 RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_alloc(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
+=======
+RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_alloc(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer ffi_CoreCrypto_2704_rustbuffer_alloc(
+>>>>>>> 6f20d8e (Fix conflicts)
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_ec77_rustbuffer_from_bytes(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1235,9 +1956,27 @@ RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
 RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
+=======
+RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer ffi_CoreCrypto_2704_rustbuffer_from_bytes(
+>>>>>>> 6f20d8e (Fix conflicts)
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 void ffi_CoreCrypto_ec77_rustbuffer_free(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1263,9 +2002,27 @@ void ffi_CoreCrypto_e3ae_rustbuffer_free(
 void ffi_CoreCrypto_7cc0_rustbuffer_free(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_rustbuffer_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_rustbuffer_free(
+=======
+void ffi_CoreCrypto_e3ae_rustbuffer_free(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void ffi_CoreCrypto_e3ae_rustbuffer_free(
+=======
+void ffi_CoreCrypto_7cc0_rustbuffer_free(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+void ffi_CoreCrypto_2704_rustbuffer_free(
+>>>>>>> 6f20d8e (Fix conflicts)
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 <<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_ec77_rustbuffer_reserve(
 ||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
@@ -1291,6 +2048,23 @@ RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
 RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_reserve(
 >>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
 >>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
+||||||| parent of 6f20d8e (Fix conflicts)
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
+=======
+RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_reserve(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+=======
+RustBuffer ffi_CoreCrypto_2704_rustbuffer_reserve(
+>>>>>>> 6f20d8e (Fix conflicts)
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,223 +46,223 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_272d_CoreCrypto_object_free(
+void ffi_CoreCrypto_c1e3_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_272d_CoreCrypto_new(
+void*_Nonnull CoreCrypto_c1e3_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_set_callbacks(
+void CoreCrypto_c1e3_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_c1e3_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_create_conversation(
+void CoreCrypto_c1e3_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_272d_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_c1e3_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_272d_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_c1e3_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_final_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_final_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_final_update_keying_material(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_final_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_final_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_wipe_conversation(
+void CoreCrypto_c1e3_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_c1e3_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_c1e3_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_export_clients(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_reseed_rng(
+void CoreCrypto_c1e3_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_commit_accepted(
+void CoreCrypto_c1e3_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_c1e3_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_clear_pending_commit(
+void CoreCrypto_c1e3_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_proteus_init(
+void CoreCrypto_c1e3_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_c1e3_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_proteus_session_save(
+void CoreCrypto_c1e3_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_proteus_session_delete(
+void CoreCrypto_c1e3_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_c1e3_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_c1e3_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_c1e3_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_272d_init_with_path_and_key(
+void*_Nonnull CoreCrypto_c1e3_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_272d_version(
+RustBuffer CoreCrypto_c1e3_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_272d_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_c1e3_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_272d_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_c1e3_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_272d_rustbuffer_free(
+void ffi_CoreCrypto_c1e3_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_272d_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_c1e3_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,154 +46,1015 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
+<<<<<<< HEAD
 void ffi_CoreCrypto_ec77_CoreCrypto_object_free(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
+=======
+void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
+=======
+void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
+=======
+void ffi_CoreCrypto_7cc0_CoreCrypto_object_free(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void*_Nonnull CoreCrypto_ec77_CoreCrypto_new(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
+=======
+void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
+=======
+void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
+=======
+void*_Nonnull CoreCrypto_7cc0_CoreCrypto_new(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_set_callbacks(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_set_callbacks(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_set_callbacks(
+=======
+void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_set_callbacks(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_set_callbacks(
+=======
+void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
+=======
+void CoreCrypto_7cc0_CoreCrypto_set_callbacks(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_client_public_key(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_client_public_key(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_client_keypackages(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_client_keypackages(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 uint64_t CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
+=======
+uint64_t CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_create_conversation(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_create_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_create_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_create_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_create_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_create_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_create_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_create_conversation(
+=======
+void CoreCrypto_7cc0_CoreCrypto_create_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 uint64_t CoreCrypto_ec77_CoreCrypto_conversation_epoch(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
+=======
+uint64_t CoreCrypto_7cc0_CoreCrypto_conversation_epoch(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 int8_t CoreCrypto_ec77_CoreCrypto_conversation_exists(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
+||||||| parent of e5e4538 (Adding bindings)
+int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
+=======
+int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
+||||||| parent of e5e4538 (Adding bindings)
+int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
+=======
+int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
+=======
+int8_t CoreCrypto_7cc0_CoreCrypto_conversation_exists(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_process_welcome_message(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_process_welcome_message(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_update_keying_material(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_update_keying_material(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_update_keying_material(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_wipe_conversation(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
+=======
+void CoreCrypto_7cc0_CoreCrypto_wipe_conversation(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_decrypt_message(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_decrypt_message(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_encrypt_message(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_encrypt_message(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_add_proposal(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_add_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_update_proposal(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_update_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_remove_proposal(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_join_by_external_commit(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer public_group_state,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_export_group_state(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_export_group_state(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+void CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+void CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_export_secret_key(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_export_secret_key(
+      void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_export_clients(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_clients(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_export_clients(
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_CoreCrypto_random_bytes(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
+=======
+RustBuffer CoreCrypto_7cc0_CoreCrypto_random_bytes(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_reseed_rng(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_reseed_rng(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_reseed_rng(
+=======
+void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_reseed_rng(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_reseed_rng(
+=======
+void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
+=======
+void CoreCrypto_7cc0_CoreCrypto_reseed_rng(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_commit_accepted(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_commit_accepted(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_commit_accepted(
+=======
+void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_commit_accepted(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_commit_accepted(
+=======
+void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
+=======
+void CoreCrypto_7cc0_CoreCrypto_commit_accepted(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
+=======
+void CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_clear_pending_commit(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
+=======
+void CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_ec77_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
@@ -239,30 +1100,197 @@ void CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(
     RustCallStatus *_Nonnull out_status
     );
 void ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
+=======
+void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
+=======
+void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
+=======
+void ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void*_Nonnull CoreCrypto_ec77_init_with_path_and_key(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
+=======
+void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
+=======
+void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
+=======
+void*_Nonnull CoreCrypto_7cc0_init_with_path_and_key(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_ec77_version(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_version(
+=======
+RustBuffer CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_version(
+=======
+RustBuffer CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer CoreCrypto_e3ae_version(
+=======
+RustBuffer CoreCrypto_7cc0_version(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_ec77_rustbuffer_alloc(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
+=======
+RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_alloc(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_ec77_rustbuffer_from_bytes(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
+=======
+RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void ffi_CoreCrypto_ec77_rustbuffer_free(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_rustbuffer_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_rustbuffer_free(
+=======
+void ffi_CoreCrypto_e3ae_rustbuffer_free(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_rustbuffer_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_rustbuffer_free(
+=======
+void ffi_CoreCrypto_e3ae_rustbuffer_free(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+void ffi_CoreCrypto_e3ae_rustbuffer_free(
+=======
+void ffi_CoreCrypto_7cc0_rustbuffer_free(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_ec77_rustbuffer_reserve(
+||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
+>>>>>>> e5e4538 (Adding bindings)
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
+>>>>>>> e5e4538 (Adding bindings)
+||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
+=======
+RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_reserve(
+>>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
+>>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,146 +46,575 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
+<<<<<<< HEAD
 void ffi_CoreCrypto_24ee_CoreCrypto_object_free(
+||||||| parent of ac2d23e (Adding bindings)
+void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
+=======
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
+=======
+void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void*_Nonnull CoreCrypto_24ee_CoreCrypto_new(
+||||||| parent of ac2d23e (Adding bindings)
+void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
+=======
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
+=======
+void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_set_callbacks(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_set_callbacks(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_set_callbacks(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_set_callbacks(
+=======
+void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_client_public_key(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_client_keypackages(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 uint64_t CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(
+||||||| parent of ac2d23e (Adding bindings)
+uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
+=======
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_create_conversation(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_create_conversation(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_create_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_create_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_create_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 uint64_t CoreCrypto_24ee_CoreCrypto_conversation_epoch(
+||||||| parent of ac2d23e (Adding bindings)
+uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
+=======
+<<<<<<< HEAD
+uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
+||||||| parent of e5e4538 (Adding bindings)
+uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
+=======
+uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 int8_t CoreCrypto_24ee_CoreCrypto_conversation_exists(
+||||||| parent of ac2d23e (Adding bindings)
+int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
+=======
+<<<<<<< HEAD
+int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
+||||||| parent of e5e4538 (Adding bindings)
+int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
+=======
+int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_process_welcome_message(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_update_keying_material(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_final_update_keying_material(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_wipe_conversation(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
+=======
+void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_decrypt_message(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_encrypt_message(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_new_add_proposal(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_new_update_proposal(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_new_remove_proposal(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_join_by_external_commit(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer public_group_state,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_export_group_state(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_CoreCrypto_random_bytes(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
+=======
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_e3ae_CoreCrypto_export_clients(
+      void*_Nonnull ptr,RustBuffer conversation_id,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_reseed_rng(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_reseed_rng(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_reseed_rng(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_reseed_rng(
+=======
+void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_commit_accepted(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_commit_accepted(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_commit_accepted(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_commit_accepted(
+=======
+void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_clear_pending_commit(
+||||||| parent of ac2d23e (Adding bindings)
+void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
+=======
+<<<<<<< HEAD
+void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
+||||||| parent of e5e4538 (Adding bindings)
+void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
+=======
+void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void CoreCrypto_24ee_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
@@ -231,30 +660,113 @@ void CoreCrypto_24ee_CoreCrypto_proteus_cryptobox_migrate(
     RustCallStatus *_Nonnull out_status
     );
 void ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(
+||||||| parent of ac2d23e (Adding bindings)
+void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
+=======
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
+=======
+void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void*_Nonnull CoreCrypto_24ee_init_with_path_and_key(
+||||||| parent of ac2d23e (Adding bindings)
+void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
+=======
+<<<<<<< HEAD
+void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
+||||||| parent of e5e4538 (Adding bindings)
+void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
+=======
+void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer CoreCrypto_24ee_version(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ff56_version(
+=======
+<<<<<<< HEAD
+RustBuffer CoreCrypto_ff56_version(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer CoreCrypto_54ee_version(
+=======
+RustBuffer CoreCrypto_e3ae_version(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_24ee_rustbuffer_alloc(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
+=======
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_24ee_rustbuffer_from_bytes(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
+=======
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 void ffi_CoreCrypto_24ee_rustbuffer_free(
+||||||| parent of ac2d23e (Adding bindings)
+void ffi_CoreCrypto_ff56_rustbuffer_free(
+=======
+<<<<<<< HEAD
+void ffi_CoreCrypto_ff56_rustbuffer_free(
+||||||| parent of e5e4538 (Adding bindings)
+void ffi_CoreCrypto_54ee_rustbuffer_free(
+=======
+void ffi_CoreCrypto_e3ae_rustbuffer_free(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
+<<<<<<< HEAD
 RustBuffer ffi_CoreCrypto_24ee_rustbuffer_reserve(
+||||||| parent of ac2d23e (Adding bindings)
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
+=======
+<<<<<<< HEAD
+RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
+||||||| parent of e5e4538 (Adding bindings)
+RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
+=======
+RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
+>>>>>>> e5e4538 (Adding bindings)
+>>>>>>> ac2d23e (Adding bindings)
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,2025 +46,223 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ec77_CoreCrypto_object_free(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
-=======
-void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
-=======
-void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
-=======
-void ffi_CoreCrypto_7cc0_CoreCrypto_object_free(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
-=======
-void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
-=======
-void ffi_CoreCrypto_7cc0_CoreCrypto_object_free(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void ffi_CoreCrypto_2704_CoreCrypto_object_free(
->>>>>>> 6f20d8e (Fix conflicts)
+void ffi_CoreCrypto_272d_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ec77_CoreCrypto_new(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
-=======
-void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
-=======
-void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
-=======
-void*_Nonnull CoreCrypto_7cc0_CoreCrypto_new(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
-=======
-void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
-=======
-void*_Nonnull CoreCrypto_7cc0_CoreCrypto_new(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void*_Nonnull CoreCrypto_2704_CoreCrypto_new(
->>>>>>> 6f20d8e (Fix conflicts)
+void*_Nonnull CoreCrypto_272d_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_set_callbacks(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_set_callbacks(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_set_callbacks(
-=======
-void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_set_callbacks(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_set_callbacks(
-=======
-void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
-=======
-void CoreCrypto_7cc0_CoreCrypto_set_callbacks(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_set_callbacks(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_set_callbacks(
-=======
-void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
-=======
-void CoreCrypto_7cc0_CoreCrypto_set_callbacks(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_set_callbacks(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_client_public_key(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_client_public_key(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_client_public_key(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_client_public_key(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_client_keypackages(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_client_keypackages(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_client_keypackages(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_client_keypackages(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-uint64_t CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
-=======
-uint64_t CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
-=======
-uint64_t CoreCrypto_7cc0_CoreCrypto_client_valid_keypackages_count(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-uint64_t CoreCrypto_2704_CoreCrypto_client_valid_keypackages_count(
->>>>>>> 6f20d8e (Fix conflicts)
+uint64_t CoreCrypto_272d_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_create_conversation(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_create_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_create_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_create_conversation(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_create_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_create_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_create_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_create_conversation(
-=======
-void CoreCrypto_7cc0_CoreCrypto_create_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_create_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_create_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_create_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_create_conversation(
-=======
-void CoreCrypto_7cc0_CoreCrypto_create_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_create_conversation(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-uint64_t CoreCrypto_ec77_CoreCrypto_conversation_epoch(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
-=======
-uint64_t CoreCrypto_7cc0_CoreCrypto_conversation_epoch(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
-=======
-uint64_t CoreCrypto_7cc0_CoreCrypto_conversation_epoch(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-uint64_t CoreCrypto_2704_CoreCrypto_conversation_epoch(
->>>>>>> 6f20d8e (Fix conflicts)
+uint64_t CoreCrypto_272d_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-int8_t CoreCrypto_ec77_CoreCrypto_conversation_exists(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
-||||||| parent of e5e4538 (Adding bindings)
-int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
-=======
-int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
-||||||| parent of e5e4538 (Adding bindings)
-int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
-=======
-int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
-=======
-int8_t CoreCrypto_7cc0_CoreCrypto_conversation_exists(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
-||||||| parent of e5e4538 (Adding bindings)
-int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
-=======
-int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
-=======
-int8_t CoreCrypto_7cc0_CoreCrypto_conversation_exists(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-int8_t CoreCrypto_2704_CoreCrypto_conversation_exists(
->>>>>>> 6f20d8e (Fix conflicts)
+int8_t CoreCrypto_272d_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_process_welcome_message(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_process_welcome_message(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_process_welcome_message(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_process_welcome_message(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_add_clients_to_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_add_clients_to_conversation(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_remove_clients_from_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_remove_clients_from_conversation(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_update_keying_material(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_update_keying_material(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_update_keying_material(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_update_keying_material(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_commit_pending_proposals(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_commit_pending_proposals(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_final_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_final_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_final_update_keying_material(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_update_keying_material(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_final_update_keying_material(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_final_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_final_commit_pending_proposals(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_final_commit_pending_proposals(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_final_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_wipe_conversation(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
-=======
-void CoreCrypto_7cc0_CoreCrypto_wipe_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
-=======
-void CoreCrypto_7cc0_CoreCrypto_wipe_conversation(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_wipe_conversation(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_decrypt_message(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_decrypt_message(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_decrypt_message(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_decrypt_message(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_encrypt_message(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_encrypt_message(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_encrypt_message(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_encrypt_message(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_new_add_proposal(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_add_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_add_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_new_add_proposal(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_new_update_proposal(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_update_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_update_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_new_update_proposal(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_new_remove_proposal(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_remove_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_new_remove_proposal(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_add_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_new_external_add_proposal(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_new_external_remove_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_new_external_remove_proposal(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_join_by_external_commit(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_join_by_external_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_join_by_external_commit(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_export_group_state(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_export_group_state(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_export_group_state(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_export_group_state(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-void CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-void CoreCrypto_7cc0_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-void CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-void CoreCrypto_7cc0_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_export_secret_key(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
-      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_export_secret_key(
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
-      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
-      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_export_secret_key(
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_export_secret_key(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_export_clients(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_clients(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_export_clients(
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-RustBuffer CoreCrypto_7cc0_CoreCrypto_export_clients(
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_export_clients(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_export_clients(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_CoreCrypto_random_bytes(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_random_bytes(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
-=======
-RustBuffer CoreCrypto_7cc0_CoreCrypto_random_bytes(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_CoreCrypto_random_bytes(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_reseed_rng(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_reseed_rng(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_reseed_rng(
-=======
-void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_reseed_rng(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_reseed_rng(
-=======
-void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
-=======
-void CoreCrypto_7cc0_CoreCrypto_reseed_rng(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_reseed_rng(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_reseed_rng(
-=======
-void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
-=======
-void CoreCrypto_7cc0_CoreCrypto_reseed_rng(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_reseed_rng(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_commit_accepted(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_commit_accepted(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_commit_accepted(
-=======
-void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_commit_accepted(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_commit_accepted(
-=======
-void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
-=======
-void CoreCrypto_7cc0_CoreCrypto_commit_accepted(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_commit_accepted(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_commit_accepted(
-=======
-void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
-=======
-void CoreCrypto_7cc0_CoreCrypto_commit_accepted(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_commit_accepted(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
-=======
-void CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
-=======
-void CoreCrypto_7cc0_CoreCrypto_clear_pending_proposal(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_clear_pending_proposal(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_clear_pending_commit(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
-=======
-void CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
-=======
-void CoreCrypto_7cc0_CoreCrypto_clear_pending_commit(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void CoreCrypto_2704_CoreCrypto_clear_pending_commit(
->>>>>>> 6f20d8e (Fix conflicts)
+void CoreCrypto_272d_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void CoreCrypto_ec77_CoreCrypto_proteus_init(
+void CoreCrypto_272d_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_272d_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_272d_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_ec77_CoreCrypto_proteus_session_save(
+void CoreCrypto_272d_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_ec77_CoreCrypto_proteus_session_delete(
+void CoreCrypto_272d_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_272d_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_272d_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_272d_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_272d_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_272d_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_272d_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
-=======
-void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
-=======
-void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
-=======
-void ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
-=======
-void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
-=======
-void ffi_CoreCrypto_7cc0_CoreCryptoCallbacks_init_callback(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void ffi_CoreCrypto_2704_CoreCryptoCallbacks_init_callback(
->>>>>>> 6f20d8e (Fix conflicts)
+void ffi_CoreCrypto_272d_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ec77_init_with_path_and_key(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
-=======
-void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
-=======
-void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
-=======
-void*_Nonnull CoreCrypto_7cc0_init_with_path_and_key(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
-=======
-void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
-=======
-void*_Nonnull CoreCrypto_7cc0_init_with_path_and_key(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void*_Nonnull CoreCrypto_2704_init_with_path_and_key(
->>>>>>> 6f20d8e (Fix conflicts)
+void*_Nonnull CoreCrypto_272d_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ec77_version(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_version(
-=======
-RustBuffer CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_version(
-=======
-RustBuffer CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_version(
-=======
-RustBuffer CoreCrypto_7cc0_version(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_version(
-=======
-RustBuffer CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer CoreCrypto_e3ae_version(
-=======
-RustBuffer CoreCrypto_7cc0_version(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer CoreCrypto_2704_version(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer CoreCrypto_272d_version(
       
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ec77_rustbuffer_alloc(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
-=======
-RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_alloc(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
-=======
-RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_alloc(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer ffi_CoreCrypto_2704_rustbuffer_alloc(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer ffi_CoreCrypto_272d_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ec77_rustbuffer_from_bytes(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
-=======
-RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
-=======
-RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_from_bytes(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer ffi_CoreCrypto_2704_rustbuffer_from_bytes(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer ffi_CoreCrypto_272d_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ec77_rustbuffer_free(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_rustbuffer_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_rustbuffer_free(
-=======
-void ffi_CoreCrypto_e3ae_rustbuffer_free(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_rustbuffer_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_rustbuffer_free(
-=======
-void ffi_CoreCrypto_e3ae_rustbuffer_free(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void ffi_CoreCrypto_e3ae_rustbuffer_free(
-=======
-void ffi_CoreCrypto_7cc0_rustbuffer_free(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_rustbuffer_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_rustbuffer_free(
-=======
-void ffi_CoreCrypto_e3ae_rustbuffer_free(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-void ffi_CoreCrypto_e3ae_rustbuffer_free(
-=======
-void ffi_CoreCrypto_7cc0_rustbuffer_free(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-void ffi_CoreCrypto_2704_rustbuffer_free(
->>>>>>> 6f20d8e (Fix conflicts)
+void ffi_CoreCrypto_272d_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ec77_rustbuffer_reserve(
-||||||| parent of 5ff2d51 (Removing the label and setting it as a constant)
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
->>>>>>> e5e4538 (Adding bindings)
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
-=======
-RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_reserve(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
->>>>>>> 5ff2d51 (Removing the label and setting it as a constant)
-||||||| parent of 6f20d8e (Fix conflicts)
-<<<<<<< HEAD
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
->>>>>>> e5e4538 (Adding bindings)
-||||||| parent of 0c39ea0 (Removing the label and setting it as a constant)
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
-=======
-RustBuffer ffi_CoreCrypto_7cc0_rustbuffer_reserve(
->>>>>>> 0c39ea0 (Removing the label and setting it as a constant)
-=======
-RustBuffer ffi_CoreCrypto_2704_rustbuffer_reserve(
->>>>>>> 6f20d8e (Fix conflicts)
+RustBuffer ffi_CoreCrypto_272d_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,727 +46,223 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-<<<<<<< HEAD
-void ffi_CoreCrypto_24ee_CoreCrypto_object_free(
-||||||| parent of ac2d23e (Adding bindings)
-void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
-=======
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCrypto_object_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCrypto_object_free(
-=======
-void ffi_CoreCrypto_e3ae_CoreCrypto_object_free(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void ffi_CoreCrypto_ec77_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_24ee_CoreCrypto_new(
-||||||| parent of ac2d23e (Adding bindings)
-void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
-=======
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_CoreCrypto_new(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_CoreCrypto_new(
-=======
-void*_Nonnull CoreCrypto_e3ae_CoreCrypto_new(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void*_Nonnull CoreCrypto_ec77_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_set_callbacks(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_set_callbacks(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_set_callbacks(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_set_callbacks(
-=======
-void CoreCrypto_e3ae_CoreCrypto_set_callbacks(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_client_public_key(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_public_key(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_public_key(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_public_key(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_client_keypackages(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_client_keypackages(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_client_keypackages(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_client_keypackages(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-uint64_t CoreCrypto_24ee_CoreCrypto_client_valid_keypackages_count(
-||||||| parent of ac2d23e (Adding bindings)
-uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
-=======
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_client_valid_keypackages_count(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_client_valid_keypackages_count(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_client_valid_keypackages_count(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+uint64_t CoreCrypto_ec77_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_create_conversation(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_create_conversation(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_create_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_create_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_create_conversation(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-uint64_t CoreCrypto_24ee_CoreCrypto_conversation_epoch(
-||||||| parent of ac2d23e (Adding bindings)
-uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
-=======
-<<<<<<< HEAD
-uint64_t CoreCrypto_ff56_CoreCrypto_conversation_epoch(
-||||||| parent of e5e4538 (Adding bindings)
-uint64_t CoreCrypto_54ee_CoreCrypto_conversation_epoch(
-=======
-uint64_t CoreCrypto_e3ae_CoreCrypto_conversation_epoch(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+uint64_t CoreCrypto_ec77_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-int8_t CoreCrypto_24ee_CoreCrypto_conversation_exists(
-||||||| parent of ac2d23e (Adding bindings)
-int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
-=======
-<<<<<<< HEAD
-int8_t CoreCrypto_ff56_CoreCrypto_conversation_exists(
-||||||| parent of e5e4538 (Adding bindings)
-int8_t CoreCrypto_54ee_CoreCrypto_conversation_exists(
-=======
-int8_t CoreCrypto_e3ae_CoreCrypto_conversation_exists(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+int8_t CoreCrypto_ec77_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_process_welcome_message(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_process_welcome_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_process_welcome_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_process_welcome_message(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_add_clients_to_conversation(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_remove_clients_from_conversation(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_update_keying_material(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_commit_pending_proposals(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_final_add_clients_to_conversation(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_add_clients_to_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_add_clients_to_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_add_clients_to_conversation(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_final_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_final_remove_clients_from_conversation(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_remove_clients_from_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_remove_clients_from_conversation(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_remove_clients_from_conversation(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_final_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_final_update_keying_material(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_update_keying_material(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_update_keying_material(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_update_keying_material(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_final_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_final_commit_pending_proposals(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_final_commit_pending_proposals(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_final_commit_pending_proposals(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_final_commit_pending_proposals(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_final_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_wipe_conversation(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_wipe_conversation(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_wipe_conversation(
-=======
-void CoreCrypto_e3ae_CoreCrypto_wipe_conversation(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_decrypt_message(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_decrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_decrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_decrypt_message(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_encrypt_message(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_encrypt_message(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_encrypt_message(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_encrypt_message(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_new_add_proposal(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_new_update_proposal(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_update_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_update_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_update_proposal(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_new_remove_proposal(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_new_external_add_proposal(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_add_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_add_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_add_proposal(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_new_external_remove_proposal(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_new_external_remove_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_new_external_remove_proposal(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_new_external_remove_proposal(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_join_by_external_commit(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_join_by_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_join_by_external_commit(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_join_by_external_commit(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_export_group_state(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_export_group_state(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_export_group_state(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_group_state(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_merge_pending_group_from_external_commit(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_merge_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_merge_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_merge_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_clear_pending_group_from_external_commit(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_group_from_external_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_group_from_external_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_group_from_external_commit(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_CoreCrypto_random_bytes(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_CoreCrypto_random_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_CoreCrypto_random_bytes(
-=======
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_ec77_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer label,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_e3ae_CoreCrypto_export_clients(
+RustBuffer CoreCrypto_ec77_CoreCrypto_export_clients(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_e3ae_CoreCrypto_random_bytes(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_reseed_rng(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_reseed_rng(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_reseed_rng(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_reseed_rng(
-=======
-void CoreCrypto_e3ae_CoreCrypto_reseed_rng(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_commit_accepted(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_commit_accepted(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_commit_accepted(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_commit_accepted(
-=======
-void CoreCrypto_e3ae_CoreCrypto_commit_accepted(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_clear_pending_proposal(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_proposal(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_proposal(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_proposal(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_clear_pending_commit(
-||||||| parent of ac2d23e (Adding bindings)
-void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
-=======
-<<<<<<< HEAD
-void CoreCrypto_ff56_CoreCrypto_clear_pending_commit(
-||||||| parent of e5e4538 (Adding bindings)
-void CoreCrypto_54ee_CoreCrypto_clear_pending_commit(
-=======
-void CoreCrypto_e3ae_CoreCrypto_clear_pending_commit(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void CoreCrypto_ec77_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void CoreCrypto_24ee_CoreCrypto_proteus_init(
+void CoreCrypto_ec77_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_24ee_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_ec77_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_24ee_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_24ee_CoreCrypto_proteus_session_save(
+void CoreCrypto_ec77_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_24ee_CoreCrypto_proteus_session_delete(
+void CoreCrypto_ec77_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_24ee_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_24ee_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_24ee_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_24ee_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_24ee_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_ec77_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_24ee_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_ec77_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_24ee_CoreCryptoCallbacks_init_callback(
-||||||| parent of ac2d23e (Adding bindings)
-void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
-=======
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_CoreCryptoCallbacks_init_callback(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_CoreCryptoCallbacks_init_callback(
-=======
-void ffi_CoreCrypto_e3ae_CoreCryptoCallbacks_init_callback(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void ffi_CoreCrypto_ec77_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_24ee_init_with_path_and_key(
-||||||| parent of ac2d23e (Adding bindings)
-void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
-=======
-<<<<<<< HEAD
-void*_Nonnull CoreCrypto_ff56_init_with_path_and_key(
-||||||| parent of e5e4538 (Adding bindings)
-void*_Nonnull CoreCrypto_54ee_init_with_path_and_key(
-=======
-void*_Nonnull CoreCrypto_e3ae_init_with_path_and_key(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void*_Nonnull CoreCrypto_ec77_init_with_path_and_key(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer CoreCrypto_24ee_version(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer CoreCrypto_ff56_version(
-=======
-<<<<<<< HEAD
-RustBuffer CoreCrypto_ff56_version(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer CoreCrypto_54ee_version(
-=======
-RustBuffer CoreCrypto_e3ae_version(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer CoreCrypto_ec77_version(
       
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_24ee_rustbuffer_alloc(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
-=======
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_alloc(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_alloc(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_alloc(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer ffi_CoreCrypto_ec77_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_24ee_rustbuffer_from_bytes(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
-=======
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_from_bytes(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_from_bytes(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_from_bytes(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer ffi_CoreCrypto_ec77_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-void ffi_CoreCrypto_24ee_rustbuffer_free(
-||||||| parent of ac2d23e (Adding bindings)
-void ffi_CoreCrypto_ff56_rustbuffer_free(
-=======
-<<<<<<< HEAD
-void ffi_CoreCrypto_ff56_rustbuffer_free(
-||||||| parent of e5e4538 (Adding bindings)
-void ffi_CoreCrypto_54ee_rustbuffer_free(
-=======
-void ffi_CoreCrypto_e3ae_rustbuffer_free(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+void ffi_CoreCrypto_ec77_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_24ee_rustbuffer_reserve(
-||||||| parent of ac2d23e (Adding bindings)
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
-=======
-<<<<<<< HEAD
-RustBuffer ffi_CoreCrypto_ff56_rustbuffer_reserve(
-||||||| parent of e5e4538 (Adding bindings)
-RustBuffer ffi_CoreCrypto_54ee_rustbuffer_reserve(
-=======
-RustBuffer ffi_CoreCrypto_e3ae_rustbuffer_reserve(
->>>>>>> e5e4538 (Adding bindings)
->>>>>>> ac2d23e (Adding bindings)
+RustBuffer ffi_CoreCrypto_ec77_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -194,7 +194,7 @@ interface CoreCrypto {
     sequence<u8> export_secret_key(ConversationId conversation_id, u32 key_length);
 
     [Throws=CryptoError]
-    sequence<ClientId> export_clients(ConversationId conversation_id);
+    sequence<ClientId> get_client_ids(ConversationId conversation_id);
 
     [Throws=CryptoError]
     sequence<u8> random_bytes(u32 length);

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -191,7 +191,7 @@ interface CoreCrypto {
     void clear_pending_group_from_external_commit(ConversationId conversation_id);
 
     [Throws=CryptoError]
-    sequence<u8> export_secret_key(ConversationId conversation_id, [ByRef] string label, u32 key_length);
+    sequence<u8> export_secret_key(ConversationId conversation_id, u32 key_length);
 
     [Throws=CryptoError]
     sequence<ClientId> export_clients(ConversationId conversation_id);

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -191,6 +191,12 @@ interface CoreCrypto {
     void clear_pending_group_from_external_commit(ConversationId conversation_id);
 
     [Throws=CryptoError]
+    sequence<u8> export_secret_key(ConversationId conversation_id, [ByRef] string label, u32 key_length);
+
+    [Throws=CryptoError]
+    sequence<ClientId> export_clients(ConversationId conversation_id);
+
+    [Throws=CryptoError]
     sequence<u8> random_bytes(u32 length);
 
     [Throws=CryptoError]

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -745,6 +745,26 @@ impl CoreCrypto<'_> {
             ),
         )
     }
+
+    /// See [core_crypto::MlsCentral::export_clients]
+    pub fn export_clients(&self, conversation_id: ConversationId) -> CryptoResult<Vec<ClientId>> {
+        self.central
+            .lock()
+            .map_err(|_| CryptoError::LockPoisonError)?
+            .export_clients(&conversation_id)
+    }
+    /// See [core_crypto::MlsCentral::export_secret_key]
+    pub fn export_secret_key(
+        &self,
+        conversation_id: ConversationId,
+        label: &str,
+        key_length: u32,
+    ) -> CryptoResult<Vec<u8>> {
+        self.central
+            .lock()
+            .map_err(|_| CryptoError::LockPoisonError)?
+            .export_secret_key(&conversation_id, label, key_length as usize)
+    }
 }
 
 #[cfg_attr(not(feature = "proteus"), allow(unused_variables))]

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -754,16 +754,11 @@ impl CoreCrypto<'_> {
             .export_clients(&conversation_id)
     }
     /// See [core_crypto::MlsCentral::export_secret_key]
-    pub fn export_secret_key(
-        &self,
-        conversation_id: ConversationId,
-        label: &str,
-        key_length: u32,
-    ) -> CryptoResult<Vec<u8>> {
+    pub fn export_secret_key(&self, conversation_id: ConversationId, key_length: u32) -> CryptoResult<Vec<u8>> {
         self.central
             .lock()
             .map_err(|_| CryptoError::LockPoisonError)?
-            .export_secret_key(&conversation_id, label, key_length as usize)
+            .export_secret_key(&conversation_id, key_length as usize)
     }
 }
 

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -746,12 +746,12 @@ impl CoreCrypto<'_> {
         )
     }
 
-    /// See [core_crypto::MlsCentral::export_clients]
-    pub fn export_clients(&self, conversation_id: ConversationId) -> CryptoResult<Vec<ClientId>> {
+    /// See [core_crypto::MlsCentral::get_client_ids]
+    pub fn get_client_ids(&self, conversation_id: ConversationId) -> CryptoResult<Vec<ClientId>> {
         self.central
             .lock()
             .map_err(|_| CryptoError::LockPoisonError)?
-            .export_clients(&conversation_id)
+            .get_client_ids(&conversation_id)
     }
     /// See [core_crypto::MlsCentral::export_secret_key]
     pub fn export_secret_key(&self, conversation_id: ConversationId, key_length: u32) -> CryptoResult<Vec<u8>> {

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -1437,6 +1437,43 @@ impl CoreCrypto {
             .err_into(),
         )
     }
+
+    /// Returns: [`WasmCryptoResult<Vec<u8>>`]
+    ///
+    /// see [core_crypto::MlsCentral::export_secret_key]
+    pub fn export_secret_key(&self, conversation_id: Box<[u8]>, label: String, key_length: usize) -> Promise {
+        let this = self.0.clone();
+        future_to_promise(
+            async move {
+                let key = this
+                    .read()
+                    .await
+                    .export_secret_key(&conversation_id.to_vec(), &label, key_length)?;
+                WasmCryptoResult::Ok(Uint8Array::from(key.as_slice()).into())
+            }
+            .err_into(),
+        )
+    }
+
+    /// Returns: [`WasmCryptoResult<Box<[js_sys::Uint8Array]>`]
+    ///
+    /// see [core_crypto::MlsCentral::export_clients]
+    pub fn export_clients(&self, conversation_id: Box<[u8]>) -> Promise {
+        let this = self.0.clone();
+        future_to_promise(
+            async move {
+                let clients = this.read().await.export_clients(&conversation_id.to_vec())?;
+                let clients = js_sys::Array::from_iter(
+                    clients
+                        .into_iter()
+                        .map(|client| Uint8Array::from(client.as_slice()))
+                        .map(JsValue::from),
+                );
+                WasmCryptoResult::Ok(clients.into())
+            }
+            .err_into(),
+        )
+    }
 }
 
 #[wasm_bindgen]

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -1441,14 +1441,14 @@ impl CoreCrypto {
     /// Returns: [`WasmCryptoResult<Vec<u8>>`]
     ///
     /// see [core_crypto::MlsCentral::export_secret_key]
-    pub fn export_secret_key(&self, conversation_id: Box<[u8]>, label: String, key_length: usize) -> Promise {
+    pub fn export_secret_key(&self, conversation_id: Box<[u8]>, key_length: usize) -> Promise {
         let this = self.0.clone();
         future_to_promise(
             async move {
                 let key = this
                     .read()
                     .await
-                    .export_secret_key(&conversation_id.to_vec(), &label, key_length)?;
+                    .export_secret_key(&conversation_id.to_vec(), key_length)?;
                 WasmCryptoResult::Ok(Uint8Array::from(key.as_slice()).into())
             }
             .err_into(),

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -1457,12 +1457,12 @@ impl CoreCrypto {
 
     /// Returns: [`WasmCryptoResult<Box<[js_sys::Uint8Array]>`]
     ///
-    /// see [core_crypto::MlsCentral::export_clients]
-    pub fn export_clients(&self, conversation_id: Box<[u8]>) -> Promise {
+    /// see [core_crypto::MlsCentral::get_client_ids]
+    pub fn get_client_ids(&self, conversation_id: Box<[u8]>) -> Promise {
         let this = self.0.clone();
         future_to_promise(
             async move {
-                let clients = this.read().await.export_clients(&conversation_id.to_vec())?;
+                let clients = this.read().await.get_client_ids(&conversation_id.to_vec())?;
                 let clients = js_sys::Array::from_iter(
                     clients
                         .into_iter()

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -195,6 +195,9 @@ pub enum MlsError {
     /// OpenMls crypto error
     #[error(transparent)]
     MlsCryptoError(#[from] openmls::prelude::CryptoError),
+    /// OpenMls Export Secret error
+    #[error(transparent)]
+    MlsExportSecretError(#[from] openmls::prelude::ExportSecretError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -18,9 +18,7 @@
 
 use mls_crypto_provider::MlsCryptoProvider;
 
-use crate::{client::ClientId, CryptoError, CryptoResult, MlsCentral, MlsError};
-
-use super::{ConversationId, MlsConversation};
+use crate::mls::{client::ClientId, ConversationId, CryptoError, CryptoResult, MlsCentral, MlsConversation, MlsError};
 
 const EXPORTER_LABEL: &str = "exporter";
 

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -65,10 +65,9 @@ pub mod tests {
     use std::usize;
 
     use crate::{
-        credential::CredentialSupplier,
         error::{CryptoError, MlsError},
+        mls::{credential::CredentialSupplier, MlsConversationConfiguration},
         test_utils::*,
-        MlsConversationConfiguration,
     };
     use openmls::prelude::ExportSecretError;
     use wasm_bindgen_test::*;

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -22,16 +22,17 @@ use crate::{client::ClientId, CryptoError, CryptoResult, MlsCentral, MlsError};
 
 use super::{ConversationId, MlsConversation};
 
+const EXPORTER_LABEL: &'static str = "exporter";
+
 impl MlsConversation {
     /// See [MlsCentral::export_secret_key]
     pub fn export_secret_key(
         &self,
         backend: &MlsCryptoProvider,
-        label: &str,
         key_length: usize,
     ) -> CryptoResult<Vec<u8>> {
         self.group
-            .export_secret(backend, label, &[], key_length)
+            .export_secret(backend, EXPORTER_LABEL, &[], key_length)
             .map_err(MlsError::from)
             .map_err(CryptoError::from)
     }
@@ -54,11 +55,10 @@ impl MlsCentral {
     pub fn export_secret_key(
         &self,
         conversation_id: &ConversationId,
-        label: &str,
         key_length: usize,
     ) -> CryptoResult<Vec<u8>> {
         self.get_conversation(conversation_id)?
-            .export_secret_key(&self.mls_backend, label, key_length)
+            .export_secret_key(&self.mls_backend, key_length)
     }
 
     /// Exports the clients from a conversation

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -71,112 +71,134 @@ impl MlsCentral {
 }
 
 #[cfg(test)]
-pub mod export_tests {
-    use std::usize;
+pub mod tests {
 
-    use crate::{
-        error::{CryptoError, MlsError},
-        mls::{credential::CredentialSupplier, ConversationId, MlsConversationConfiguration},
-        test_utils::*,
-    };
-    use openmls::prelude::ExportSecretError;
-    use wasm_bindgen_test::*;
+    mod export_secret {
+        use std::usize;
 
-    wasm_bindgen_test_configure!(run_in_browser);
+        use crate::{
+            error::{CryptoError, MlsError},
+            mls::{credential::CredentialSupplier, ConversationId, MlsConversationConfiguration},
+            test_utils::*,
+        };
+        use openmls::prelude::ExportSecretError;
+        use wasm_bindgen_test::*;
 
-    #[apply(all_credential_types)]
-    #[wasm_bindgen_test]
-    pub async fn can_export_secret_key(credential: CredentialSupplier) {
-        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-                alice_central
-                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                    .await
-                    .unwrap();
+        wasm_bindgen_test_configure!(run_in_browser);
 
-                let result = alice_central.export_secret_key(&id, 128);
-                assert!(result.is_ok());
-                assert!(result.unwrap().len() == 128);
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn can_export_secret_key(credential: CredentialSupplier) {
+            run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                        .await
+                        .unwrap();
+
+                    let result = alice_central.export_secret_key(&id, 128);
+                    assert!(result.is_ok());
+                    assert!(result.unwrap().len() == 128);
+                })
             })
-        })
-        .await
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn cannot_export_secret_key_invalid_length(credential: CredentialSupplier) {
+            run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                        .await
+                        .unwrap();
+
+                    let result = alice_central.export_secret_key(&id, usize::MAX);
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        CryptoError::MlsError(MlsError::MlsExportSecretError(ExportSecretError::KeyLengthTooLong))
+                    ));
+                })
+            })
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn cannot_export_secret_key_not_found(credential: CredentialSupplier) {
+            run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                        .await
+                        .unwrap();
+
+                    let wrong = ConversationId::from("not_found");
+                    let error = alice_central.get_client_ids(&wrong).unwrap_err();
+                    assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
+                })
+            })
+            .await
+        }
     }
 
-    #[apply(all_credential_types)]
-    #[wasm_bindgen_test]
-    pub async fn cannot_export_secret_key_invalid_length(credential: CredentialSupplier) {
-        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-                alice_central
-                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                    .await
-                    .unwrap();
+    mod get_client_ids {
+        use crate::{
+            error::CryptoError,
+            mls::{credential::CredentialSupplier, ConversationId, MlsConversationConfiguration},
+            test_utils::*,
+        };
+        use wasm_bindgen_test::*;
 
-                let result = alice_central.export_secret_key(&id, usize::MAX);
-                assert!(matches!(
-                    result.unwrap_err(),
-                    CryptoError::MlsError(MlsError::MlsExportSecretError(ExportSecretError::KeyLengthTooLong))
-                ));
+        wasm_bindgen_test_configure!(run_in_browser);
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn can_get_client_ids(credential: CredentialSupplier) {
+            run_test_with_client_ids(
+                credential,
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                            .await
+                            .unwrap();
+
+                        let clients = alice_central.get_client_ids(&id).unwrap();
+                        assert!(clients.len() == 1);
+
+                        alice_central.invite(&id, &mut bob_central).await.unwrap();
+                        let clients = alice_central.get_client_ids(&id).unwrap();
+                        assert!(clients.len() == 2);
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_credential_types)]
+        #[wasm_bindgen_test]
+        pub async fn cannot_get_client_ids_not_found(credential: CredentialSupplier) {
+            run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                        .await
+                        .unwrap();
+
+                    let wrong = ConversationId::from("not_found");
+                    let error = alice_central.get_client_ids(&wrong).unwrap_err();
+                    assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
+                })
             })
-        })
-        .await
-    }
-
-    #[apply(all_credential_types)]
-    #[wasm_bindgen_test]
-    pub async fn cannot_export_secret_key_not_found(credential: CredentialSupplier) {
-        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-                alice_central
-                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                    .await
-                    .unwrap();
-
-                let wrong = ConversationId::from("not_found");
-                let error = alice_central.get_client_ids(&wrong).unwrap_err();
-                assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
-            })
-        })
-        .await
-    }
-
-    #[apply(all_credential_types)]
-    #[wasm_bindgen_test]
-    pub async fn can_get_client_ids(credential: CredentialSupplier) {
-        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-                alice_central
-                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                    .await
-                    .unwrap();
-
-                let clients = alice_central.get_client_ids(&id).unwrap();
-                assert!(clients.len() == 1);
-            })
-        })
-        .await
-    }
-
-    #[apply(all_credential_types)]
-    #[wasm_bindgen_test]
-    pub async fn cannot_get_client_ids_not_found(credential: CredentialSupplier) {
-        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-                alice_central
-                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                    .await
-                    .unwrap();
-
-                let wrong = ConversationId::from("not_found");
-                let error = alice_central.get_client_ids(&wrong).unwrap_err();
-                assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
-            })
-        })
-        .await
+            .await
+        }
     }
 }

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -76,7 +76,7 @@ pub mod export_tests {
 
     use crate::{
         error::{CryptoError, MlsError},
-        mls::{credential::CredentialSupplier, MlsConversationConfiguration, ConversationId},
+        mls::{credential::CredentialSupplier, ConversationId, MlsConversationConfiguration},
         test_utils::*,
     };
     use openmls::prelude::ExportSecretError;
@@ -87,116 +87,96 @@ pub mod export_tests {
     #[apply(all_credential_types)]
     #[wasm_bindgen_test]
     pub async fn can_export_secret_key(credential: CredentialSupplier) {
-        run_test_with_client_ids(
-            credential,
-            ["alice"],
-            move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
+        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+            Box::pin(async move {
+                let id = conversation_id();
+                alice_central
+                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                    .await
+                    .unwrap();
 
-                    let result = alice_central.export_secret_key(&id, 128);
-                    assert!(result.is_ok());
-                    assert!(result.unwrap().len() == 128);
-                })
-            },
-        )
+                let result = alice_central.export_secret_key(&id, 128);
+                assert!(result.is_ok());
+                assert!(result.unwrap().len() == 128);
+            })
+        })
         .await
     }
 
     #[apply(all_credential_types)]
     #[wasm_bindgen_test]
     pub async fn cannot_export_secret_key_invalid_length(credential: CredentialSupplier) {
-        run_test_with_client_ids(
-            credential,
-            ["alice"],
-            move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
+        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+            Box::pin(async move {
+                let id = conversation_id();
+                alice_central
+                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                    .await
+                    .unwrap();
 
-                    let result = alice_central.export_secret_key(&id, usize::MAX);
-                    assert!(matches!(
-                        result.unwrap_err(),
-                        CryptoError::MlsError(MlsError::MlsExportSecretError(ExportSecretError::KeyLengthTooLong))
-                    ));
-                })
-            },
-        )
+                let result = alice_central.export_secret_key(&id, usize::MAX);
+                assert!(matches!(
+                    result.unwrap_err(),
+                    CryptoError::MlsError(MlsError::MlsExportSecretError(ExportSecretError::KeyLengthTooLong))
+                ));
+            })
+        })
         .await
     }
 
     #[apply(all_credential_types)]
     #[wasm_bindgen_test]
     pub async fn cannot_export_secret_key_not_found(credential: CredentialSupplier) {
-        run_test_with_client_ids(
-            credential,
-            ["alice"],
-            move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
+        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+            Box::pin(async move {
+                let id = conversation_id();
+                alice_central
+                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                    .await
+                    .unwrap();
 
-                    let wrong = ConversationId::from("not_found");
-                    let error = alice_central.get_client_ids(&wrong).unwrap_err();
-                    assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
-                })
-            },
-        )
+                let wrong = ConversationId::from("not_found");
+                let error = alice_central.get_client_ids(&wrong).unwrap_err();
+                assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
+            })
+        })
         .await
     }
 
     #[apply(all_credential_types)]
     #[wasm_bindgen_test]
     pub async fn can_get_client_ids(credential: CredentialSupplier) {
-        run_test_with_client_ids(
-            credential,
-            ["alice"],
-            move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
+        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+            Box::pin(async move {
+                let id = conversation_id();
+                alice_central
+                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                    .await
+                    .unwrap();
 
-                    let clients = alice_central.get_client_ids(&id).unwrap();
-                    assert!(clients.len() == 1);
-                })
-            },
-        )
+                let clients = alice_central.get_client_ids(&id).unwrap();
+                assert!(clients.len() == 1);
+            })
+        })
         .await
     }
 
     #[apply(all_credential_types)]
     #[wasm_bindgen_test]
     pub async fn cannot_get_client_ids_not_found(credential: CredentialSupplier) {
-        run_test_with_client_ids(
-            credential,
-            ["alice"],
-            move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .new_conversation(id.clone(), MlsConversationConfiguration::default())
-                        .await
-                        .unwrap();
+        run_test_with_client_ids(credential, ["alice"], move |[mut alice_central]| {
+            Box::pin(async move {
+                let id = conversation_id();
+                alice_central
+                    .new_conversation(id.clone(), MlsConversationConfiguration::default())
+                    .await
+                    .unwrap();
 
-                    let wrong = ConversationId::from("not_found");
-                    let error = alice_central.get_client_ids(&wrong).unwrap_err();
-                    assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
-                })
-            },
-        )
+                let wrong = ConversationId::from("not_found");
+                let error = alice_central.get_client_ids(&wrong).unwrap_err();
+                assert!(matches!(error, CryptoError::ConversationNotFound(c) if c == wrong));
+            })
+        })
         .await
     }
 }

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -22,15 +22,11 @@ use crate::{client::ClientId, CryptoError, CryptoResult, MlsCentral, MlsError};
 
 use super::{ConversationId, MlsConversation};
 
-const EXPORTER_LABEL: &'static str = "exporter";
+const EXPORTER_LABEL: &str = "exporter";
 
 impl MlsConversation {
     /// See [MlsCentral::export_secret_key]
-    pub fn export_secret_key(
-        &self,
-        backend: &MlsCryptoProvider,
-        key_length: usize,
-    ) -> CryptoResult<Vec<u8>> {
+    pub fn export_secret_key(&self, backend: &MlsCryptoProvider, key_length: usize) -> CryptoResult<Vec<u8>> {
         self.group
             .export_secret(backend, EXPORTER_LABEL, &[], key_length)
             .map_err(MlsError::from)
@@ -52,11 +48,7 @@ impl MlsCentral {
     ///
     /// # Errors
     /// OpenMls secret generation error or conversation not found
-    pub fn export_secret_key(
-        &self,
-        conversation_id: &ConversationId,
-        key_length: usize,
-    ) -> CryptoResult<Vec<u8>> {
+    pub fn export_secret_key(&self, conversation_id: &ConversationId, key_length: usize) -> CryptoResult<Vec<u8>> {
         self.get_conversation(conversation_id)?
             .export_secret_key(&self.mls_backend, key_length)
     }

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -1,0 +1,71 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+
+//! Primitives to export data from a group, such as derived keys and client ids.
+
+use mls_crypto_provider::MlsCryptoProvider;
+
+use crate::{client::ClientId, CryptoError, CryptoResult, MlsCentral, MlsError};
+
+use super::{ConversationId, MlsConversation};
+
+impl MlsConversation {
+    /// See [MlsCentral::export_secret_key]
+    pub fn export_secret_key(
+        &self,
+        backend: &MlsCryptoProvider,
+        label: &str,
+        key_length: usize,
+    ) -> CryptoResult<Vec<u8>> {
+        self.group
+            .export_secret(backend, label, &[], key_length)
+            .map_err(MlsError::from)
+            .map_err(CryptoError::from)
+    }
+
+    /// See [MlsCentral::export_clients]
+    pub fn export_clients(&self) -> Vec<ClientId> {
+        self.group
+            .members()
+            .iter()
+            .map(|kp| ClientId::from(kp.credential().identity()))
+            .collect()
+    }
+}
+
+impl MlsCentral {
+    /// Derives a new key from the one in the group, allowing it to be use elsewehere.
+    ///
+    /// # Errors
+    /// OpenMls secret generation error or conversation not found
+    pub fn export_secret_key(
+        &self,
+        conversation_id: &ConversationId,
+        label: &str,
+        key_length: usize,
+    ) -> CryptoResult<Vec<u8>> {
+        self.get_conversation(conversation_id)?
+            .export_secret_key(&self.mls_backend, label, key_length)
+    }
+
+    /// Exports the clients from a conversation
+    ///
+    /// # Errors
+    /// if the conversation can't be found
+    pub fn export_clients(&self, conversation_id: &ConversationId) -> CryptoResult<Vec<ClientId>> {
+        Ok(self.get_conversation(conversation_id)?.export_clients())
+    }
+}

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -47,6 +47,7 @@ pub mod decrypt;
 #[cfg(test)]
 mod durability;
 pub mod encrypt;
+pub mod export;
 pub mod handshake;
 pub mod merge;
 pub(crate) mod public_group_state;


### PR DESCRIPTION
…embers

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Will introduce the possibility to derive a new key from a group and export its client ids.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
