### PR TITLE
fix: aarch64-apple-ios-sim target not compiling 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,12 @@ package = "hpke-rs-rust-crypto"
 git = "https://github.com/wireapp/rcgen"
 tag = "v1.1.0-pre.core-crypto-0.6.0"
 
+# aarch64-apple-ios-sim target support has not yet been released
+[patch.crates-io.openssl-src]
+git = "https://github.com/alexcrichton/openssl-src-rs.git"
+branch = "release/111"
+package = "openssl-src"
+
 # Needed for quick mode and (later) result comparison see (https://www.tweag.io/blog/2022-03-03-criterion-rs/)
 # TODO: remove once branch got merged in 0.4 release
 [patch.crates-io.criterion]

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -122,13 +122,15 @@ command = "cargo"
 args = ["build", "--target", "x86_64-apple-ios", "--features", "mobile", "--release"]
 
 [tasks.ios-simulator-arm]
+# override CFLAGS to fix ring compilation
+env = { "CRATE_CC_NO_DEFAULTS" = 1, "TARGET_CFLAGS" = { script = ["echo \"--target=arm64-apple-ios14.0.0-simulator -mios-simulator-version-min=14.0 -isysroot `xcrun --show-sdk-path --sdk iphonesimulator`\""] } }
 condition = { platforms = ["mac"] }
 command = "cargo"
 args = ["build", "--target", "aarch64-apple-ios-sim", "--features", "mobile", "--release"]
 
 [tasks.ios]
 condition = { platforms = ["mac"] }
-dependencies = ["ios-device", "ios-simulator-x86"]
+dependencies = ["ios-device", "ios-simulator-x86", "ios-simulator-arm"]
 
 [tasks.ios-test-sim-build]
 condition = { platforms = ["mac"] }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The `aarch64-apple-ios-sim` target is currently disabled since it fails to compile.

### Causes

OpenSSL and Ring fails to compile.

OpenSSL has has fix but it's not released yet https://github.com/alexcrichton/openssl-src-rs/pull/175

Ring fails due to a bad argument to the compiler:

```
  running "clang" "-Os" "-fPIC" "--target=arm64-apple-ios7.0-simulator" "-arch arm64" "-mios-simulator-version-min=7.0" "-isysroot" "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator15.2.sdk" "-fembed-bitcode" "-Wno-error=inline" "-I" "include" "-I" "/Users/jacob/Development/wire/core-crypto/target/aarch64-apple-ios-sim/release/build/ring-c1f698412350209d/out" "-pedantic" "-pedantic-errors" "-Wall" "-Wextra" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wenum-compare" "-Wfloat-equal" "-Wformat=2" "-Winline" "-Winvalid-pch" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wundef" "-Wuninitialized" "-Wwrite-strings" "-fno-strict-aliasing" "-fvisibility=hidden" "-fstack-protector" "-g3" "-DNDEBUG" "-Werror" "-c" "-o/Users/jacob/Development/wire/core-crypto/target/aarch64-apple-ios-sim/release/build/ring-c1f698412350209d/out/aesv8-armx-ios64.o" "/Users/jacob/Development/wire/core-crypto/target/aarch64-apple-ios-sim/release/build/ring-c1f698412350209d/out/aesv8-armx-ios64.S"
  clang: error: argument unused during compilation: '-arch arm64' [-Werror,-Wunused-command-line-argument]
  thread 'main' panicked at 'execution failed', /Users/jacob/.cargo/git/checkouts/ring-51509f604a4fd25b/0f3bf00/build.rs:707:9
```

### Solutions

1. Build [openssl-src-rs](https://github.com/alexcrichton/openssl-src-rs) from the `release/111` branch which contains the fix.
2. Override the CFLAGS when compiling for `aarch64-apple-ios-sim` with correct arguments to the compiler.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
