### PR TITLE
hotfix: 0.6.0-rc6 [CL-129]

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,11 +11,14 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -73,7 +73,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - uses: Swatinem/rust-cache@v2
@@ -89,3 +89,5 @@ jobs:
         run: |
           npm install
           npm run build
+      - name: Run E2E JS suite
+        run: npm run test:raw

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -6,6 +6,10 @@ concurrency:
 
 on: [push]
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   check-android:
     if: github.repository == 'wireapp/core-crypto'
@@ -46,9 +50,6 @@ jobs:
 
   check-swift:
     runs-on: macos-latest
-    env:
-      CARGO_TERM_COLOR: always
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -65,8 +66,6 @@ jobs:
 
   check-wasm:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,11 +6,13 @@ concurrency:
 
 on: [ push ]
 
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - name: Install rust toolchain

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   docgen:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -13,6 +13,8 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   publish-android:

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -13,6 +13,8 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   build-linux-artifacts:

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -13,6 +13,8 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   publish-swift:

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -13,6 +13,8 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   publish-wasm:

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,12 +8,12 @@ on: [push]
 
 env:
   RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   fmt:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -24,8 +24,6 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -35,8 +33,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -48,8 +44,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -62,8 +56,6 @@ jobs:
 
   proteus-test:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -75,8 +67,6 @@ jobs:
   # extract things unrelated to main tests not to slow them down
   tooling-test:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -89,8 +79,6 @@ jobs:
 
   wasm-build:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     strategy:
       matrix:
         workspace: [ "crypto", "keystore", "mls-provider" ]
@@ -107,8 +95,6 @@ jobs:
 
   wasm-test:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     strategy:
       matrix:
         workspace: ["core-crypto", "core-crypto-keystore", "mls-crypto-provider"]
@@ -129,8 +115,6 @@ jobs:
 
   proteus-wasm-test:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -146,8 +130,6 @@ jobs:
 
   e2e-interop-test:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -166,8 +148,6 @@ jobs:
 
   hack:
     runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check
+      - run: cargo check --tests
       - run: cargo check --benches
 
   build:
@@ -90,6 +90,8 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: Swatinem/rust-cache@v2
+      - name: WASM check
+        run: cargo check --tests --target wasm32-unknown-unknown
       - name: WASM build
         run: wasm-pack build --dev --target web ${{ matrix.workspace }}
 
@@ -120,13 +122,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      # - name: Install wasm-pack
+      #   run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: Swatinem/rust-cache@v2
       - name: Run tests (wasm)
         run: |
-          wasm-pack test --chrome --headless keystore --features proteus-keystore -- proteus
-          wasm-pack test --chrome --headless crypto --features proteus,cryptobox-migrate -- proteus
+          cargo test --release --features proteus-keystore -p core-crypto-keystore -- proteus
+          cargo test --release crypto --features proteus,cryptobox-migrate -- proteus
+      # - name: Run tests (wasm)
+      #   run: |
+      #     wasm-pack test --chrome --headless keystore --features proteus-keystore -- proteus
+      #     wasm-pack test --chrome --headless crypto --features proteus,cryptobox-migrate -- proteus
 
   e2e-interop-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,15 +105,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      # - name: Install wasm-pack
-      #   run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: stable
       - uses: Swatinem/rust-cache@v2
       - name: Run tests (wasm)
         run: cargo test --release --target wasm32-unknown-unknown -p ${{ matrix.workspace }}
-        # run: cargo test --target wasm32-unknown-unknown
 
   proteus-wasm-test:
     runs-on: ubuntu-latest
@@ -122,17 +119,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      # - name: Install wasm-pack
-      #   run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests (wasm)
+      - name: Run tests (wasm w/ wasm-pack)
         run: |
-          cargo test --release --features proteus-keystore -p core-crypto-keystore -- proteus
-          cargo test --release crypto --features proteus,cryptobox-migrate -- proteus
-      # - name: Run tests (wasm)
-      #   run: |
-      #     wasm-pack test --chrome --headless keystore --features proteus-keystore -- proteus
-      #     wasm-pack test --chrome --headless crypto --features proteus,cryptobox-migrate -- proteus
+          wasm-pack test --chrome --headless keystore --features proteus-keystore -- proteus
+          wasm-pack test --chrome --headless crypto --features proteus,cryptobox-migrate -- proteus
 
   e2e-interop-test:
     runs-on: ubuntu-latest

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -40,8 +40,10 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 async-lock = "2.5"
 serde-wasm-bindgen = "0.4"
+serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 js-sys = "0.3"
+web-sys = "0.3"
 
 [build-dependencies]
 # UniFFI - Android + iOS bindings - Build support

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -94,6 +94,7 @@ args = [
 
 [tasks.wasm-build]
 command = "wasm-pack"
+# env = { "WASM_BINDGEN_WEAKREF" = 1, "WASM_BINDGEN_EXTERNREF" = 1 }
 args = [
     "build",
     "--out-dir", "bindings/js/wasm",

--- a/crypto-ffi/bindings/js/jest.config.js
+++ b/crypto-ffi/bindings/js/jest.config.js
@@ -6,4 +6,8 @@ export default {
   moduleDirectories: ["node_modules"],
   globalSetup: "<rootDir>/test/setup.js",
   globalTeardown: "<rootDir>/test/teardown.js",
+  forceExit: true,
+  cache: false,
+  detectOpenHandles: true,
+  verbose: true,
 };

--- a/crypto-ffi/bindings/js/rollup.config.js
+++ b/crypto-ffi/bindings/js/rollup.config.js
@@ -65,7 +65,7 @@ const rollup = {
         rust({
             cargoArgs,
             // wasmBindgenArgs: ["--weak-refs", "--reference-types"],
-            // wasmOptArgs: ["-Os"],
+            wasmOptArgs: ["-Os"],
         }),
         ts({
             tsconfig: paths.tsconfig,

--- a/crypto-ffi/bindings/js/rollup.config.test.js
+++ b/crypto-ffi/bindings/js/rollup.config.test.js
@@ -1,5 +1,5 @@
 import html from "@rollup/plugin-html";
-import config from "./rollup.config";
+import config from "./rollup.config.js";
 
 config.plugins.push(html());
 

--- a/crypto-ffi/bindings/js/test/setup.js
+++ b/crypto-ffi/bindings/js/test/setup.js
@@ -2,8 +2,11 @@ import { setup as setupDevServer } from "jest-dev-server";
 
 export default async function globalSetup() {
   await setupDevServer({
-    command: "npx http-server platforms/web -g -p 3000",
+    command: "npm run test:http-server",
     launchTimeout: 5000,
+    host: "127.0.0.1",
     port: 3000,
+    protocol: "http",
+    usedPortAction: "kill",
   });
 }

--- a/crypto-ffi/bindings/js/tsconfig.json
+++ b/crypto-ffi/bindings/js/tsconfig.json
@@ -8,7 +8,7 @@
     "target": "es2020", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "es2020",                  /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -785,7 +785,7 @@ impl CoreCrypto<'_> {
 impl CoreCrypto<'_> {
     /// See [core_crypto::proteus::ProteusCentral::try_new]
     pub fn proteus_init(&self) -> CryptoResult<()> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -799,7 +799,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::session_from_prekey]
     pub fn proteus_session_from_prekey(&self, session_id: &str, prekey: &[u8]) -> CryptoResult<()> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             let _ = future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -815,7 +815,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::session_from_message]
     pub fn proteus_session_from_message(&self, session_id: &str, envelope: &[u8]) -> CryptoResult<Vec<u8>> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             let (_, payload) = future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -832,7 +832,7 @@ impl CoreCrypto<'_> {
     /// See [core_crypto::proteus::ProteusCentral::session_save]
     /// **Note**: This isn't usually needed as persisting sessions happens automatically when decrypting/encrypting messages and initializing Sessions
     pub fn proteus_session_save(&self, session_id: &str) -> CryptoResult<()> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -846,7 +846,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::session_delete]
     pub fn proteus_session_delete(&self, session_id: &str) -> CryptoResult<()> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -860,7 +860,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::session_exists]
     pub fn proteus_session_exists(&self, session_id: &str) -> CryptoResult<bool> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             self.central
                 .lock()
                 .map_err(|_| CryptoError::LockPoisonError)?
@@ -870,7 +870,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::decrypt]
     pub fn proteus_decrypt(&self, session_id: &str, ciphertext: &[u8]) -> CryptoResult<Vec<u8>> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -884,7 +884,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::encrypt]
     pub fn proteus_encrypt(&self, session_id: &str, plaintext: &[u8]) -> CryptoResult<Vec<u8>> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -902,7 +902,7 @@ impl CoreCrypto<'_> {
         sessions: Vec<String>,
         plaintext: &[u8],
     ) -> CryptoResult<std::collections::HashMap<String, Vec<u8>>> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -916,7 +916,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::new_prekey]
     pub fn proteus_new_prekey(&self, prekey_id: u16) -> CryptoResult<Vec<u8>> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -930,7 +930,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::new_prekey_auto]
     pub fn proteus_new_prekey_auto(&self) -> CryptoResult<Vec<u8>> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -944,7 +944,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::fingerprint]
     pub fn proteus_fingerprint(&self) -> CryptoResult<String> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             self.central
                 .lock()
                 .map_err(|_| CryptoError::LockPoisonError)?
@@ -954,7 +954,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::fingerprint_local]
     pub fn proteus_fingerprint_local(&self, session_id: &str) -> CryptoResult<String> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             self.central
                 .lock()
                 .map_err(|_| CryptoError::LockPoisonError)?
@@ -964,7 +964,7 @@ impl CoreCrypto<'_> {
 
     /// See [core_crypto::proteus::ProteusCentral::fingerprint_remote]
     pub fn proteus_fingerprint_remote(&self, session_id: &str) -> CryptoResult<String> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             self.central
                 .lock()
                 .map_err(|_| CryptoError::LockPoisonError)?
@@ -975,14 +975,14 @@ impl CoreCrypto<'_> {
     /// See [core_crypto::proteus::ProteusCentral::fingerprint_prekeybundle]
     /// NOTE: uniffi doesn't support associated functions, so we have to have the self here
     pub fn proteus_fingerprint_prekeybundle(&self, prekey: &[u8]) -> CryptoResult<String> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             core_crypto::proteus::ProteusCentral::fingerprint_prekeybundle(prekey)
         }}
     }
 
     /// See [core_crypto::proteus::ProteusCentral::cryptobox_migrate]
     pub fn proteus_cryptobox_migrate(&self, path: &str) -> CryptoResult<()> {
-        proteus_impl! { self => {
+        proteus_impl! { self.proteus_last_error_code => {
             future::block_on(
                 self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
                     self.central
@@ -995,8 +995,11 @@ impl CoreCrypto<'_> {
     }
 
     /// Returns the latest proteus error code. If 0, no error has occured
+    ///
+    /// NOTE: This will clear the last error code.
     pub fn proteus_last_error_code(&self) -> u32 {
-        self.proteus_last_error_code.load(std::sync::atomic::Ordering::Relaxed)
+        self.proteus_last_error_code
+            .swap(0, std::sync::atomic::Ordering::SeqCst)
     }
 }
 

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -133,11 +133,10 @@ pub type CryptoResult<T> = Result<T, CryptoError>;
 impl CryptoError {
     /// Returns the proteus error code
     pub fn proteus_error_code(&self) -> u32 {
-        if let Self::ProteusError(e) = self {
-            e.error_code()
-        } else {
-            0
-        }
+        let Self::ProteusError(e) = self else {
+            return 0;
+        };
+        e.error_code()
     }
 }
 

--- a/crypto/src/test_utils/proteus_utils.rs
+++ b/crypto/src/test_utils/proteus_utils.rs
@@ -41,7 +41,7 @@ impl CryptoboxLike {
     }
 
     pub fn new_prekey(&mut self) -> proteus_wasm::keys::PreKeyBundle {
-        let prekey_id = (self.prekeys.len() + 1 % u16::MAX as usize) as u16;
+        let prekey_id = ((self.prekeys.len() + 1) % u16::MAX as usize) as u16;
         let prekey = proteus_wasm::keys::PreKey::new(proteus_wasm::keys::PreKeyId::new(prekey_id));
         let prekey_bundle = proteus_wasm::keys::PreKeyBundle::new(self.identity.public_key.clone(), &prekey);
         self.prekeys.push(prekey);

--- a/keystore/src/proteus.rs
+++ b/keystore/src/proteus.rs
@@ -67,7 +67,7 @@ impl proteus_traits::PreKeyStore for Connection {
             let _ = self.memory_cache.lock().await.pop(format!("proteus:{}", id).as_bytes());
         }
 
-        Connection::remove::<ProteusPrekey, _>(self, &id.to_le_bytes()).await?;
+        Connection::remove::<ProteusPrekey, _>(self, id.to_le_bytes()).await?;
 
         Ok(())
     }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "build:test": "npm run clean && rollup -c crypto-ffi/bindings/js/rollup.config.test.js",
     "clean": "rm -f ./platforms/web/*.{js,ts,wasm,html} && rm -rf ./platforms/web/assets",
     "package": "npm run build && npm pack",
-    "test:raw": "jest -c crypto-ffi/bindings/js/jest.config.js --no-cache --runInBand --verbose",
+    "test:raw": "jest -c crypto-ffi/bindings/js/jest.config.js --runInBand",
     "test": "npm run build:test && npm run test:raw",
-    "test:cov": "npm run build:test && jest -c crypto-ffi/bindings/js/jest.config.js --coverage --no-cache --runInBand --verbose"
+    "test:cov": "npm run build:test && jest -c crypto-ffi/bindings/js/jest.config.js --coverage --runInBand",
+    "test:http-server": "http-server platforms/web -g -p 3000"
   },
   "publishConfig": {
     "access": "public"
@@ -39,25 +40,26 @@
     "url": "https://github.com/wireapp/core-crypto/issues"
   },
   "devDependencies": {
-    "@rollup/plugin-html": "^0.2.4",
-    "@types/jest": "^29.0.1",
+    "@rollup/plugin-html": "^1.0.2",
+    "@types/jest": "^29.4.0",
     "@types/jest-dev-server": "^5.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.36.2",
-    "@typescript-eslint/parser": "^5.36.2",
-    "@wasm-tool/rollup-plugin-rust": "^2.3.1",
-    "dts-bundle-generator": "^6.13.0",
-    "eslint": "^8.23.1",
-    "eslint-config-prettier": "^8.5.0",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.50.0",
+    "@wasm-tool/rollup-plugin-rust": "^2.3.3",
+    "dts-bundle-generator": "^7.2.0",
+    "eslint": "^8.33.0",
+    "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "jest": "^29.0.3",
-    "jest-dev-server": "^6.1.1",
-    "prettier": "^2.7.1",
-    "puppeteer": "^17.1.3",
-    "rollup": "^2.79.0",
-    "rollup-jest": "^3.0.0",
-    "rollup-plugin-ts": "^3.0.2",
-    "ts-jest": "^29.0.0",
-    "ts-loader": "^9.3.1",
-    "typescript": "^4.8.3"
+    "http-server": "^14.1.1",
+    "jest": "^29.4.1",
+    "jest-dev-server": "^6.2.0",
+    "prettier": "^2.8.3",
+    "puppeteer": "^19.6.2",
+    "rollup": "^3.12.0",
+    "rollup-jest": "^3.1.0",
+    "rollup-plugin-ts": "^3.2.0",
+    "ts-jest": "^29.0.5",
+    "ts-loader": "^9.4.2",
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
Because rc5 is botched

## Post-mortem

The issue was basically that the implemented system was not working - at all.

* The use of the `?` operator in Rust short-circuits code execution, so the current code was unable to save the Proteus error codes aside - as we used a `match` statement to retrieve and query the error for its code.
	* A fix for this was to instead "localize" the short-circuiting by wrapping our proteus code in IIFEs (Immediately Invoked Function Expressions) or IICs (Immediately Invoked Closure) for Rust-specific lingo. This allows us to retrieve the Error as-is and inspect it.
* The extended JS `Error` instance in Rust was a good idea, unfortunately it's 100% unsupported by the current tooling (`wasm_bindgen` namely). 
	* So I had the idea to instead serialize a "rich error" to JSON, pass it across the WASM FFI, and build the rich error within our TypeScript bindings by parsing this JSON payload. This will create more adherence if we ever modify the internal interface, but at least this is functioning.
