### PR TITLE
feat: verify messages signed by expired KeyPackages

### DIFF
--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -81,6 +81,7 @@ enum CryptoError {
     "ProteusNotInitialized",
     "ProteusSupportNotEnabled",
     "MlsNotInitialized",
+    "InvalidKeyPackage",
 };
 
 dictionary DecryptedMessage {

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -122,6 +122,9 @@ pub enum CryptoError {
     /// A MLS operation was requested but MLS hasn't been initialized on this instance
     #[error("A MLS operation was requested but MLS hasn't been initialized on this instance")]
     MlsNotInitialized,
+    /// Decrypted message uses an invalid KeyPackage (probably expired)
+    #[error("Decrypted message uses an invalid KeyPackage")]
+    InvalidKeyPackage,
 }
 
 /// A simpler definition for Result types that the Error is a [CryptoError]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

while adding more tests to demonstrate some MLS properties, I found out that application messages signed by expired KeyPackages passed verification

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
