### PR TITLE
fix: consistent commits

### DIFF
--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -179,13 +179,14 @@ impl MlsConversation {
             .add_members(backend, &keypackages)
             .await
             .map_err(MlsError::from)?;
+        let public_group_state = MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?;
 
         self.persist_group_when_changed(backend, false).await?;
 
         Ok(MlsConversationCreationMessage {
             welcome,
             commit,
-            public_group_state: MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?,
+            public_group_state,
         })
     }
 
@@ -218,13 +219,14 @@ impl MlsConversation {
             .remove_members(backend, &member_kps)
             .await
             .map_err(MlsError::from)?;
+        let public_group_state = MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?;
 
         self.persist_group_when_changed(backend, false).await?;
 
         Ok(MlsCommitBundle {
             commit,
             welcome,
-            public_group_state: MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?,
+            public_group_state,
         })
     }
 
@@ -235,13 +237,14 @@ impl MlsConversation {
         backend: &MlsCryptoProvider,
     ) -> CryptoResult<MlsCommitBundle> {
         let (commit, welcome, pgs) = self.group.self_update(backend, None).await.map_err(MlsError::from)?;
+        let public_group_state = MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?;
 
         self.persist_group_when_changed(backend, false).await?;
 
         Ok(MlsCommitBundle {
             welcome,
             commit,
-            public_group_state: MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?,
+            public_group_state,
         })
     }
 
@@ -257,13 +260,14 @@ impl MlsConversation {
                 .commit_to_pending_proposals(backend)
                 .await
                 .map_err(MlsError::from)?;
+            let public_group_state = MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?;
 
             self.persist_group_when_changed(backend, false).await?;
 
             Ok(Some(MlsCommitBundle {
                 welcome,
                 commit,
-                public_group_state: MlsPublicGroupStateBundle::try_new_full_plaintext(pgs)?,
+                public_group_state,
             }))
         } else {
             Ok(None)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Commits could lead to inconsistent state in keystore in case PGS serialization fails

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
