### PR TITLE
fix: Make tags have semantic versioning names and downgrading to swift 5.5 - CL-49

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           GIT_SSH_COMMAND: "ssh -i /Users/runner/.ssh/id_rsa -o UserKnownHostsFile=/Users/runner/.ssh/known_hosts"
         run: |
+          export SEMANTIC_VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v\(.*\)/\1/')
           mkdir -p /Users/runner/.ssh
           echo "${{ secrets.SSH_DEPLOY_KEY }}" > /Users/runner/.ssh/id_rsa
           chmod 600 /Users/runner/.ssh/id_rsa
@@ -42,6 +43,6 @@ jobs:
           cp -r ../core-crypto/crypto-ffi/bindings/swift/* ./
           git add .
           git commit -m "chore: release of core-crypto $GITHUB_REF_NAME"
-          git tag $GITHUB_REF_NAME
+          git tag $SEMANTIC_VERSION
           git push origin main
-          git push origin $GITHUB_REF_NAME
+          git push origin $SEMANTIC_VERSION

--- a/crypto-ffi/bindings/swift/Package.swift
+++ b/crypto-ffi/bindings/swift/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 
 import PackageDescription
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

SPM versions must follow semantic versioning, meaning the tags in the package must be correctly named. iOS team is still on swift 5.5, so downgrading the package to the correct version

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
