### PR TITLE
fix: publishing for JVM generating empty artifacts

### DIFF
--- a/kotlin/jvm/build.gradle.kts
+++ b/kotlin/jvm/build.gradle.kts
@@ -18,6 +18,7 @@ val generatedDir = buildDir.resolve("generated").resolve("uniffi")
 val crateDir = projectDir.resolve("../../crypto-ffi/")
 val crateTargetDir = projectDir.resolve("../../target")
 val crateTargetBindingsDir = crateDir.resolve("bindings/kt")
+val processedResourcesDir = buildDir.resolve("processedResources")
 
 val copyBindings = tasks.register("copyBindings", Copy::class) {
     group = "uniffi"
@@ -34,7 +35,7 @@ fun registerCopyJvmBinaryTask(target: String, jniTarget: String, include: String
         )
         include(include)
         into(
-            buildDir.resolve("processedResources").resolve("jvm").resolve("main").resolve(jniTarget)
+            processedResourcesDir.resolve("jvm").resolve("main").resolve(jniTarget)
         )
     }
 
@@ -64,10 +65,14 @@ tasks.withType<Test> {
     }
 }
 
+kotlin.sourceSets.getByName("main").apply {
+    kotlin.srcDir(generatedDir)
+}
+
 sourceSets {
     main {
-        kotlin {
-            generatedDir
+        resources {
+            srcDir(processedResourcesDir)
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues


JVM package of core crypto is broken

### Causes

The sources and resources were configured incorrectly and thus empty Jars were produced.

### Solutions

Fix Gradle setup

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
