### PR TITLE
chore: update JVM publish workflow to build on native platforms

### DIFF
--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -68,7 +68,7 @@ jobs:
     if: github.repository == 'wireapp/core-crypto'
     name: Publish JVM Package
     needs: [build-linux-artifacts, build-darwin-artifacts]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -15,8 +15,59 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  build-linux-artifacts:
+    if: github.repository == 'wireapp/core-crypto'
+    name: Build Linux Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Setup rust"
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "x86_64-unknown-linux-gnu"
+      - name: Setup cargo-make
+        uses: davidB/rust-cargo-make@v1
+      - name: Build Artifacts
+        run: |
+          cd crypto-ffi
+          cargo make jvm
+      - name: Upload x86_64-unknown-linux-gnu artifacts
+        uses: actions/upload-artifact@v3
+        with:
+            name: x86_64-unknown-linux-gnu
+            path: target/x86_64-unknown-linux-gnu/release/*.so
+
+  build-darwin-artifacts:
+    if: github.repository == 'wireapp/core-crypto'
+    name: Build Darwin Artifacts
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: "x86_64-apple-darwin,aarch64-apple-darwin"
+      - name: Setup cargo-make
+        uses: davidB/rust-cargo-make@v1
+      - name: Build Artifacts
+        run: |
+          cd crypto-ffi
+          cargo make jvm
+      - name: Upload x86_64-apple-darwin artifacts
+        uses: actions/upload-artifact@v3
+        with:
+            name: x86_64-apple-darwin
+            path: target/x86_64-apple-darwin/release/*.dylib
+      - name: Upload aarch64-apple-darwin artifacts
+        uses: actions/upload-artifact@v3
+        with:
+            name: aarch64-apple-darwin
+            path: target/aarch64-apple-darwin/release/*.dylib
+
   publish-jvm:
     if: github.repository == 'wireapp/core-crypto'
+    name: Publish JVM Package
+    needs: [build-linux-artifacts, build-darwin-artifacts]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -29,24 +80,21 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
-      - name: "Setup rust"
-        uses: dtolnay/rust-toolchain@stable
+      - name: Download x86_64 Linux Artifact
+        uses: actions/download-artifact@v3
         with:
-          targets: "x86_64-apple-darwin,aarch64-apple-darwin,x86_64-unknown-linux-gnu"
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
-
-      - name: Build JVM package
-        env:
-          CC_x86_64_unknown_linux_gnu: x86_64-unknown-linux-gnu-gcc
-          CXX_x86_64_unknown_linux_gnu: x86_64-unknown-linux-gnu-g++
-          AR_x86_64_unknown_linux_gnu: x86_64-unknown-linux-gnu-ar
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: x86_64-unknown-linux-gnu-gcc
-        run: |
-          brew tap messense/macos-cross-toolchains
-          brew install x86_64-unknown-linux-gnu
-          cd crypto-ffi
-          cargo make copy-jvm-resources
+          name: x86_64-unknown-linux-gnu
+          path: target/x86_64-unknown-linux-gnu/release
+      - name: Download x86_64 Apple Darwin Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: x86_64-apple-darwin
+          path: target/x86_64-apple-darwin/release
+      - name: Download Aarch64 Apple Darwin Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: aarch64-apple-darwin
+          path: target/aarch64-apple-darwin/release
       - name: Publish package
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Publishing CoreCrypto for the JVM no longer supports linux targets

### Causes

Building for linux now only possible on a linux host and the CI job for publishing the JVM package runs on a mac host.

### Solutions

Split up up the JVM publish workflow into three jobs which build the library on each native platform and upload the result as a GitHub Artifacts. The final job download the artifacts and creates and publishes the JVM package.

### Notes

- The `copy-jvm-resources` task is obsolete now since it's now performed by the JVM Gradle file.
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
