### PR TITLE
chore: Generate xcframework for swift and publish it alongside the release

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -40,7 +40,11 @@ jobs:
           cd crypto-ffi
           ssh-keyscan -H github.com > /Users/runner/.ssh/known_hosts
           cargo make create-swift-package
-          cd ../../
+          cd bindings/swift
+          export CHECKSUM=$(swift package compute-checksum out./LibCoreCrypto.xcframework.zip)
+          sed -i '' "s/#VERSION/$GITHUB_REF_NAME/g" Package.swift
+          sed -i '' "s/#CHECKSUM/$CHECKSUM/g" Package.swift
+          cd ../../../../
           git clone git@github.com:wireapp/core-crypto-swift.git
           cd core-crypto-swift
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -147,11 +147,30 @@ condition = { platforms = ["mac"] }
 script = '''
     cd bindings/swift
 
-    lipo -create -output ./lib/libcore_crypto_ffi.a \
+    rm -rf ./out/*
+    mkdir -p ./out/ios/
+    mkdir -p ./out/macos/
+
+    lipo -create -output ./out/ios/libcore_crypto_ffi.a \
         ../../../target/x86_64-apple-ios/release/libcore_crypto_ffi.a \
-        ../../../target/aarch64-apple-ios/release/libcore_crypto_ffi.a
+        ../../../target/aarch64-apple-ios-sim/release/libcore_crypto_ffi.a
+
+    lipo -create -output ./out/macos/libcore_crypto_ffi.a \
+        ../../../target/aarch64-apple-darwin/release/libcore_crypto_ffi.a \
+        ../../../target/x86_64-apple-darwin/release/libcore_crypto_ffi.a
+
+    xcodebuild -create-xcframework \
+       -library ../../../target/aarch64-apple-ios/release/libcore_crypto_ffi.a \
+       -headers ./lib/ \
+       -library ./out/ios/libcore_crypto_ffi.a \
+       -headers ./lib/ \
+       -library ./out/macos/libcore_crypto_ffi.a \
+       -headers ./lib/ \
+       -output ./out/LibCoreCrypto.xcframework
+
+    ditto -c -k --sequesterRsrc --keepParent ./out/LibCoreCrypto.xcframework ./out/LibCoreCrypto.xcframework.zip
 '''
-dependencies = ["ios"]
+dependencies = ["jvm-aarch64-darwin", "jvm-x86-darwin", "ios"]
 
 ################################### Android ###################################
 

--- a/crypto-ffi/bindings/swift/Package.swift
+++ b/crypto-ffi/bindings/swift/Package.swift
@@ -8,11 +8,7 @@ let package = Package(
     products: [
         .library(
             name: "CoreCrypto",
-            targets: ["CoreCrypto", "CoreCryptoSwift"]
-        ),
-        .library(
-            name: "LibCoreCrypto",
-            targets: ["LibCoreCrypto"]
+            targets: ["CoreCrypto", "CoreCryptoSwift", "LibCoreCrypto"]
         ),
     ],
     dependencies: [],
@@ -21,9 +17,10 @@ let package = Package(
             name: "CoreCrypto",
             dependencies: ["CoreCryptoSwift"]
         ),
-        .systemLibrary(
+        .binaryTarget(
             name: "LibCoreCrypto",
-            path: "./lib"
+            url: "https://github.com/wireapp/core-crypto/releases/download/#VERSION/LibCoreCrypto.xcframework.zip",
+            checksum: "#CHECKSUM"
         ),
         .target(
             name: "CoreCryptoSwift",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Will generate a xcframework for apple devices. The xcframework will be zipped and added as an asset to the release that triggered the workflow. The Package.swift will be edited pointing to the new version and its corresponding checksum and pushed to the repo `core-crypt-swift`.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
