### PR TITLE
fix: Increment IndexedDB store version when crate version changes [CL-127]

### DIFF
--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -25,6 +25,7 @@ mls-keystore = ["dep:openmls_traits"]
 proteus-keystore = ["dep:proteus-traits"]
 ios-wal-compat = ["dep:security-framework"]
 memory-cache = ["dep:lru"]
+idb-regression-test = []
 
 [dependencies]
 thiserror = "1.0"
@@ -97,6 +98,7 @@ rstest = "0.16"
 rstest_reuse = "0.4"
 async-std = { version = "1.12", features = ["attributes"] }
 futures-lite = "1.12"
+core-crypto-keystore = { path = ".", features = ["idb-regression-test"] }
 
 [dev-dependencies.proteus-wasm]
 version = "2.0"

--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -205,4 +205,9 @@ impl Connection {
     pub fn is_cache_enabled(&self) -> bool {
         self.cache_enabled.load(std::sync::atomic::Ordering::Relaxed)
     }
+
+    #[inline]
+    pub fn is_cache_supported(&self) -> bool {
+        cfg!(feature = "memory-cache")
+    }
 }

--- a/keystore/tests/common.rs
+++ b/keystore/tests/common.rs
@@ -21,7 +21,7 @@ pub use core_crypto_keystore::Connection as CryptoKeystore;
 pub use rstest::*;
 pub use rstest_reuse::{self, *};
 
-const TEST_ENCRYPTION_KEY: &str = "test1234";
+pub const TEST_ENCRYPTION_KEY: &str = "test1234";
 
 #[fixture]
 pub fn store_name() -> String {


### PR DESCRIPTION
The IndexedDB store didn't get its upgrade handler triggered, leading to new stores not being created. I made it so that the store version follows a simplified scheme depending on the crate version