### PR TITLE
feat: expose a 'WrongEpoch' error

### DIFF
--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -73,6 +73,7 @@ enum CryptoError {
     "UnauthorizedExternalCommit",
     "InvalidHashReference",
     "GenerationOutOfBound",
+    "WrongEpoch",
     "DecryptionError",
     "HexDecodeError",
     "ProteusError",

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -104,6 +104,9 @@ pub enum CryptoError {
     /// Tried to decrypt a message in the wrong epoch
     #[error("Decrypted an application message from the wrong epoch")]
     DecryptionError,
+    /// Incoming message is for the wrong epoch
+    #[error("Incoming message is for the wrong epoch")]
+    WrongEpoch,
     /// Proteus Error Wrapper
     #[error(transparent)]
     ProteusError(#[from] ProteusError),

--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -386,8 +386,6 @@ pub mod tests {
 
     use crate::{mls::proposal::MlsProposal, test_utils::*};
 
-    use openmls::prelude::{ParseMessageError, ValidationError};
-
     use super::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
@@ -1256,12 +1254,7 @@ pub mod tests {
                             .unwrap();
                         // fails when we try to decrypt a commit for current epoch
                         let decrypt_twice = bob_central.decrypt_message(&id, &commit.to_bytes().unwrap()).await;
-                        assert!(matches!(
-                            decrypt_twice.unwrap_err(),
-                            CryptoError::MlsError(MlsError::MlsParseMessageError(ParseMessageError::ValidationError(
-                                ValidationError::WrongEpoch
-                            )))
-                        ));
+                        assert!(matches!(decrypt_twice.unwrap_err(), CryptoError::WrongEpoch));
                     })
                 },
             )
@@ -1293,12 +1286,7 @@ pub mod tests {
 
                         // fails when a commit is skipped
                         let out_of_order = bob_central.decrypt_message(&id, &commit2.to_bytes().unwrap()).await;
-                        assert!(matches!(
-                            out_of_order.unwrap_err(),
-                            CryptoError::MlsError(MlsError::MlsParseMessageError(ParseMessageError::ValidationError(
-                                ValidationError::WrongEpoch
-                            )))
-                        ));
+                        assert!(matches!(out_of_order.unwrap_err(), CryptoError::WrongEpoch));
                         // works in the right order though
                         assert!(bob_central
                             .decrypt_message(&id, &commit1.to_bytes().unwrap())
@@ -1311,12 +1299,7 @@ pub mod tests {
 
                         // and then fails again when trying to decrypt a commit with an epoch in the past
                         let past_commit = bob_central.decrypt_message(&id, &commit2.to_bytes().unwrap()).await;
-                        assert!(matches!(
-                            past_commit.unwrap_err(),
-                            CryptoError::MlsError(MlsError::MlsParseMessageError(ParseMessageError::ValidationError(
-                                ValidationError::WrongEpoch
-                            )))
-                        ));
+                        assert!(matches!(past_commit.unwrap_err(), CryptoError::WrongEpoch));
                     })
                 },
             )
@@ -1409,9 +1392,7 @@ pub mod tests {
                                     .decrypt_message(&id, commit2.to_bytes().unwrap())
                                     .await
                                     .unwrap_err(),
-                                CryptoError::MlsError(MlsError::MlsParseMessageError(
-                                    ParseMessageError::ValidationError(ValidationError::WrongEpoch)
-                                ))
+                                CryptoError::WrongEpoch
                             ));
                         })
                     },
@@ -1454,12 +1435,7 @@ pub mod tests {
 
                         // fails when we try to decrypt a proposal for past epoch
                         let past_proposal = bob_central.decrypt_message(&id, &proposal.to_bytes().unwrap()).await;
-                        assert!(matches!(
-                            past_proposal.unwrap_err(),
-                            CryptoError::MlsError(MlsError::MlsParseMessageError(ParseMessageError::ValidationError(
-                                ValidationError::WrongEpoch
-                            )))
-                        ));
+                        assert!(matches!(past_proposal.unwrap_err(), CryptoError::WrongEpoch));
                     })
                 },
             )

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -197,13 +197,11 @@ impl MlsConversation {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_utils::*, CryptoError, MlsError};
+    use crate::{prelude::MlsConversationInitBundle, test_utils::*, CryptoError};
     use openmls::prelude::*;
     use wasm_bindgen_test::*;
 
     use core_crypto_keystore::{CryptoKeystoreError, CryptoKeystoreMls, MissingKeyErrorKind};
-
-    use crate::prelude::MlsConversationInitBundle;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -355,12 +353,7 @@ mod tests {
                     let result = alice_central
                         .decrypt_message(&id, &external_commit.to_bytes().unwrap())
                         .await;
-                    assert!(matches!(
-                        result.unwrap_err(),
-                        crate::CryptoError::MlsError(MlsError::MlsParseMessageError(
-                            ParseMessageError::ValidationError(ValidationError::WrongEpoch)
-                        ))
-                    ));
+                    assert!(matches!(result.unwrap_err(), crate::CryptoError::WrongEpoch));
                 })
             },
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

expose a 'WrongEpoch' error whenever one attempts to decrypt a message in the wrong epoch.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
