### PR TITLE
test: member can rejoin group by external commit [CL-100]

### DIFF
--- a/crypto/src/test_utils/fixtures.rs
+++ b/crypto/src/test_utils/fixtures.rs
@@ -82,3 +82,12 @@ impl TestCase {
         (self.credential)(self.cfg.ciphersuite)
     }
 }
+
+impl Default for TestCase {
+    fn default() -> Self {
+        Self {
+            credential: |_| None,
+            cfg: MlsConversationConfiguration::default(),
+        }
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fix the wrong assumption that a member could not rejoin a group by external commit

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
