### PR TITLE
fix: Change the internal type of the public group info to Vec<u8> so we don't have extra bytes in the serialized message - FS-1127

### DIFF
--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -51,7 +51,7 @@ impl TryFrom<MlsConversationCreationMessage> for MemberAddedMessages {
         Ok(Self {
             welcome,
             commit,
-            public_group_state: pgs.try_into()?,
+            public_group_state: pgs.into(),
         })
     }
 }
@@ -72,7 +72,7 @@ impl TryFrom<MlsCommitBundle> for CommitBundle {
         Ok(Self {
             welcome,
             commit,
-            public_group_state: pgs.try_into()?,
+            public_group_state: pgs.into(),
         })
     }
 }
@@ -86,15 +86,13 @@ pub struct PublicGroupStateBundle {
     pub payload: Vec<u8>,
 }
 
-impl TryFrom<MlsPublicGroupStateBundle> for PublicGroupStateBundle {
-    type Error = CryptoError;
-
-    fn try_from(pgs: MlsPublicGroupStateBundle) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<MlsPublicGroupStateBundle> for PublicGroupStateBundle {
+    fn from(pgs: MlsPublicGroupStateBundle) -> Self {
+        Self {
             encryption_type: pgs.encryption_type,
             ratchet_tree_type: pgs.ratchet_tree_type,
-            payload: pgs.payload.tls_serialize_detached().map_err(MlsError::from)?,
-        })
+            payload: pgs.payload.bytes(),
+        }
     }
 }
 
@@ -138,7 +136,7 @@ impl TryFrom<MlsConversationInitBundle> for ConversationInitBundle {
         Ok(Self {
             conversation_id,
             commit,
-            public_group_state: pgs.try_into()?,
+            public_group_state: pgs.into(),
         })
     }
 }

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -21,7 +21,6 @@ use js_sys::{Promise, Uint8Array};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
-use core_crypto::prelude::tls_codec::Serialize;
 use core_crypto::prelude::*;
 pub use core_crypto::CryptoError;
 
@@ -139,7 +138,7 @@ impl TryFrom<MlsConversationCreationMessage> for MemberAddedMessages {
         Ok(Self {
             welcome,
             commit,
-            public_group_state: pgs.try_into()?,
+            public_group_state: pgs.into(),
         })
     }
 }
@@ -178,7 +177,7 @@ impl TryFrom<MlsCommitBundle> for CommitBundle {
         Ok(Self {
             welcome,
             commit,
-            public_group_state: pgs.try_into()?,
+            public_group_state: pgs.into(),
         })
     }
 }
@@ -209,15 +208,13 @@ impl PublicGroupStateBundle {
     }
 }
 
-impl TryFrom<MlsPublicGroupStateBundle> for PublicGroupStateBundle {
-    type Error = WasmCryptoError;
-
-    fn try_from(pgs: MlsPublicGroupStateBundle) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<MlsPublicGroupStateBundle> for PublicGroupStateBundle {
+    fn from(pgs: MlsPublicGroupStateBundle) -> Self {
+        Self {
             encryption_type: pgs.encryption_type.into(),
             ratchet_tree_type: pgs.ratchet_tree_type.into(),
-            payload: pgs.payload.tls_serialize_detached().map_err(MlsError::from)?,
-        })
+            payload: pgs.payload.bytes(),
+        }
     }
 }
 
@@ -323,7 +320,7 @@ impl TryFrom<MlsConversationInitBundle> for ConversationInitBundle {
         Ok(Self {
             conversation_id,
             commit,
-            public_group_state: pgs.try_into()?,
+            public_group_state: pgs.into(),
         })
     }
 }

--- a/crypto/src/mls/conversation/public_group_state.rs
+++ b/crypto/src/mls/conversation/public_group_state.rs
@@ -18,7 +18,7 @@ impl MlsPublicGroupStateBundle {
     /// Creates a new [PublicGroupStateBundle] with complete and unencrypted [PublicGroupState]
     pub(crate) fn try_new_full_plaintext(pgs: PublicGroupState) -> CryptoResult<Self> {
         use tls_codec::Serialize as _;
-        let payload = pgs.tls_serialize_detached().map_err(MlsError::from)?.into();
+        let payload = pgs.tls_serialize_detached().map_err(MlsError::from)?;
         Ok(Self {
             encryption_type: MlsPublicGroupStateEncryptionType::Plaintext,
             ratchet_tree_type: MlsRatchetTreeType::Full,
@@ -88,23 +88,16 @@ pub enum MlsRatchetTreeType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PublicGroupStatePayload {
     /// Unencrypted [PublicGroupState]
-    Plaintext(tls_codec::TlsByteVecU32),
+    Plaintext(Vec<u8>),
     // TODO: expose when fully implemented
     // Encrypted(Vec<u8>),
 }
 
-impl tls_codec::Size for PublicGroupStatePayload {
-    fn tls_serialized_len(&self) -> usize {
-        match &self {
-            Self::Plaintext(pgs) => pgs.tls_serialized_len(),
-        }
-    }
-}
-
-impl tls_codec::Serialize for PublicGroupStatePayload {
-    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+impl PublicGroupStatePayload {
+    /// Returns the internal byte array
+    pub fn bytes(self) -> Vec<u8> {
         match self {
-            Self::Plaintext(pgs) => pgs.tls_serialize(writer),
+            PublicGroupStatePayload::Plaintext(pgs) => pgs,
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Will change the internal type of the serialized public group state to `Vec<u8>` instead of `TlsByteVecU32`

### Issues

The `TlsByteVecU32` prepends the array length when serialized, causing issues to the backend that doesn't expect this.

### Solutions

Changing it to raw byte array (`Vec<u8>`) solves the issue.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
