### PR TITLE
feat: add end to end identity bindings [CL-21]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,14 @@ git = "https://github.com/alexcrichton/openssl-src-rs.git"
 branch = "release/111"
 package = "openssl-src"
 
+[patch.crates-io.jwt-simple]
+git = "https://github.com/beltram/rust-jwt-simple"
+branch = "wire"
+
+[patch.crates-io.biscuit]
+git = "https://github.com/beltram/biscuit"
+branch = "feat/wasm"
+
 # Needed for quick mode and (later) result comparison see (https://www.tweag.io/blog/2022-03-03-criterion-rs/)
 # TODO: remove once branch got merged in 0.4 release
 [patch.crates-io.criterion]

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_8881_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_13ff_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_8881_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_13ff_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,235 +264,307 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_8881_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_13ff_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_8881_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_8881_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_restore_from_disk(`ptr`: Pointer,
+    fun CoreCrypto_13ff_CoreCrypto_restore_from_disk(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_13ff_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_13ff_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_13ff_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_13ff_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_8881_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_8881_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_8881_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+    fun CoreCrypto_13ff_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_13ff_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_13ff_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_8881_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_8881_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun CoreCrypto_13ff_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Pointer
+
+    fun ffi_CoreCrypto_13ff_WireE2eIdentity_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_8881_version(
+    fun CoreCrypto_13ff_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_8881_rustbuffer_alloc(`size`: Int,
+    fun CoreCrypto_13ff_WireE2eIdentity_new_account_request(`ptr`: Pointer,`directory`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_8881_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun CoreCrypto_13ff_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_8881_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun CoreCrypto_13ff_WireE2eIdentity_new_order_request(`ptr`: Pointer,`handle`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`expiryDays`: Int,`directory`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`userId`: RustBuffer.ByValue,`clientId`: Long,`domain`: RustBuffer.ByValue,`clientIdChallenge`: RustBuffer.ByValue,`backendNonce`: RustBuffer.ByValue,`expirySeconds`: Long,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_new_challenge_request(`ptr`: Pointer,`handle`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_8881_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun CoreCrypto_13ff_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_finalize_request(`ptr`: Pointer,`domains`: RustBuffer.ByValue,`order`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_certificate_request(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_13ff_WireE2eIdentity_certificate_response(`ptr`: Pointer,`certificateChain`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_13ff_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun CoreCrypto_13ff_version(
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_13ff_rustbuffer_alloc(`size`: Int,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_13ff_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_13ff_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun ffi_CoreCrypto_13ff_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -997,6 +1069,9 @@ public interface CoreCryptoInterface {
     @Throws(CryptoException::class)
     fun `proteusCryptoboxMigrate`(`path`: String)
     
+    @Throws(CryptoException::class)
+    fun `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName): WireE2eIdentity
+    
 }
 
 class CoreCrypto(
@@ -1005,7 +1080,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: ClientId, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1018,7 +1093,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_8881_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_13ff_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1026,7 +1101,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInit`(`clientId`: ClientId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }
     
@@ -1034,7 +1109,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `restoreFromDisk`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_restore_from_disk(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_restore_from_disk(it,  _status)
 }
         }
     
@@ -1042,7 +1117,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1050,7 +1125,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1059,7 +1134,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1068,7 +1143,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1077,7 +1152,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1085,7 +1160,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1093,7 +1168,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1102,7 +1177,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1111,7 +1186,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1120,7 +1195,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1129,7 +1204,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1138,7 +1213,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1147,7 +1222,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1155,7 +1230,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1164,7 +1239,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1173,7 +1248,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1182,7 +1257,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1191,7 +1266,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1200,7 +1275,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1209,7 +1284,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1218,7 +1293,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1227,7 +1302,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1235,7 +1310,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1243,7 +1318,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1252,7 +1327,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1261,7 +1336,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1270,7 +1345,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1279,7 +1354,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1287,7 +1362,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1295,7 +1370,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1303,7 +1378,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1311,7 +1386,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1319,7 +1394,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1327,7 +1402,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1336,7 +1411,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1344,7 +1419,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1352,7 +1427,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionExists`(`sessionId`: String): Boolean =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1361,7 +1436,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1370,7 +1445,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1379,7 +1454,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1388,7 +1463,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1397,7 +1472,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekeyAuto`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_new_prekey_auto(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_new_prekey_auto(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1406,7 +1481,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1415,7 +1490,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintLocal`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1424,7 +1499,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintRemote`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1433,7 +1508,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintPrekeybundle`(`prekey`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1442,17 +1517,26 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
+    
+    @Throws(CryptoException::class)override fun `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName): WireE2eIdentity =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_new_acme_enrollment(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+}
+        }.let {
+            FfiConverterTypeWireE2eIdentity.lift(it)
+        }
     
 
     companion object {
         fun `deferredInit`(`path`: String, `key`: String, `entropySeed`: List<UByte>?): CoreCrypto =
             CoreCrypto(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
         
     }
@@ -1478,6 +1562,311 @@ public object FfiConverterTypeCoreCrypto: FfiConverter<CoreCrypto, Pointer> {
         // The Rust code always expects pointers written as 8 bytes,
         // and will fail to compile if they don't fit.
         buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+
+
+
+public interface WireE2eIdentityInterface {
+    
+    @Throws(E2eIdentityException::class)
+    fun `directoryResponse`(`directory`: Json): AcmeDirectory
+    
+    @Throws(E2eIdentityException::class)
+    fun `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `newAccountResponse`(`account`: Json): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `newOrderRequest`(`handle`: String, `clientId`: String, `expiryDays`: UInt, `directory`: AcmeDirectory, `account`: Account, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `newOrderResponse`(`order`: Json): NewOrder
+    
+    @Throws(E2eIdentityException::class)
+    fun `newAuthzRequest`(`url`: String, `account`: Account, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `newAuthzResponse`(`authz`: Json): NewAuthz
+    
+    @Throws(E2eIdentityException::class)
+    fun `createDpopToken`(`accessTokenUrl`: String, `userId`: String, `clientId`: ULong, `domain`: String, `clientIdChallenge`: Challenge, `backendNonce`: String, `expirySeconds`: ULong): String
+    
+    @Throws(E2eIdentityException::class)
+    fun `newChallengeRequest`(`handle`: Challenge, `account`: Account, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `newChallengeResponse`(`challenge`: Json)
+    
+    @Throws(E2eIdentityException::class)
+    fun `checkOrderRequest`(`orderUrl`: String, `account`: Account, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `checkOrderResponse`(`order`: Json): Order
+    
+    @Throws(E2eIdentityException::class)
+    fun `finalizeRequest`(`domains`: List<String>, `order`: Order, `account`: Account, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `finalizeResponse`(`finalize`: Json): Finalize
+    
+    @Throws(E2eIdentityException::class)
+    fun `certificateRequest`(`finalize`: Finalize, `account`: Account, `previousNonce`: String): Json
+    
+    @Throws(E2eIdentityException::class)
+    fun `certificateResponse`(`certificateChain`: String): List<String>
+    
+}
+
+class WireE2eIdentity(
+    pointer: Pointer
+) : FFIObject(pointer), WireE2eIdentityInterface {
+
+    /**
+     * Disconnect the object from the underlying Rust object.
+     *
+     * It can be called more than once, but once called, interacting with the object
+     * causes an `IllegalStateException`.
+     *
+     * Clients **must** call this method once done with the object, or cause a memory leak.
+     */
+    override protected fun freeRustArcPtr() {
+        rustCall() { status ->
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_13ff_WireE2eIdentity_object_free(this.pointer, status)
+        }
+    }
+
+    
+    @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: Json): AcmeDirectory =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_directory_response(it, FfiConverterTypeJson.lower(`directory`),  _status)
+}
+        }.let {
+            FfiConverterTypeAcmeDirectory.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_account_request(it, FfiConverterTypeAcmeDirectory.lower(`directory`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: Json): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_account_response(it, FfiConverterTypeJson.lower(`account`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`handle`: String, `clientId`: String, `expiryDays`: UInt, `directory`: AcmeDirectory, `account`: Account, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`handle`), FfiConverterString.lower(`clientId`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeAcmeDirectory.lower(`directory`), FfiConverterTypeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: Json): NewOrder =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_order_response(it, FfiConverterTypeJson.lower(`order`),  _status)
+}
+        }.let {
+            FfiConverterTypeNewOrder.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `account`: Account, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterTypeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: Json): NewAuthz =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_authz_response(it, FfiConverterTypeJson.lower(`authz`),  _status)
+}
+        }.let {
+            FfiConverterTypeNewAuthz.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `createDpopToken`(`accessTokenUrl`: String, `userId`: String, `clientId`: ULong, `domain`: String, `clientIdChallenge`: Challenge, `backendNonce`: String, `expirySeconds`: ULong): String =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterString.lower(`userId`), FfiConverterULong.lower(`clientId`), FfiConverterString.lower(`domain`), FfiConverterTypeChallenge.lower(`clientIdChallenge`), FfiConverterString.lower(`backendNonce`), FfiConverterULong.lower(`expirySeconds`),  _status)
+}
+        }.let {
+            FfiConverterString.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newChallengeRequest`(`handle`: Challenge, `account`: Account, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_challenge_request(it, FfiConverterTypeChallenge.lower(`handle`), FfiConverterTypeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: Json) =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_new_challenge_response(it, FfiConverterTypeJson.lower(`challenge`),  _status)
+}
+        }
+    
+    
+    @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `account`: Account, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterTypeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: Json): Order =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_check_order_response(it, FfiConverterTypeJson.lower(`order`),  _status)
+}
+        }.let {
+            FfiConverterTypeOrder.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`domains`: List<String>, `order`: Order, `account`: Account, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_finalize_request(it, FfiConverterSequenceString.lower(`domains`), FfiConverterTypeOrder.lower(`order`), FfiConverterTypeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: Json): Finalize =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_finalize_response(it, FfiConverterTypeJson.lower(`finalize`),  _status)
+}
+        }.let {
+            FfiConverterTypeFinalize.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `certificateRequest`(`finalize`: Finalize, `account`: Account, `previousNonce`: String): Json =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_certificate_request(it, FfiConverterTypeFinalize.lower(`finalize`), FfiConverterTypeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+}
+        }.let {
+            FfiConverterTypeJson.lift(it)
+        }
+    
+    @Throws(E2eIdentityException::class)override fun `certificateResponse`(`certificateChain`: String): List<String> =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_WireE2eIdentity_certificate_response(it, FfiConverterString.lower(`certificateChain`),  _status)
+}
+        }.let {
+            FfiConverterSequenceString.lift(it)
+        }
+    
+
+    
+}
+
+public object FfiConverterTypeWireE2eIdentity: FfiConverter<WireE2eIdentity, Pointer> {
+    override fun lower(value: WireE2eIdentity): Pointer = value.callWithPointer { it }
+
+    override fun lift(value: Pointer): WireE2eIdentity {
+        return WireE2eIdentity(value)
+    }
+
+    override fun read(buf: ByteBuffer): WireE2eIdentity {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: WireE2eIdentity) = 8
+
+    override fun write(value: WireE2eIdentity, buf: ByteBuffer) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+
+
+
+data class AcmeDirectory (
+    var `newNonce`: String, 
+    var `newAccount`: String, 
+    var `newOrder`: String
+) {
+    
+}
+
+public object FfiConverterTypeAcmeDirectory: FfiConverterRustBuffer<AcmeDirectory> {
+    override fun read(buf: ByteBuffer): AcmeDirectory {
+        return AcmeDirectory(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: AcmeDirectory) = (
+            FfiConverterString.allocationSize(value.`newNonce`) +
+            FfiConverterString.allocationSize(value.`newAccount`) +
+            FfiConverterString.allocationSize(value.`newOrder`)
+    )
+
+    override fun write(value: AcmeDirectory, buf: ByteBuffer) {
+            FfiConverterString.write(value.`newNonce`, buf)
+            FfiConverterString.write(value.`newAccount`, buf)
+            FfiConverterString.write(value.`newOrder`, buf)
+    }
+}
+
+
+
+
+data class Challenge (
+    var `delegate`: Json, 
+    var `url`: String
+) {
+    
+}
+
+public object FfiConverterTypeChallenge: FfiConverterRustBuffer<Challenge> {
+    override fun read(buf: ByteBuffer): Challenge {
+        return Challenge(
+            FfiConverterTypeJson.read(buf),
+            FfiConverterString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: Challenge) = (
+            FfiConverterTypeJson.allocationSize(value.`delegate`) +
+            FfiConverterString.allocationSize(value.`url`)
+    )
+
+    override fun write(value: Challenge, buf: ByteBuffer) {
+            FfiConverterTypeJson.write(value.`delegate`, buf)
+            FfiConverterString.write(value.`url`, buf)
     }
 }
 
@@ -1657,6 +2046,35 @@ public object FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer<Decrypted
 
 
 
+data class Finalize (
+    var `delegate`: Json, 
+    var `certificateUrl`: String
+) {
+    
+}
+
+public object FfiConverterTypeFinalize: FfiConverterRustBuffer<Finalize> {
+    override fun read(buf: ByteBuffer): Finalize {
+        return Finalize(
+            FfiConverterTypeJson.read(buf),
+            FfiConverterString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: Finalize) = (
+            FfiConverterTypeJson.allocationSize(value.`delegate`) +
+            FfiConverterString.allocationSize(value.`certificateUrl`)
+    )
+
+    override fun write(value: Finalize, buf: ByteBuffer) {
+            FfiConverterTypeJson.write(value.`delegate`, buf)
+            FfiConverterString.write(value.`certificateUrl`, buf)
+    }
+}
+
+
+
+
 data class Invitee (
     var `id`: ClientId, 
     var `kp`: List<UByte>
@@ -1713,6 +2131,68 @@ public object FfiConverterTypeMemberAddedMessages: FfiConverterRustBuffer<Member
             FfiConverterSequenceUByte.write(value.`commit`, buf)
             FfiConverterSequenceUByte.write(value.`welcome`, buf)
             FfiConverterTypePublicGroupStateBundle.write(value.`publicGroupState`, buf)
+    }
+}
+
+
+
+
+data class NewAuthz (
+    var `identifier`: String, 
+    var `wireHttpChallenge`: Challenge?, 
+    var `wireOidcChallenge`: Challenge?
+) {
+    
+}
+
+public object FfiConverterTypeNewAuthz: FfiConverterRustBuffer<NewAuthz> {
+    override fun read(buf: ByteBuffer): NewAuthz {
+        return NewAuthz(
+            FfiConverterString.read(buf),
+            FfiConverterOptionalTypeChallenge.read(buf),
+            FfiConverterOptionalTypeChallenge.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NewAuthz) = (
+            FfiConverterString.allocationSize(value.`identifier`) +
+            FfiConverterOptionalTypeChallenge.allocationSize(value.`wireHttpChallenge`) +
+            FfiConverterOptionalTypeChallenge.allocationSize(value.`wireOidcChallenge`)
+    )
+
+    override fun write(value: NewAuthz, buf: ByteBuffer) {
+            FfiConverterString.write(value.`identifier`, buf)
+            FfiConverterOptionalTypeChallenge.write(value.`wireHttpChallenge`, buf)
+            FfiConverterOptionalTypeChallenge.write(value.`wireOidcChallenge`, buf)
+    }
+}
+
+
+
+
+data class NewOrder (
+    var `delegate`: Json, 
+    var `authorizations`: List<String>
+) {
+    
+}
+
+public object FfiConverterTypeNewOrder: FfiConverterRustBuffer<NewOrder> {
+    override fun read(buf: ByteBuffer): NewOrder {
+        return NewOrder(
+            FfiConverterTypeJson.read(buf),
+            FfiConverterSequenceString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NewOrder) = (
+            FfiConverterTypeJson.allocationSize(value.`delegate`) +
+            FfiConverterSequenceString.allocationSize(value.`authorizations`)
+    )
+
+    override fun write(value: NewOrder, buf: ByteBuffer) {
+            FfiConverterTypeJson.write(value.`delegate`, buf)
+            FfiConverterSequenceString.write(value.`authorizations`, buf)
     }
 }
 
@@ -2111,6 +2591,70 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
 
 
 
+
+sealed class E2eIdentityException(message: String): Exception(message) {
+        // Each variant is a nested class
+        // Flat enums carries a string error message, so no special implementation is necessary.
+        class NotYetSupported(message: String) : E2eIdentityException(message)
+        class CryptoException(message: String) : E2eIdentityException(message)
+        class IdentityException(message: String) : E2eIdentityException(message)
+        class UrlException(message: String) : E2eIdentityException(message)
+        class JsonException(message: String) : E2eIdentityException(message)
+        
+
+    companion object ErrorHandler : CallStatusErrorHandler<E2eIdentityException> {
+        override fun lift(error_buf: RustBuffer.ByValue): E2eIdentityException = FfiConverterTypeE2eIdentityError.lift(error_buf)
+    }
+}
+
+public object FfiConverterTypeE2eIdentityError : FfiConverterRustBuffer<E2eIdentityException> {
+    override fun read(buf: ByteBuffer): E2eIdentityException {
+        
+            return when(buf.getInt()) {
+            1 -> E2eIdentityException.NotYetSupported(FfiConverterString.read(buf))
+            2 -> E2eIdentityException.CryptoException(FfiConverterString.read(buf))
+            3 -> E2eIdentityException.IdentityException(FfiConverterString.read(buf))
+            4 -> E2eIdentityException.UrlException(FfiConverterString.read(buf))
+            5 -> E2eIdentityException.JsonException(FfiConverterString.read(buf))
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+        }
+        
+    }
+
+    override fun allocationSize(value: E2eIdentityException): Int {
+        return 4
+    }
+
+    override fun write(value: E2eIdentityException, buf: ByteBuffer) {
+        when(value) {
+            is E2eIdentityException.NotYetSupported -> {
+                buf.putInt(1)
+                Unit
+            }
+            is E2eIdentityException.CryptoException -> {
+                buf.putInt(2)
+                Unit
+            }
+            is E2eIdentityException.IdentityException -> {
+                buf.putInt(3)
+                Unit
+            }
+            is E2eIdentityException.UrlException -> {
+                buf.putInt(4)
+                Unit
+            }
+            is E2eIdentityException.JsonException -> {
+                buf.putInt(5)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+
+}
+
+
+
+
 internal typealias Handle = Long
 internal class ConcurrentHandleMap<T>(
     private val leftMap: MutableMap<Handle, T> = mutableMapOf(),
@@ -2337,7 +2881,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_8881_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_13ff_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -2396,6 +2940,35 @@ public object FfiConverterOptionalDuration: FfiConverterRustBuffer<java.time.Dur
         } else {
             buf.put(1)
             FfiConverterDuration.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeChallenge: FfiConverterRustBuffer<Challenge?> {
+    override fun read(buf: ByteBuffer): Challenge? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeChallenge.read(buf)
+    }
+
+    override fun allocationSize(value: Challenge?): Int {
+        if (value == null) {
+            return 1
+        } else {
+            return 1 + FfiConverterTypeChallenge.allocationSize(value)
+        }
+    }
+
+    override fun write(value: Challenge?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeChallenge.write(value, buf)
         }
     }
 }
@@ -2738,6 +3311,16 @@ public object FfiConverterMapStringListUByte: FfiConverterRustBuffer<Map<String,
  * is needed because the UDL type name is used in function/method signatures.
  * It's also what we have an external type that references a custom type.
  */
+public typealias Account = List<UByte>
+public typealias FfiConverterTypeAccount = FfiConverterSequenceUByte
+
+
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ * It's also what we have an external type that references a custom type.
+ */
 public typealias ClientId = List<UByte>
 public typealias FfiConverterTypeClientId = FfiConverterSequenceUByte
 
@@ -2758,13 +3341,33 @@ public typealias FfiConverterTypeConversationId = FfiConverterSequenceUByte
  * is needed because the UDL type name is used in function/method signatures.
  * It's also what we have an external type that references a custom type.
  */
+public typealias Json = List<UByte>
+public typealias FfiConverterTypeJson = FfiConverterSequenceUByte
+
+
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ * It's also what we have an external type that references a custom type.
+ */
 public typealias MemberId = List<UByte>
 public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
+
+
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ * It's also what we have an external type that references a custom type.
+ */
+public typealias Order = List<UByte>
+public typealias FfiConverterTypeOrder = FfiConverterSequenceUByte
 
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_8881_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_13ff_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_8881_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_13ff_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_8881_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_13ff_rustbuffer_free(self, $0) }
     }
 }
 
@@ -467,6 +467,7 @@ public protocol CoreCryptoProtocol {
     func `proteusFingerprintRemote`(`sessionId`: String) throws -> String
     func `proteusFingerprintPrekeybundle`(`prekey`: [UInt8]) throws -> String
     func `proteusCryptoboxMigrate`(`path`: String) throws
+    func `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity
     
 }
 
@@ -484,7 +485,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_8881_CoreCrypto_new(
+    CoreCrypto_13ff_CoreCrypto_new(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterTypeClientId.lower(`clientId`), 
@@ -493,7 +494,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_8881_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_13ff_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -502,7 +503,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_8881_CoreCrypto_deferred_init(
+    CoreCrypto_13ff_CoreCrypto_deferred_init(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterOptionSequenceUInt8.lower(`entropySeed`), $0)
@@ -514,7 +515,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInit`(`clientId`: ClientId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_mls_init(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_mls_init(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
 }
@@ -522,14 +523,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `restoreFromDisk`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_restore_from_disk(self.pointer, $0
+    CoreCrypto_13ff_CoreCrypto_restore_from_disk(self.pointer, $0
     )
 }
     }
     public func `setCallbacks`(`callbacks`: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(`callbacks`), $0
     )
 }
@@ -538,7 +539,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_13ff_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -547,7 +548,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(`amountRequested`), $0
     )
 }
@@ -557,7 +558,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_13ff_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -565,7 +566,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeConversationConfiguration.lower(`config`), $0
     )
@@ -575,7 +576,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -586,7 +587,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_8881_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -596,7 +597,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(`welcomeMessage`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -607,7 +608,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeInvitee.lower(`clients`), $0
     )
@@ -618,7 +619,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeClientId.lower(`clients`), $0
     )
@@ -629,7 +630,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -639,7 +640,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -648,7 +649,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `wipeConversation`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -657,7 +658,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`payload`), $0
     )
@@ -668,7 +669,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`message`), $0
     )
@@ -679,7 +680,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`keyPackage`), $0
     )
@@ -690,7 +691,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -700,7 +701,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
@@ -711,7 +712,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), $0
     )
@@ -722,7 +723,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterSequenceUInt8.lower(`keyPackageRef`), $0
@@ -734,7 +735,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(`publicGroupState`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -744,7 +745,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -752,7 +753,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -761,7 +762,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -771,7 +772,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt32.lower(`keyLength`), $0
     )
@@ -782,7 +783,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_get_client_ids(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -792,7 +793,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(`length`), $0
     )
 }
@@ -801,7 +802,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `reseedRng`(`seed`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(`seed`), $0
     )
 }
@@ -809,7 +810,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `commitAccepted`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -817,7 +818,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`proposalRef`), $0
     )
@@ -826,7 +827,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -834,14 +835,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusInit`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_13ff_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
@@ -851,7 +852,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`envelope`), $0
     )
@@ -861,7 +862,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionSave`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -869,7 +870,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionDelete`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -878,7 +879,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterBool.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_session_exists(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_session_exists(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -888,7 +889,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`ciphertext`), $0
     )
@@ -899,7 +900,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -910,7 +911,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -921,7 +922,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(`prekeyId`), $0
     )
 }
@@ -931,7 +932,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
+    CoreCrypto_13ff_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
     )
 }
         )
@@ -940,7 +941,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_13ff_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -949,7 +950,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_fingerprint_local(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_local(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -959,7 +960,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -969,7 +970,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
 }
@@ -978,10 +979,20 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusCryptoboxMigrate`(`path`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_8881_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_13ff_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(`path`), $0
     )
 }
+    }
+    public func `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity {
+        return try FfiConverterTypeWireE2eIdentity.lift(
+            try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_13ff_CoreCrypto_new_acme_enrollment(self.pointer, 
+        FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), $0
+    )
+}
+        )
     }
     
 }
@@ -1014,6 +1025,359 @@ public struct FfiConverterTypeCoreCrypto: FfiConverter {
 
     public static func lower(_ value: CoreCrypto) -> UnsafeMutableRawPointer {
         return value.pointer
+    }
+}
+
+
+public protocol WireE2eIdentityProtocol {
+    func `directoryResponse`(`directory`: Json) throws -> AcmeDirectory
+    func `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String) throws -> Json
+    func `newAccountResponse`(`account`: Json) throws -> Json
+    func `newOrderRequest`(`handle`: String, `clientId`: String, `expiryDays`: UInt32, `directory`: AcmeDirectory, `account`: Account, `previousNonce`: String) throws -> Json
+    func `newOrderResponse`(`order`: Json) throws -> NewOrder
+    func `newAuthzRequest`(`url`: String, `account`: Account, `previousNonce`: String) throws -> Json
+    func `newAuthzResponse`(`authz`: Json) throws -> NewAuthz
+    func `createDpopToken`(`accessTokenUrl`: String, `userId`: String, `clientId`: UInt64, `domain`: String, `clientIdChallenge`: Challenge, `backendNonce`: String, `expirySeconds`: UInt64) throws -> String
+    func `newChallengeRequest`(`handle`: Challenge, `account`: Account, `previousNonce`: String) throws -> Json
+    func `newChallengeResponse`(`challenge`: Json) throws
+    func `checkOrderRequest`(`orderUrl`: String, `account`: Account, `previousNonce`: String) throws -> Json
+    func `checkOrderResponse`(`order`: Json) throws -> Order
+    func `finalizeRequest`(`domains`: [String], `order`: Order, `account`: Account, `previousNonce`: String) throws -> Json
+    func `finalizeResponse`(`finalize`: Json) throws -> Finalize
+    func `certificateRequest`(`finalize`: Finalize, `account`: Account, `previousNonce`: String) throws -> Json
+    func `certificateResponse`(`certificateChain`: String) throws -> [String]
+    
+}
+
+public class WireE2eIdentity: WireE2eIdentityProtocol {
+    fileprivate let pointer: UnsafeMutableRawPointer
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    deinit {
+        try! rustCall { ffi_CoreCrypto_13ff_WireE2eIdentity_object_free(pointer, $0) }
+    }
+
+    
+
+    
+    public func `directoryResponse`(`directory`: Json) throws -> AcmeDirectory {
+        return try FfiConverterTypeAcmeDirectory.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_directory_response(self.pointer, 
+        FfiConverterTypeJson.lower(`directory`), $0
+    )
+}
+        )
+    }
+    public func `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_account_request(self.pointer, 
+        FfiConverterTypeAcmeDirectory.lower(`directory`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `newAccountResponse`(`account`: Json) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_account_response(self.pointer, 
+        FfiConverterTypeJson.lower(`account`), $0
+    )
+}
+        )
+    }
+    public func `newOrderRequest`(`handle`: String, `clientId`: String, `expiryDays`: UInt32, `directory`: AcmeDirectory, `account`: Account, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_order_request(self.pointer, 
+        FfiConverterString.lower(`handle`), 
+        FfiConverterString.lower(`clientId`), 
+        FfiConverterUInt32.lower(`expiryDays`), 
+        FfiConverterTypeAcmeDirectory.lower(`directory`), 
+        FfiConverterTypeAccount.lower(`account`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `newOrderResponse`(`order`: Json) throws -> NewOrder {
+        return try FfiConverterTypeNewOrder.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_order_response(self.pointer, 
+        FfiConverterTypeJson.lower(`order`), $0
+    )
+}
+        )
+    }
+    public func `newAuthzRequest`(`url`: String, `account`: Account, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_authz_request(self.pointer, 
+        FfiConverterString.lower(`url`), 
+        FfiConverterTypeAccount.lower(`account`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `newAuthzResponse`(`authz`: Json) throws -> NewAuthz {
+        return try FfiConverterTypeNewAuthz.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_authz_response(self.pointer, 
+        FfiConverterTypeJson.lower(`authz`), $0
+    )
+}
+        )
+    }
+    public func `createDpopToken`(`accessTokenUrl`: String, `userId`: String, `clientId`: UInt64, `domain`: String, `clientIdChallenge`: Challenge, `backendNonce`: String, `expirySeconds`: UInt64) throws -> String {
+        return try FfiConverterString.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_create_dpop_token(self.pointer, 
+        FfiConverterString.lower(`accessTokenUrl`), 
+        FfiConverterString.lower(`userId`), 
+        FfiConverterUInt64.lower(`clientId`), 
+        FfiConverterString.lower(`domain`), 
+        FfiConverterTypeChallenge.lower(`clientIdChallenge`), 
+        FfiConverterString.lower(`backendNonce`), 
+        FfiConverterUInt64.lower(`expirySeconds`), $0
+    )
+}
+        )
+    }
+    public func `newChallengeRequest`(`handle`: Challenge, `account`: Account, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_challenge_request(self.pointer, 
+        FfiConverterTypeChallenge.lower(`handle`), 
+        FfiConverterTypeAccount.lower(`account`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `newChallengeResponse`(`challenge`: Json) throws {
+        try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_new_challenge_response(self.pointer, 
+        FfiConverterTypeJson.lower(`challenge`), $0
+    )
+}
+    }
+    public func `checkOrderRequest`(`orderUrl`: String, `account`: Account, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_check_order_request(self.pointer, 
+        FfiConverterString.lower(`orderUrl`), 
+        FfiConverterTypeAccount.lower(`account`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `checkOrderResponse`(`order`: Json) throws -> Order {
+        return try FfiConverterTypeOrder.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_check_order_response(self.pointer, 
+        FfiConverterTypeJson.lower(`order`), $0
+    )
+}
+        )
+    }
+    public func `finalizeRequest`(`domains`: [String], `order`: Order, `account`: Account, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_finalize_request(self.pointer, 
+        FfiConverterSequenceString.lower(`domains`), 
+        FfiConverterTypeOrder.lower(`order`), 
+        FfiConverterTypeAccount.lower(`account`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `finalizeResponse`(`finalize`: Json) throws -> Finalize {
+        return try FfiConverterTypeFinalize.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_finalize_response(self.pointer, 
+        FfiConverterTypeJson.lower(`finalize`), $0
+    )
+}
+        )
+    }
+    public func `certificateRequest`(`finalize`: Finalize, `account`: Account, `previousNonce`: String) throws -> Json {
+        return try FfiConverterTypeJson.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_certificate_request(self.pointer, 
+        FfiConverterTypeFinalize.lower(`finalize`), 
+        FfiConverterTypeAccount.lower(`account`), 
+        FfiConverterString.lower(`previousNonce`), $0
+    )
+}
+        )
+    }
+    public func `certificateResponse`(`certificateChain`: String) throws -> [String] {
+        return try FfiConverterSequenceString.lift(
+            try
+    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
+    CoreCrypto_13ff_WireE2eIdentity_certificate_response(self.pointer, 
+        FfiConverterString.lower(`certificateChain`), $0
+    )
+}
+        )
+    }
+    
+}
+
+
+public struct FfiConverterTypeWireE2eIdentity: FfiConverter {
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = WireE2eIdentity
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WireE2eIdentity {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: WireE2eIdentity, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> WireE2eIdentity {
+        return WireE2eIdentity(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: WireE2eIdentity) -> UnsafeMutableRawPointer {
+        return value.pointer
+    }
+}
+
+
+public struct AcmeDirectory {
+    public var `newNonce`: String
+    public var `newAccount`: String
+    public var `newOrder`: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(`newNonce`: String, `newAccount`: String, `newOrder`: String) {
+        self.`newNonce` = `newNonce`
+        self.`newAccount` = `newAccount`
+        self.`newOrder` = `newOrder`
+    }
+}
+
+
+extension AcmeDirectory: Equatable, Hashable {
+    public static func ==(lhs: AcmeDirectory, rhs: AcmeDirectory) -> Bool {
+        if lhs.`newNonce` != rhs.`newNonce` {
+            return false
+        }
+        if lhs.`newAccount` != rhs.`newAccount` {
+            return false
+        }
+        if lhs.`newOrder` != rhs.`newOrder` {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(`newNonce`)
+        hasher.combine(`newAccount`)
+        hasher.combine(`newOrder`)
+    }
+}
+
+
+public struct FfiConverterTypeAcmeDirectory: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AcmeDirectory {
+        return try AcmeDirectory(
+            `newNonce`: FfiConverterString.read(from: &buf), 
+            `newAccount`: FfiConverterString.read(from: &buf), 
+            `newOrder`: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: AcmeDirectory, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.`newNonce`, into: &buf)
+        FfiConverterString.write(value.`newAccount`, into: &buf)
+        FfiConverterString.write(value.`newOrder`, into: &buf)
+    }
+}
+
+
+public struct Challenge {
+    public var `delegate`: Json
+    public var `url`: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(`delegate`: Json, `url`: String) {
+        self.`delegate` = `delegate`
+        self.`url` = `url`
+    }
+}
+
+
+extension Challenge: Equatable, Hashable {
+    public static func ==(lhs: Challenge, rhs: Challenge) -> Bool {
+        if lhs.`delegate` != rhs.`delegate` {
+            return false
+        }
+        if lhs.`url` != rhs.`url` {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(`delegate`)
+        hasher.combine(`url`)
+    }
+}
+
+
+public struct FfiConverterTypeChallenge: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Challenge {
+        return try Challenge(
+            `delegate`: FfiConverterTypeJson.read(from: &buf), 
+            `url`: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Challenge, into buf: inout [UInt8]) {
+        FfiConverterTypeJson.write(value.`delegate`, into: &buf)
+        FfiConverterString.write(value.`url`, into: &buf)
     }
 }
 
@@ -1304,6 +1668,52 @@ public struct FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer {
 }
 
 
+public struct Finalize {
+    public var `delegate`: Json
+    public var `certificateUrl`: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(`delegate`: Json, `certificateUrl`: String) {
+        self.`delegate` = `delegate`
+        self.`certificateUrl` = `certificateUrl`
+    }
+}
+
+
+extension Finalize: Equatable, Hashable {
+    public static func ==(lhs: Finalize, rhs: Finalize) -> Bool {
+        if lhs.`delegate` != rhs.`delegate` {
+            return false
+        }
+        if lhs.`certificateUrl` != rhs.`certificateUrl` {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(`delegate`)
+        hasher.combine(`certificateUrl`)
+    }
+}
+
+
+public struct FfiConverterTypeFinalize: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Finalize {
+        return try Finalize(
+            `delegate`: FfiConverterTypeJson.read(from: &buf), 
+            `certificateUrl`: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: Finalize, into buf: inout [UInt8]) {
+        FfiConverterTypeJson.write(value.`delegate`, into: &buf)
+        FfiConverterString.write(value.`certificateUrl`, into: &buf)
+    }
+}
+
+
 public struct Invitee {
     public var `id`: ClientId
     public var `kp`: [UInt8]
@@ -1400,6 +1810,106 @@ public struct FfiConverterTypeMemberAddedMessages: FfiConverterRustBuffer {
         FfiConverterSequenceUInt8.write(value.`commit`, into: &buf)
         FfiConverterSequenceUInt8.write(value.`welcome`, into: &buf)
         FfiConverterTypePublicGroupStateBundle.write(value.`publicGroupState`, into: &buf)
+    }
+}
+
+
+public struct NewAuthz {
+    public var `identifier`: String
+    public var `wireHttpChallenge`: Challenge?
+    public var `wireOidcChallenge`: Challenge?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(`identifier`: String, `wireHttpChallenge`: Challenge?, `wireOidcChallenge`: Challenge?) {
+        self.`identifier` = `identifier`
+        self.`wireHttpChallenge` = `wireHttpChallenge`
+        self.`wireOidcChallenge` = `wireOidcChallenge`
+    }
+}
+
+
+extension NewAuthz: Equatable, Hashable {
+    public static func ==(lhs: NewAuthz, rhs: NewAuthz) -> Bool {
+        if lhs.`identifier` != rhs.`identifier` {
+            return false
+        }
+        if lhs.`wireHttpChallenge` != rhs.`wireHttpChallenge` {
+            return false
+        }
+        if lhs.`wireOidcChallenge` != rhs.`wireOidcChallenge` {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(`identifier`)
+        hasher.combine(`wireHttpChallenge`)
+        hasher.combine(`wireOidcChallenge`)
+    }
+}
+
+
+public struct FfiConverterTypeNewAuthz: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NewAuthz {
+        return try NewAuthz(
+            `identifier`: FfiConverterString.read(from: &buf), 
+            `wireHttpChallenge`: FfiConverterOptionTypeChallenge.read(from: &buf), 
+            `wireOidcChallenge`: FfiConverterOptionTypeChallenge.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: NewAuthz, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.`identifier`, into: &buf)
+        FfiConverterOptionTypeChallenge.write(value.`wireHttpChallenge`, into: &buf)
+        FfiConverterOptionTypeChallenge.write(value.`wireOidcChallenge`, into: &buf)
+    }
+}
+
+
+public struct NewOrder {
+    public var `delegate`: Json
+    public var `authorizations`: [String]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(`delegate`: Json, `authorizations`: [String]) {
+        self.`delegate` = `delegate`
+        self.`authorizations` = `authorizations`
+    }
+}
+
+
+extension NewOrder: Equatable, Hashable {
+    public static func ==(lhs: NewOrder, rhs: NewOrder) -> Bool {
+        if lhs.`delegate` != rhs.`delegate` {
+            return false
+        }
+        if lhs.`authorizations` != rhs.`authorizations` {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(`delegate`)
+        hasher.combine(`authorizations`)
+    }
+}
+
+
+public struct FfiConverterTypeNewOrder: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NewOrder {
+        return try NewOrder(
+            `delegate`: FfiConverterTypeJson.read(from: &buf), 
+            `authorizations`: FfiConverterSequenceString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: NewOrder, into buf: inout [UInt8]) {
+        FfiConverterTypeJson.write(value.`delegate`, into: &buf)
+        FfiConverterSequenceString.write(value.`authorizations`, into: &buf)
     }
 }
 
@@ -2092,6 +2602,95 @@ extension CryptoError: Equatable, Hashable {}
 
 extension CryptoError: Error { }
 
+
+public enum E2eIdentityError {
+
+    
+    
+    // Simple error enums only carry a message
+    case NotYetSupported(message: String)
+    
+    // Simple error enums only carry a message
+    case CryptoError(message: String)
+    
+    // Simple error enums only carry a message
+    case IdentityError(message: String)
+    
+    // Simple error enums only carry a message
+    case UrlError(message: String)
+    
+    // Simple error enums only carry a message
+    case JsonError(message: String)
+    
+}
+
+public struct FfiConverterTypeE2eIdentityError: FfiConverterRustBuffer {
+    typealias SwiftType = E2eIdentityError
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> E2eIdentityError {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        
+
+        
+        case 1: return .NotYetSupported(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 2: return .CryptoError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 3: return .IdentityError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 4: return .UrlError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 5: return .JsonError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: E2eIdentityError, into buf: inout [UInt8]) {
+        switch value {
+
+        
+
+        
+        case let .NotYetSupported(message):
+            writeInt(&buf, Int32(1))
+            FfiConverterString.write(message, into: &buf)
+        case let .CryptoError(message):
+            writeInt(&buf, Int32(2))
+            FfiConverterString.write(message, into: &buf)
+        case let .IdentityError(message):
+            writeInt(&buf, Int32(3))
+            FfiConverterString.write(message, into: &buf)
+        case let .UrlError(message):
+            writeInt(&buf, Int32(4))
+            FfiConverterString.write(message, into: &buf)
+        case let .JsonError(message):
+            writeInt(&buf, Int32(5))
+            FfiConverterString.write(message, into: &buf)
+
+        
+        }
+    }
+}
+
+
+extension E2eIdentityError: Equatable, Hashable {}
+
+extension E2eIdentityError: Error { }
+
 fileprivate extension NSLock {
     func withLock<T>(f: () throws -> T) rethrows -> T {
         self.lock()
@@ -2271,7 +2870,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_8881_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_13ff_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -2355,6 +2954,27 @@ fileprivate struct FfiConverterOptionDuration: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterDuration.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeChallenge: FfiConverterRustBuffer {
+    typealias SwiftType = Challenge?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeChallenge.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeChallenge.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -2625,6 +3245,30 @@ fileprivate struct FfiConverterDictionaryStringSequenceUInt8: FfiConverterRustBu
  * Typealias from the type name used in the UDL file to the builtin type.  This
  * is needed because the UDL type name is used in function/method signatures.
  */
+public typealias Account = [UInt8]
+public struct FfiConverterTypeAccount: FfiConverter {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Account {
+        return try FfiConverterSequenceUInt8.read(from: &buf)
+    }
+
+    public static func write(_ value: Account, into buf: inout [UInt8]) {
+        return FfiConverterSequenceUInt8.write(value, into: &buf)
+    }
+
+    public static func lift(_ value: RustBuffer) throws -> Account {
+        return try FfiConverterSequenceUInt8.lift(value)
+    }
+
+    public static func lower(_ value: Account) -> RustBuffer {
+        return FfiConverterSequenceUInt8.lower(value)
+    }
+}
+
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
 public typealias ClientId = [UInt8]
 public struct FfiConverterTypeClientId: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ClientId {
@@ -2673,6 +3317,30 @@ public struct FfiConverterTypeConversationId: FfiConverter {
  * Typealias from the type name used in the UDL file to the builtin type.  This
  * is needed because the UDL type name is used in function/method signatures.
  */
+public typealias Json = [UInt8]
+public struct FfiConverterTypeJson: FfiConverter {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Json {
+        return try FfiConverterSequenceUInt8.read(from: &buf)
+    }
+
+    public static func write(_ value: Json, into buf: inout [UInt8]) {
+        return FfiConverterSequenceUInt8.write(value, into: &buf)
+    }
+
+    public static func lift(_ value: RustBuffer) throws -> Json {
+        return try FfiConverterSequenceUInt8.lift(value)
+    }
+
+    public static func lower(_ value: Json) -> RustBuffer {
+        return FfiConverterSequenceUInt8.lower(value)
+    }
+}
+
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
 public typealias MemberId = [UInt8]
 public struct FfiConverterTypeMemberId: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MemberId {
@@ -2692,13 +3360,37 @@ public struct FfiConverterTypeMemberId: FfiConverter {
     }
 }
 
+
+/**
+ * Typealias from the type name used in the UDL file to the builtin type.  This
+ * is needed because the UDL type name is used in function/method signatures.
+ */
+public typealias Order = [UInt8]
+public struct FfiConverterTypeOrder: FfiConverter {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Order {
+        return try FfiConverterSequenceUInt8.read(from: &buf)
+    }
+
+    public static func write(_ value: Order, into buf: inout [UInt8]) {
+        return FfiConverterSequenceUInt8.write(value, into: &buf)
+    }
+
+    public static func lift(_ value: RustBuffer) throws -> Order {
+        return try FfiConverterSequenceUInt8.lift(value)
+    }
+
+    public static func lower(_ value: Order) -> RustBuffer {
+        return FfiConverterSequenceUInt8.lower(value)
+    }
+}
+
 public func `version`()  -> String {
     return try! FfiConverterString.lift(
         try!
     
     rustCall() {
     
-    CoreCrypto_8881_version($0)
+    CoreCrypto_13ff_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,235 +46,307 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_8881_CoreCrypto_object_free(
+void ffi_CoreCrypto_13ff_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_8881_CoreCrypto_new(
+void*_Nonnull CoreCrypto_13ff_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_8881_CoreCrypto_deferred_init(
+void*_Nonnull CoreCrypto_13ff_CoreCrypto_deferred_init(
       RustBuffer path,RustBuffer key,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_mls_init(
+void CoreCrypto_13ff_CoreCrypto_mls_init(
       void*_Nonnull ptr,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_restore_from_disk(
+void CoreCrypto_13ff_CoreCrypto_restore_from_disk(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_set_callbacks(
+void CoreCrypto_13ff_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_13ff_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_13ff_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_8881_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_13ff_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_create_conversation(
+void CoreCrypto_13ff_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_8881_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_13ff_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_8881_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_13ff_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_13ff_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_13ff_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_13ff_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_13ff_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_13ff_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_wipe_conversation(
+void CoreCrypto_13ff_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_13ff_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_13ff_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_13ff_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_13ff_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_13ff_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_13ff_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_13ff_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_13ff_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_13ff_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_13ff_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_13ff_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_13ff_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_get_client_ids(
+RustBuffer CoreCrypto_13ff_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_13ff_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_reseed_rng(
+void CoreCrypto_13ff_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_commit_accepted(
+void CoreCrypto_13ff_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_13ff_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_clear_pending_commit(
+void CoreCrypto_13ff_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_proteus_init(
+void CoreCrypto_13ff_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_13ff_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_proteus_session_save(
+void CoreCrypto_13ff_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_proteus_session_delete(
+void CoreCrypto_13ff_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_8881_CoreCrypto_proteus_session_exists(
+int8_t CoreCrypto_13ff_CoreCrypto_proteus_session_exists(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_new_prekey_auto(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_new_prekey_auto(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_fingerprint_local(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_local(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_fingerprint_remote(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_remote(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_CoreCrypto_proteus_fingerprint_prekeybundle(
+RustBuffer CoreCrypto_13ff_CoreCrypto_proteus_fingerprint_prekeybundle(
       void*_Nonnull ptr,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_8881_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_13ff_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_8881_CoreCryptoCallbacks_init_callback(
+void*_Nonnull CoreCrypto_13ff_CoreCrypto_new_acme_enrollment(
+      void*_Nonnull ptr,RustBuffer ciphersuite,
+    RustCallStatus *_Nonnull out_status
+    );
+void ffi_CoreCrypto_13ff_WireE2eIdentity_object_free(
+      void*_Nonnull ptr,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_directory_response(
+      void*_Nonnull ptr,RustBuffer directory,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_account_request(
+      void*_Nonnull ptr,RustBuffer directory,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_account_response(
+      void*_Nonnull ptr,RustBuffer account,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_order_request(
+      void*_Nonnull ptr,RustBuffer handle,RustBuffer client_id,uint32_t expiry_days,RustBuffer directory,RustBuffer account,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_order_response(
+      void*_Nonnull ptr,RustBuffer order,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_authz_request(
+      void*_Nonnull ptr,RustBuffer url,RustBuffer account,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_authz_response(
+      void*_Nonnull ptr,RustBuffer authz,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_create_dpop_token(
+      void*_Nonnull ptr,RustBuffer access_token_url,RustBuffer user_id,uint64_t client_id,RustBuffer domain,RustBuffer client_id_challenge,RustBuffer backend_nonce,uint64_t expiry_seconds,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_new_challenge_request(
+      void*_Nonnull ptr,RustBuffer handle,RustBuffer account,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+void CoreCrypto_13ff_WireE2eIdentity_new_challenge_response(
+      void*_Nonnull ptr,RustBuffer challenge,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_check_order_request(
+      void*_Nonnull ptr,RustBuffer order_url,RustBuffer account,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_check_order_response(
+      void*_Nonnull ptr,RustBuffer order,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_finalize_request(
+      void*_Nonnull ptr,RustBuffer domains,RustBuffer order,RustBuffer account,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_finalize_response(
+      void*_Nonnull ptr,RustBuffer finalize,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_certificate_request(
+      void*_Nonnull ptr,RustBuffer finalize,RustBuffer account,RustBuffer previous_nonce,
+    RustCallStatus *_Nonnull out_status
+    );
+RustBuffer CoreCrypto_13ff_WireE2eIdentity_certificate_response(
+      void*_Nonnull ptr,RustBuffer certificate_chain,
+    RustCallStatus *_Nonnull out_status
+    );
+void ffi_CoreCrypto_13ff_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_8881_version(
+RustBuffer CoreCrypto_13ff_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_8881_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_13ff_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_8881_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_13ff_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_8881_rustbuffer_free(
+void ffi_CoreCrypto_13ff_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_8881_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_13ff_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -283,9 +283,107 @@ interface CoreCrypto {
 
     [Throws=CryptoError]
     void proteus_cryptobox_migrate([ByRef] string path);
+
+    [Throws=CryptoError]
+    WireE2eIdentity new_acme_enrollment(CiphersuiteName ciphersuite);
+};
+
+[Custom]
+typedef sequence<u8> Json;
+
+[Custom]
+typedef sequence<u8> Account;
+
+[Custom]
+typedef sequence<u8> Order;
+
+[Error]
+enum E2eIdentityError {
+    "NotYetSupported",
+    "CryptoError",
+    "IdentityError",
+    "UrlError",
+    "JsonError",
+};
+
+dictionary AcmeDirectory {
+    string new_nonce;
+    string new_account;
+    string new_order;
+};
+
+dictionary NewOrder {
+    Json delegate;
+    sequence<string> authorizations;
+};
+
+dictionary NewAuthz {
+    string identifier;
+    Challenge? wire_http_challenge;
+    Challenge? wire_oidc_challenge;
+};
+
+dictionary Challenge {
+    Json delegate;
+    string url;
+};
+
+dictionary Finalize {
+    Json delegate;
+    string certificate_url;
+};
+
+interface WireE2eIdentity {
+
+    [Throws=E2eIdentityError]
+    AcmeDirectory directory_response(Json directory);
+
+    [Throws=E2eIdentityError]
+    Json new_account_request(AcmeDirectory directory, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    Json new_account_response(Json account);
+
+    [Throws=E2eIdentityError]
+    Json new_order_request(string handle, string client_id, u32 expiry_days, AcmeDirectory directory, Account account, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    NewOrder new_order_response(Json order);
+
+    [Throws=E2eIdentityError]
+    Json new_authz_request(string url, Account account, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    NewAuthz new_authz_response(Json authz);
+
+    [Throws=E2eIdentityError]
+    string create_dpop_token(string access_token_url, string user_id, u64 client_id, string domain, Challenge client_id_challenge, string backend_nonce, u64 expiry_seconds);
+
+    [Throws=E2eIdentityError]
+    Json new_challenge_request(Challenge handle, Account account, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    void new_challenge_response(Json challenge);
+
+    [Throws=E2eIdentityError]
+    Json check_order_request(string order_url, Account account, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    Order check_order_response(Json order);
+
+    [Throws=E2eIdentityError]
+    Json finalize_request(sequence<string> domains, Order order, Account account, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    Finalize finalize_response(Json finalize);
+
+    [Throws=E2eIdentityError]
+    Json certificate_request(Finalize finalize, Account account, string previous_nonce);
+
+    [Throws=E2eIdentityError]
+    sequence<string> certificate_response(string certificate_chain);
 };
 
 namespace CoreCrypto {
-
     string version();
 };

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -33,7 +33,7 @@ bench-in-db = []
 [dependencies]
 async-recursion = "1.0"
 thiserror = "1.0"
-derive_more = { version = "0.99", features = ["deref"] }
+derive_more = { version = "0.99", features = ["from", "into", "deref"] }
 cfg-if = "1.0"
 hex = "0.4"
 
@@ -43,6 +43,12 @@ openmls_traits = "0.1"
 tls_codec = "0.2"
 serde = "1.0"
 serde_json = "1.0"
+url = "2.3"
+
+[dependencies.wire-e2e-identity]
+version = "0.1.0"
+package = "wire-e2e-identity"
+git = "https://github.com/wireapp/rusty-jwt-tools"
 
 [dependencies.proteus-wasm]
 version = "2.0"

--- a/crypto/src/e2e_identity/crypto.rs
+++ b/crypto/src/e2e_identity/crypto.rs
@@ -1,0 +1,36 @@
+use super::error::*;
+use crate::prelude::MlsCiphersuite;
+use mls_crypto_provider::MlsCryptoProvider;
+use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsCryptoProvider};
+use wire_e2e_identity::prelude::JwsAlgorithm;
+
+impl super::WireE2eIdentity {
+    pub(super) fn new_sign_keypair(
+        ciphersuite: MlsCiphersuite,
+        backend: &MlsCryptoProvider,
+    ) -> E2eIdentityResult<Vec<u8>> {
+        let crypto = backend.crypto();
+        let cs = openmls_traits::types::Ciphersuite::from(ciphersuite);
+        let (sk, _pk) = crypto.signature_key_gen(cs.signature_algorithm())?;
+        Ok(sk)
+    }
+}
+
+impl TryFrom<MlsCiphersuite> for JwsAlgorithm {
+    type Error = E2eIdentityError;
+
+    fn try_from(cs: MlsCiphersuite) -> E2eIdentityResult<Self> {
+        let cs = openmls_traits::types::Ciphersuite::from(cs);
+        Ok(match cs {
+            Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => JwsAlgorithm::Ed25519,
+            Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => JwsAlgorithm::P256,
+            Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => JwsAlgorithm::P384,
+            Ciphersuite::MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448
+            | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
+            | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => {
+                return Err(E2eIdentityError::NotYetSupported)
+            }
+        })
+    }
+}

--- a/crypto/src/e2e_identity/error.rs
+++ b/crypto/src/e2e_identity/error.rs
@@ -1,0 +1,24 @@
+//! End to end identity errors
+
+/// Wrapper over a [Result] of an end to end identity error
+pub type E2eIdentityResult<T> = Result<T, E2eIdentityError>;
+
+/// End to end identity errors
+#[derive(Debug, thiserror::Error)]
+pub enum E2eIdentityError {
+    /// Incoming support
+    #[error("Not yet supported")]
+    NotYetSupported,
+    /// Error generating keys
+    #[error(transparent)]
+    CryptoError(#[from] openmls_traits::types::CryptoError),
+    /// Error creating client Dpop token or acne error
+    #[error(transparent)]
+    IdentityError(#[from] wire_e2e_identity::prelude::E2eIdentityError),
+    /// Error parsing a URL
+    #[error(transparent)]
+    UrlError(#[from] url::ParseError),
+    /// Json error
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+}

--- a/crypto/src/e2e_identity/mod.rs
+++ b/crypto/src/e2e_identity/mod.rs
@@ -1,0 +1,253 @@
+use crate::{prelude::MlsCentral, prelude::MlsCiphersuite};
+use error::*;
+use mls_crypto_provider::MlsCryptoProvider;
+use wire_e2e_identity::prelude::RustyE2eIdentity;
+
+mod crypto;
+pub mod error;
+pub mod types;
+
+type Json = Vec<u8>;
+
+impl MlsCentral {
+    /// TODO
+    pub fn new_acme_enrollment(&self, ciphersuite: MlsCiphersuite) -> E2eIdentityResult<WireE2eIdentity> {
+        WireE2eIdentity::try_new(&self.mls_backend, ciphersuite)
+    }
+}
+
+/// Wire end to end identity solution for fetching a x509 certificate which identifies a client.
+///
+/// Here are the steps to follow to implement it:
+#[derive(Debug)]
+pub struct WireE2eIdentity(RustyE2eIdentity);
+
+impl WireE2eIdentity {
+    /// TODO
+    pub fn try_new(backend: &MlsCryptoProvider, ciphersuite: MlsCiphersuite) -> E2eIdentityResult<Self> {
+        let alg = ciphersuite.try_into()?;
+        let sign_kp = Self::new_sign_keypair(ciphersuite, backend)?;
+        Ok(Self(RustyE2eIdentity::try_new(alg, sign_kp)?))
+    }
+
+    /// TODO
+    pub fn directory_response(&self, directory: Json) -> E2eIdentityResult<types::E2eiAcmeDirectory> {
+        let directory = serde_json::from_slice(&directory[..])?;
+        Ok(self.0.acme_directory_response(directory)?.into())
+    }
+
+    /// TODO
+    pub fn new_account_request(
+        &self,
+        directory: types::E2eiAcmeDirectory,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let account = self
+            .0
+            .acme_new_account_request(&directory.try_into()?, previous_nonce)?;
+        let account = serde_json::to_vec(&account)?;
+        Ok(account)
+    }
+
+    /// TODO
+    pub fn new_account_response(&self, account: Json) -> E2eIdentityResult<types::E2eiAcmeAccount> {
+        let account = serde_json::from_slice(&account[..])?;
+        self.0.acme_new_account_response(account)?.try_into()
+    }
+
+    /// TODO
+    pub fn new_order_request(
+        &self,
+        handle: String,
+        client_id: String,
+        expiry_days: u32,
+        directory: types::E2eiAcmeDirectory,
+        account: types::E2eiAcmeAccount,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let expiry = core::time::Duration::from_secs(u64::from(expiry_days) * 3600 * 24);
+        let order = self.0.acme_new_order_request(
+            handle,
+            client_id,
+            expiry,
+            &directory.try_into()?,
+            &account.try_into()?,
+            previous_nonce,
+        )?;
+        let order = serde_json::to_vec(&order)?;
+        Ok(order)
+    }
+
+    /// TODO
+    pub fn new_order_response(&self, order: Json) -> E2eIdentityResult<types::E2eiNewAcmeOrder> {
+        let order = serde_json::from_slice(&order[..])?;
+        self.0.acme_new_order_response(order)?.try_into()
+    }
+
+    /// TODO
+    pub fn new_authz_request(
+        &self,
+        url: String,
+        account: types::E2eiAcmeAccount,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let authz = self
+            .0
+            .acme_new_authz_request(&url.parse()?, &account.try_into()?, previous_nonce)?;
+        let authz = serde_json::to_vec(&authz)?;
+        Ok(authz)
+    }
+
+    /// TODO
+    pub fn new_authz_response(&self, authz: Json) -> E2eIdentityResult<types::E2eiNewAcmeAuthz> {
+        let authz = serde_json::from_slice(&authz[..])?;
+        self.0.acme_new_authz_response(authz)?.try_into()
+    }
+
+    /// TODO
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_dpop_token(
+        &self,
+        access_token_url: String,
+        user_id: String,
+        client_id: u64,
+        domain: String,
+        client_id_challenge: types::E2eiAcmeChall,
+        backend_nonce: String,
+        expiry_seconds: u64,
+    ) -> E2eIdentityResult<String> {
+        let expiry = core::time::Duration::from_secs(expiry_seconds);
+        Ok(self.0.new_dpop_token(
+            &access_token_url.parse()?,
+            user_id,
+            client_id,
+            domain,
+            &client_id_challenge.try_into()?,
+            backend_nonce,
+            expiry,
+        )?)
+    }
+
+    /// TODO
+    pub fn new_challenge_request(
+        &self,
+        handle_chall: types::E2eiAcmeChall,
+        account: types::E2eiAcmeAccount,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let challenge =
+            self.0
+                .acme_new_challenge_request(&handle_chall.try_into()?, &account.try_into()?, previous_nonce)?;
+        let challenge = serde_json::to_vec(&challenge)?;
+        Ok(challenge)
+    }
+
+    /// TODO
+    pub fn new_challenge_response(&self, challenge: Json) -> E2eIdentityResult<()> {
+        let challenge = serde_json::from_slice(&challenge[..])?;
+        Ok(self.0.acme_new_challenge_response(challenge)?)
+    }
+
+    /// TODO
+    pub fn check_order_request(
+        &self,
+        order_url: String,
+        account: types::E2eiAcmeAccount,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let order = self
+            .0
+            .acme_check_order_request(order_url.parse()?, &account.try_into()?, previous_nonce)?;
+        let order = serde_json::to_vec(&order)?;
+        Ok(order)
+    }
+
+    /// TODO
+    pub fn check_order_response(&self, order: Json) -> E2eIdentityResult<types::E2eiAcmeOrder> {
+        let order = serde_json::from_slice(&order[..])?;
+        self.0.acme_check_order_response(order)?.try_into()
+    }
+
+    /// TODO
+    pub fn finalize_request(
+        &self,
+        domains: Vec<String>,
+        order: types::E2eiAcmeOrder,
+        account: types::E2eiAcmeAccount,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let finalize =
+            self.0
+                .acme_finalize_request(domains, order.try_into()?, &account.try_into()?, previous_nonce)?;
+        let finalize = serde_json::to_vec(&finalize)?;
+        Ok(finalize)
+    }
+
+    /// TODO
+    pub fn finalize_response(&self, finalize: Json) -> E2eIdentityResult<types::E2eiAcmeFinalize> {
+        let finalize = serde_json::from_slice(&finalize[..])?;
+        self.0.acme_finalize_response(finalize)?.try_into()
+    }
+
+    /// TODO
+    pub fn certificate_request(
+        &self,
+        finalize: types::E2eiAcmeFinalize,
+        account: types::E2eiAcmeAccount,
+        previous_nonce: String,
+    ) -> E2eIdentityResult<Json> {
+        let certificate =
+            self.0
+                .acme_x509_certificate_request(finalize.try_into()?, account.try_into()?, previous_nonce)?;
+        let certificate = serde_json::to_vec(&certificate)?;
+        Ok(certificate)
+    }
+
+    /// TODO
+    pub fn certificate_response(&self, certificate_chain: String) -> E2eIdentityResult<Vec<String>> {
+        Ok(self.0.acme_x509_certificate_response(certificate_chain)?)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::test_utils::*;
+    use openmls::prelude::SignatureScheme;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn provided_sign_key_should_sign_account_request(case: TestCase) {
+        #[cfg(not(target_family = "wasm"))]
+        let supported_alg = [
+            SignatureScheme::ED25519,
+            SignatureScheme::ECDSA_SECP256R1_SHA256,
+            SignatureScheme::ECDSA_SECP384R1_SHA384,
+        ];
+        // EC signature are not supported because not supported by ring on WASM
+        #[cfg(target_family = "wasm")]
+        let supported_alg = [SignatureScheme::ED25519];
+
+        if supported_alg.contains(&case.signature_scheme()) {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
+                Box::pin(async move {
+                    let enrollment = cc.new_acme_enrollment(case.ciphersuite()).unwrap();
+                    let directory = serde_json::json!({
+                        "newNonce": "https://example.com/acme/new-nonce",
+                        "newAccount": "https://example.com/acme/new-account",
+                        "newOrder": "https://example.com/acme/new-order"
+                    });
+                    let directory = serde_json::to_vec(&directory).unwrap();
+                    let directory = enrollment.directory_response(directory).unwrap();
+
+                    let previous_nonce = "YUVndEZQVTV6ZUNlUkJxRG10c0syQmNWeW1kanlPbjM".to_string();
+                    let account_req = enrollment.new_account_request(directory, previous_nonce);
+                    assert!(account_req.is_ok());
+                })
+            })
+            .await
+        }
+    }
+}

--- a/crypto/src/e2e_identity/types.rs
+++ b/crypto/src/e2e_identity/types.rs
@@ -1,0 +1,212 @@
+//! We only expose byte arrays through the FFI so we do all the conversions here
+
+use super::error::{E2eIdentityError, E2eIdentityResult};
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct E2eiAcmeDirectory {
+    /// TODO
+    pub new_nonce: String,
+    /// TODO
+    pub new_account: String,
+    /// TODO
+    pub new_order: String,
+}
+
+impl From<wire_e2e_identity::prelude::AcmeDirectory> for E2eiAcmeDirectory {
+    fn from(directory: wire_e2e_identity::prelude::AcmeDirectory) -> Self {
+        Self {
+            new_nonce: directory.new_nonce.to_string(),
+            new_account: directory.new_account.to_string(),
+            new_order: directory.new_order.to_string(),
+        }
+    }
+}
+
+impl TryFrom<E2eiAcmeDirectory> for wire_e2e_identity::prelude::AcmeDirectory {
+    type Error = E2eIdentityError;
+
+    fn try_from(directory: E2eiAcmeDirectory) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            new_nonce: directory.new_nonce.parse()?,
+            new_account: directory.new_account.parse()?,
+            new_order: directory.new_order.parse()?,
+        })
+    }
+}
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize, derive_more::From, derive_more::Into, derive_more::Deref)]
+pub struct E2eiAcmeAccount(super::Json);
+
+impl TryFrom<wire_e2e_identity::prelude::E2eiAcmeAccount> for E2eiAcmeAccount {
+    type Error = E2eIdentityError;
+
+    fn try_from(from: wire_e2e_identity::prelude::E2eiAcmeAccount) -> E2eIdentityResult<Self> {
+        Ok(serde_json::to_vec(&from)?.into())
+    }
+}
+
+impl TryFrom<E2eiAcmeAccount> for wire_e2e_identity::prelude::E2eiAcmeAccount {
+    type Error = E2eIdentityError;
+
+    fn try_from(from: E2eiAcmeAccount) -> E2eIdentityResult<Self> {
+        Ok(serde_json::to_value(from)?.into())
+    }
+}
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct E2eiNewAcmeOrder {
+    /// TODO
+    pub delegate: super::Json,
+    /// TODO
+    pub authorizations: Vec<String>,
+}
+
+impl TryFrom<wire_e2e_identity::prelude::E2eiNewAcmeOrder> for E2eiNewAcmeOrder {
+    type Error = E2eIdentityError;
+
+    fn try_from(new_order: wire_e2e_identity::prelude::E2eiNewAcmeOrder) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            authorizations: new_order.authorizations.iter().map(url::Url::to_string).collect(),
+            delegate: serde_json::to_vec(&new_order.new_order)?,
+        })
+    }
+}
+
+impl TryFrom<E2eiNewAcmeOrder> for wire_e2e_identity::prelude::E2eiNewAcmeOrder {
+    type Error = E2eIdentityError;
+
+    fn try_from(new_order: E2eiNewAcmeOrder) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            authorizations: new_order.authorizations.iter().try_fold(
+                vec![],
+                |mut acc, u| -> E2eIdentityResult<Vec<url::Url>> {
+                    acc.push(u.parse()?);
+                    Ok(acc)
+                },
+            )?,
+            new_order: serde_json::to_value(new_order.delegate)?,
+        })
+    }
+}
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct E2eiNewAcmeAuthz {
+    /// TODO
+    pub identifier: String,
+    /// TODO
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wire_http_challenge: Option<E2eiAcmeChall>,
+    /// TODO
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wire_oidc_challenge: Option<E2eiAcmeChall>,
+}
+
+impl TryFrom<wire_e2e_identity::prelude::E2eiNewAcmeAuthz> for E2eiNewAcmeAuthz {
+    type Error = E2eIdentityError;
+
+    fn try_from(authz: wire_e2e_identity::prelude::E2eiNewAcmeAuthz) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            identifier: authz.identifier,
+            wire_http_challenge: authz.wire_http_challenge.map(TryFrom::try_from).transpose()?,
+            wire_oidc_challenge: authz.wire_oidc_challenge.map(TryFrom::try_from).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<E2eiNewAcmeAuthz> for wire_e2e_identity::prelude::E2eiNewAcmeAuthz {
+    type Error = E2eIdentityError;
+
+    fn try_from(authz: E2eiNewAcmeAuthz) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            identifier: authz.identifier,
+            wire_http_challenge: authz.wire_http_challenge.map(TryFrom::try_from).transpose()?,
+            wire_oidc_challenge: authz.wire_oidc_challenge.map(TryFrom::try_from).transpose()?,
+        })
+    }
+}
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct E2eiAcmeChall {
+    /// TODO
+    pub delegate: super::Json,
+    /// TODO
+    pub url: String,
+}
+
+impl TryFrom<wire_e2e_identity::prelude::E2eiAcmeChall> for E2eiAcmeChall {
+    type Error = E2eIdentityError;
+
+    fn try_from(chall: wire_e2e_identity::prelude::E2eiAcmeChall) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            delegate: serde_json::to_vec(&chall.chall)?,
+            url: chall.url.to_string(),
+        })
+    }
+}
+
+impl TryFrom<E2eiAcmeChall> for wire_e2e_identity::prelude::E2eiAcmeChall {
+    type Error = E2eIdentityError;
+
+    fn try_from(chall: E2eiAcmeChall) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            chall: serde_json::to_value(chall.delegate)?,
+            url: chall.url.parse()?,
+        })
+    }
+}
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize, derive_more::From, derive_more::Into, derive_more::Deref)]
+pub struct E2eiAcmeOrder(super::Json);
+
+impl TryFrom<wire_e2e_identity::prelude::E2eiAcmeOrder> for E2eiAcmeOrder {
+    type Error = E2eIdentityError;
+
+    fn try_from(from: wire_e2e_identity::prelude::E2eiAcmeOrder) -> E2eIdentityResult<Self> {
+        Ok(serde_json::to_vec(&from)?.into())
+    }
+}
+
+impl TryFrom<E2eiAcmeOrder> for wire_e2e_identity::prelude::E2eiAcmeOrder {
+    type Error = E2eIdentityError;
+
+    fn try_from(from: E2eiAcmeOrder) -> E2eIdentityResult<Self> {
+        Ok(serde_json::to_value(from)?.into())
+    }
+}
+
+/// TODO
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct E2eiAcmeFinalize {
+    /// TODO
+    pub certificate_url: String,
+    /// TODO
+    pub delegate: super::Json,
+}
+
+impl TryFrom<wire_e2e_identity::prelude::E2eiAcmeFinalize> for E2eiAcmeFinalize {
+    type Error = E2eIdentityError;
+
+    fn try_from(finalize: wire_e2e_identity::prelude::E2eiAcmeFinalize) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            certificate_url: finalize.certificate_url.to_string(),
+            delegate: serde_json::to_vec(&finalize.finalize)?,
+        })
+    }
+}
+
+impl TryFrom<E2eiAcmeFinalize> for wire_e2e_identity::prelude::E2eiAcmeFinalize {
+    type Error = E2eIdentityError;
+
+    fn try_from(finalize: E2eiAcmeFinalize) -> E2eIdentityResult<Self> {
+        Ok(Self {
+            certificate_url: finalize.certificate_url.parse()?,
+            finalize: serde_json::to_value(finalize.delegate)?,
+        })
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -41,6 +41,9 @@ mod error;
 /// MLS Abstraction
 pub mod mls;
 
+/// re-export [rusty-jwt-tools](https://github.com/wireapp/rusty-jwt-tools) API
+pub mod e2e_identity;
+
 #[cfg(feature = "proteus")]
 /// Proteus Abstraction
 pub mod proteus;
@@ -60,6 +63,14 @@ pub mod prelude {
     pub use mls_crypto_provider::{EntropySeed, RawEntropySeed};
 
     pub use crate::{
+        e2e_identity::{
+            error::{E2eIdentityError, E2eIdentityResult},
+            types::{
+                E2eiAcmeAccount, E2eiAcmeChall, E2eiAcmeDirectory, E2eiAcmeFinalize, E2eiAcmeOrder, E2eiNewAcmeAuthz,
+                E2eiNewAcmeOrder,
+            },
+            WireE2eIdentity,
+        },
         error::*,
         mls::{
             client::*,

--- a/crypto/src/test_utils/fixtures.rs
+++ b/crypto/src/test_utils/fixtures.rs
@@ -16,6 +16,7 @@
 
 pub use crate::mls::credential::CredentialSupplier;
 use crate::prelude::{MlsConversationConfiguration, MlsCustomConfiguration};
+use openmls_traits::types::SignatureScheme;
 
 use crate::mls::MlsCiphersuite;
 pub use rstest::*;
@@ -102,6 +103,10 @@ impl TestCase {
 
     pub fn ciphersuite(&self) -> MlsCiphersuite {
         self.cfg.ciphersuite
+    }
+
+    pub fn signature_scheme(&self) -> SignatureScheme {
+        openmls::prelude::Ciphersuite::from(self.ciphersuite()).signature_algorithm()
     }
 
     pub fn custom_cfg(&self) -> MlsCustomConfiguration {

--- a/interop/src/clients/mod.rs
+++ b/interop/src/clients/mod.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
 use color_eyre::eyre::Result;
+use core_crypto::prelude::MlsCiphersuite;
 
 pub mod corecrypto;
 #[cfg(feature = "proteus")]
@@ -83,4 +84,9 @@ pub trait EmulatedProteusClient: EmulatedClient {
     async fn encrypt(&mut self, session_id: &str, plaintext: &[u8]) -> Result<Vec<u8>>;
     async fn decrypt(&mut self, session_id: &str, ciphertext: &[u8]) -> Result<Vec<u8>>;
     async fn fingerprint(&self) -> Result<String>;
+}
+
+#[async_trait::async_trait(?Send)]
+pub trait EmulatedE2eIdentityClient: EmulatedClient {
+    async fn new_acme_enrollment(&mut self, ciphersuite: MlsCiphersuite) -> Result<()>;
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Add end to end identity bindings for Android. WASM support is partial and to be continued. Swift bindings are not done.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
