### PR TITLE
feat!: Improve memory efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ Platform support legends:
     * Note: the papercuts will majorly be with the build process. Things might be very rough to integrate as no polish at all has been given yet.
 * ❌ = tier 3 support. It doesn't work just yet, but we plan to make it work.
 
+## [0.7.0] - 2023-03-??
+
+<details>
+    <summary>git-conventional changelog</summary>
+
+### Features
+
+- [**breaking**] Added LRU cache-based underlying group store to replace the HashMaps
+
+### Miscellaneous Tasks
+
+- [**breaking**] Drop LRU from keystore
+- Bump webdriver version to 110
+
+</details>
+
+* **[BREAKING]** `wipe_conversation` is now automatically called when a commit removing the local client is recieved.
+* **[BREAKING]** Huge internal change on how we cache MLS groups and Proteus sessions in memory
+    * This affects some APIs that became async on the TS bindings
+    * Our previous `HashMap`-based cache could grow indefinitely in the case of massive accounts with many, many groups/conversations, each containing a ton of clients. This replaces this memory store by a LRU cache having the following properties:
+        * Limited by number of entries AND occupied memory
+            * Defaults for memory: All the available system memory on other platforms / 100MB on WASM
+            * Defaults for number of entries:
+                * 100 MLS groups
+                * 200 Proteus sessions
+        * Flow for retrieving a value
+            1. Check the LRU store if the value exists, if yes, it's promoted as MRU (Most Recently Used) and returned
+            2. If not found, it might have been evicted, so we search the keystore
+            3. If found in the keystore, the value is placed as MRU and returned
+                * Special case: we evict the store as much as needed to fit the new MRU value in this case. This is designed to infaillible.
+            5. If not found, we return a `None` value
+    * This approach potentially allows to have an unlimited number of groups/sessions as long as a single item does not exceed the maximum memory limit.
+    * As a consequence of the internal mutability requirements of the new map and the automatic keystore fetches, many if not all APIs are now `async`. This does not concern the Mobile FFI.
+
 ## [0.6.3] - 2023-02-17
 
 <details>
@@ -14,7 +48,8 @@ Platform support legends:
 
 ### Miscellaneous Tasks
 
-- Build linux artifacts on Ubuntu LTS for better compatibility
+- Release 0.6.3 ([#258](https://github.com/wireapp/core-crypto/issues/258))
+- Build linux artifacts on Ubuntu LTS for better compatibility ([#257](https://github.com/wireapp/core-crypto/issues/257))
 
 </details>
 
@@ -301,6 +336,239 @@ Platform support legends:
 - Fix rcgen failing on WASM due to some unsupported elliptic curve methods invoked at compile time
 - Ensure external commit are retriable
 
+
+### Bug Fixes
+
+- Wire-server sends a base64 encoded ed25519 key afterall. Consumers are in charge of base64 decoding it and pass it to core-crypto
+- TS Ciphersuite enum not correctly exported
+
+### Documentation
+
+- Add installation instructions for e2e runner on macos
+
+### Miscellaneous Tasks
+
+- Release v0.5.2
+
+
+### Bug Fixes
+
+- Incorrect null handing in Typescript wrapper for 'commitPendingProposals'
+- External_senders public key was not TLS deserialized causing rejection of external remove proposals
+
+### Documentation
+
+- Better explanation of what DecryptedMessage#proposals contains
+
+### Miscellaneous Tasks
+
+- Release v0.5.1
+- Added E2E interop testing tool
+
+
+### Bug Fixes
+
+- NPM publish workflow missing npm ci + wrong method names in TS bindings
+- NPM publish workflow missing npm i
+- Rollback openmls & chrono in order to release 0.5.0
+- Pin openmls without vulnerable chrono
+- Wee_alloc memory leak + NPM publish issue
+- Unreachable pub struct breaks docgen
+- Fixed iOS SQLCipher salt handling within keychain
+- [**breaking**] Changed misleading callback API and docs
+- [**breaking**] Added missing TS API to set CoreCrypto callbacks
+- Force software implementation for sha2 on target architectures not supporting hardware implementation (i686 & armv7 in our case)
+
+### Documentation
+
+- Add forgotten 0.4.0 changelog
+
+### Features
+
+- [**breaking**] 'commit_pending_proposals' now returns an optional CommitBundle when there is no pending proposals to commit
+
+### Miscellaneous Tasks
+
+- Release v0.5.0 Redux
+- Update UniFFI to 0.20
+- Release v0.5.0
+- Update node version from 12 to 16 LTS
+- Update dependencies
+- Remove es2020-specific operators and target es2020 only
+- Updated changelog
+
+
+### Bug Fixes
+
+- Uniffi breaking changes in patch release and ffi error due to unused `TlsMemberAddedMessages`
+
+
+### Bug Fixes
+
+- Ensure durable methods are well tested and actually durable
+
+### Features
+
+- Commits and group creation return a TLS serialized CommitBundle. The latter also contains a PublicGroupStateBundle to prepare future evolutions
+- [**breaking**] 'decrypt_message' returns the sender client id
+- Use 128 bytes of padding when encrypting messages instead of 16 previously
+- Add function to return current epoch of a group [CL-80] ([#96](https://github.com/wireapp/core-crypto/issues/96))
+- Adding a wrapper for the swift API and initial docs [CL-62] ([#89](https://github.com/wireapp/core-crypto/issues/89))
+- Add '#[durable]' macro to verify the method is tolerant to crashes and persists the MLS group in keystore
+- Expose 'clear_pending_commit' method
+- Allow rollbacking a proposal
+- [**breaking**] Expose 'clear_pending_commit' method
+- [**breaking**] Allow rollbacking a proposal
+
+### Miscellaneous Tasks
+
+- Migrate benchmarks to async and write some for core crypto operations
+- Fixed WASM E2E tests
+
+### Testing
+
+- Add reminder for x509 certificate tests
+
+
+### Miscellaneous Tasks
+
+- Release v0.3.1
+
+
+### Bug Fixes
+
+- Clippy fix impl eq
+- Libgcc swizzling for android was removed
+- Cleaned up FFI names for clearer intent
+- Caught up WASM api with the internal API changes
+- Doctests were failing because included markdown snippets were parsed and compiled
+- Defer validation that a callback has to be set for validating external add proposal after incoming proposal identified as such
+- Updated RustCrypto dependencies to match hpke-rs requirements
+- Group was not persisted after decrypting an application message
+- UniFFI wrong type defs
+- Aes_gcm compilation issue
+- WASM persistence & CoreCrypto Async edition
+- 'client_keypackages' does not require mutable access on 'mls_client'
+- Add_member/remove_member IoError
+- Incorrect number of keypackages returned
+- Added support for MLS Group persistence [CL-5]
+
+### Documentation
+
+- Added bindings docs where appropriate + generated gh-pages
+- Fix Client struct documentation
+- Improving docs of Core-Crypto - [CL-50] ([#60](https://github.com/wireapp/core-crypto/issues/60))
+
+### Features
+
+- Review external add proposal validation and remove 'InvalidProposalType' error
+- Remove required KeyPackage when creating an external add proposal
+- Remove commits auto-merge behaviour
+- Expose GroupInfo after commit operation
+- Use draft-16 implementation of external sender. Expose a correct type through ffi for remove key
+- Add API to wipe specific group from core crypto [CL-55] ([#81](https://github.com/wireapp/core-crypto/issues/81))
+- Adding validation to external proposal [CL-51] ([#71](https://github.com/wireapp/core-crypto/issues/71))
+- Decrypting a commit now also return a delay when there are pending proposals
+- Decrypting a commit now also return a delay when there are pending proposals
+- 'commit_delay' now uses openmls provided leaf index instead of computing it ourselves. It is also now infallible.
+- Ensure consistent state
+- [**breaking**] Add commit delay when a message with prending proposals is processed [CL-52] ([#67](https://github.com/wireapp/core-crypto/issues/67))
+- Added KeyPackage Pruning
+- Added support for external entropy seed
+- Join by external commit support - CL-47 ([#57](https://github.com/wireapp/core-crypto/issues/57))
+- Added Entity testing to keystore
+- External remove proposal support
+- Supports and validates x509 certificates as credential
+- Expose function to self update the key package to FFI and Wasm #CL-17 ([#48](https://github.com/wireapp/core-crypto/issues/48))
+- Added support for wasm32-unknown-unknown target
+- Support external add proposal
+- Added method to leave a conversation
+- Enforce (simple) invariants on MlsCentralConfiguration
+- Expose add/update/remove proposal
+
+### Miscellaneous Tasks
+
+- Bump WASM bundle version to 0.3.0
+- Added Changelog generator
+- Fix nits on CHANGELOG-HUMAN.md
+- Add changelog generator configuration + human changelog
+- Disable crate publishing + UniFFI catchup
+- Rename 'group_info' into 'public_group_state' to remain consistent with draft-12
+- Remove 'SelfKeypackageNotFound' error which is not used
+- Fix some clippy lints
+- Remove 'group()' test helper and inlined it
+- Fix cli compilation and update it a bit
+- Removed CryptoError variant `CentralConfigurationError`
+- Avoid cloning credential
+- Use shorthand for not using generics in conversation
+- Factorize group accessors in conversation.rs
+- Fix some clippy warnings
+- Remove .idea in sample anroid app
+- Remove unnecessary path prefixes imports
+- Remove useless mutable borrow in Client methods
+- Add Intellij files to gitignore
+- Bump jvm and android version
+- Add jvm linux support
+
+### Performance
+
+- Avoid cloning conversation extra members when creating the former
+
+### Refactor
+
+- Moved run_with_* test utils in a test_utils mod
+- Use shorthand for generics in Central
+- Factorize keystore update when group state change from a conversation pov
+
+### Testing
+
+- Add tests for 'commit_pending_proposals'
+- Verify that commit operation are returning a valid welcome if any
+- Use Index trait to access conversation from Central instead of duplicate accessor
+- Use central instead of conversation
+- Fix minor clippy lints in tests
+- Apply clippy suggestions on test sources
+- Reorganize tests in conversation.rs
+- Nest conversation tests in dedicated modules
+- Verify adding a keypackage to a ConversationMember
+
+
+### Bug Fixes
+
+- Set correct path to toolchain depending on platform & copy bindings
+- Fix broken tests
+- Tests fix
+- Fixed iOS WAL behavior for SQLite-backed stores
+- Fix Keystore trait having update method removed
+- Clippy + fmt pass on core-crypto
+- Fmt + clippy pass
+- Migrations were incorrectly defined
+
+### Features
+
+- Add android project
+- Add tasks for building and copying jvm resources
+- Add jvm project
+- WIP hand-written ts bindings
+- Generate Swift & Kotlin bindings 🎉
+- Updated deps
+- Added salt in keychain management instead of flat AES-encrypted file
+- Added WIP DS mockup based on QUIC
+- Added ability to create conversations (!!!)
+- Added api support for in-memory keystore
+- Added in-memory faculties for keystore
+- Added benches for the MLS key management
+- Added benches & fixed performance issues
+- Added integration tests + fixes
+- Implemented LRU cache for keystore
+- Added support for Proteus PreKeys
+- Progress + fix store compilation to WASM
+
+### Miscellaneous Tasks
+
+- Configure wire maven repository
+- Clean up gradle files
+
 </details>
 
 Platform support status:
@@ -493,28 +761,6 @@ There's a post mortem available here: <https://github.com/wireapp/core-crypto/pu
 
 <details>
     <summary>git-conventional changelog</summary>
-
-### Bug Fixes
-
-- Aarch64-apple-ios-sim target not compiling  ([#213](https://github.com/wireapp/core-crypto/issues/213))
-- Cryptobox import now throws errors on missing/incorrect store
-
-### Features
-
-- Expose end to end identity web API
-- Add end to end identity bindings
-
-### Miscellaneous Tasks
-
-- 0.6.0-rc.4 release
-- Updated base64, lru and spinoff deps
-- Added WebDriver-based WASM test runner
-- Xtask improvements
-- Fix 1.66 clippy warnings
-- Update base64 to 0.20
-- Fixed wrong documentation link in TS bindings docs
-- Update UniFFI to 0.22
-- Kotlin FFI docs + makefile fixes for other platforms
 
 </details>
 
@@ -713,6 +959,47 @@ There's a post mortem available here: <https://github.com/wireapp/core-crypto/pu
 
 <details>
     <summary>git-conventional changelog</summary>
+
+### Bug Fixes
+
+- 'join_by_external_commit' returns a non TLS serialized conversation id
+
+### Features
+
+- [**breaking**] Expose a 'PublicGroupStateBundle' struct used in 'CommitBundle' variants
+- [**breaking**] Remove all the final_* methods returning a TLS encoded CommitBundle
+- Returning if decrypted message changed the epoch - CL-92 ([#152](https://github.com/wireapp/core-crypto/issues/152))
+- Exporting secret key derived from the group and client ids from the members - CL-97 - CL-98 ([#142](https://github.com/wireapp/core-crypto/issues/142))
+- Added API to generate Proteus prekeys
+- Fixed Cryptobox import for WASM
+- Added support for migrating Cryptobox data
+- Added FFI for CoreCrypto-Proteus
+- Added support for Proteus
+- Validate received external commits making sure the sender's user already belongs to the MLS group and has the right role
+- [**breaking**] Rename callback~~`client_id_belongs_to_one_of`~~ into `client_is_existing_group_user`
+- [**breaking**] External commit returns a bundle containing the PGS
+- [**breaking**] Add `clear_pending_group_from_external_commit` to cleanly abort an external commit. Also renamed `group_state` argument into `public_group_state` wherever found which can be considered a breaking change in some languages
+- [**breaking**] Rename `MlsConversationInitMessage#group` into `MlsConversationInitMessage#conversation_id` because it was misleading about the actual returned value
+
+### Miscellaneous Tasks
+
+- Apply suggestions from code review
+- Updated bundled FFI files
+- Added Proteus testing infra
+- Added missing docs
+- Nits, fmt & cargo-deny tweak
+- Add m1 support for the jvm bindings ([#139](https://github.com/wireapp/core-crypto/issues/139))
+- Remove unneeded `map_err(CryptoError::from)`
+- Remove useless code
+
+### Testing
+
+- Fix external commit tests allowing member to rejoin a group by external commit
+- Add a default impl for 'TestCase', very useful when one has to debug on IntelliJ
+- Parameterize ciphers
+- Ensure external senders can be inferred when joining by external commit or welcome
+- Fix rcgen failing on WASM due to some unsupported elliptic curve methods invoked at compile time
+- Ensure external commit are retriable
 
 </details>
 
@@ -1147,42 +1434,6 @@ Note: all the platforms marked with (⚠️) above will get a round of polish fo
 
 <details>
     <summary>git-conventional changelog</summary>
-
-### Bug Fixes
-
-- Set correct path to toolchain depending on platform & copy bindings
-- Fix broken tests
-- Tests fix
-- Fixed iOS WAL behavior for SQLite-backed stores
-- Fix Keystore trait having update method removed
-- Clippy + fmt pass on core-crypto
-- Fmt + clippy pass
-- Migrations were incorrectly defined
-
-### Features
-
-- Add android project
-- Add tasks for building and copying jvm resources
-- Add jvm project
-- WIP hand-written ts bindings
-- Generate Swift & Kotlin bindings 🎉
-- Updated deps
-- Added salt in keychain management instead of flat AES-encrypted file
-- Added WIP DS mockup based on QUIC
-- Added ability to create conversations (!!!)
-- Added api support for in-memory keystore
-- Added in-memory faculties for keystore
-- Added benches for the MLS key management
-- Added benches & fixed performance issues
-- Added integration tests + fixes
-- Implemented LRU cache for keystore
-- Added support for Proteus PreKeys
-- Progress + fix store compilation to WASM
-
-### Miscellaneous Tasks
-
-- Configure wire maven repository
-- Clean up gradle files
 
 </details>
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -36,6 +36,8 @@ serde = "1.0"
 serde_json = "1.0"
 url = "2.3"
 async-trait = "0.1"
+async-lock = "2.6"
+schnellru = "0.2"
 
 wire-e2e-identity = "0.2.0"
 
@@ -51,6 +53,7 @@ optional = true
 version = "2.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+sysinfo = { version = "0.28", default-features = false, features = ["apple-app-store"] }
 async-fs = { version = "1.6", optional = true }
 futures-lite = { version = "1.12", optional = true }
 
@@ -83,6 +86,11 @@ futures-util = { version = "0.3", features = ["std", "alloc"] }
 futures-lite = "1.12"
 proteus-traits = "2.0"
 async-trait = "0.1"
+
+[dev-dependencies.core-crypto-keystore]
+version = "^0.6.3"
+path = "../keystore"
+features = ["dummy-entity"]
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 cryptobox = { git = "https://github.com/wireapp/cryptobox", tag = "v1.0.3" }

--- a/crypto/benches/public_group_state.rs
+++ b/crypto/benches/public_group_state.rs
@@ -16,7 +16,7 @@ fn export_pgs_bench(c: &mut Criterion) {
                         add_clients(&mut central, &id, ciphersuite, *i);
                         (central, id)
                     },
-                    |(central, id)| async move {
+                    |(mut central, id)| async move {
                         black_box(central.export_public_group_state(&id).await.unwrap());
                     },
                     BatchSize::SmallInput,

--- a/crypto/src/group_store.rs
+++ b/crypto/src/group_store.rs
@@ -1,0 +1,465 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+
+#[async_trait::async_trait(?Send)]
+pub trait GroupStoreEntity: std::fmt::Debug {
+    type RawStoreValue: core_crypto_keystore::entities::Entity;
+    type IdentityType;
+
+    async fn fetch_from_id(
+        id: &[u8],
+        identity: Option<Self::IdentityType>,
+        keystore: &mut core_crypto_keystore::connection::KeystoreDatabaseConnection,
+    ) -> crate::CryptoResult<Option<Self>>
+    where
+        Self: Sized;
+}
+
+#[async_trait::async_trait(?Send)]
+impl GroupStoreEntity for crate::mls::conversation::MlsConversation {
+    type RawStoreValue = core_crypto_keystore::entities::PersistedMlsGroup;
+    type IdentityType = ();
+
+    async fn fetch_from_id(
+        id: &[u8],
+        _: Option<Self::IdentityType>,
+        keystore: &mut core_crypto_keystore::connection::KeystoreDatabaseConnection,
+    ) -> crate::CryptoResult<Option<Self>> {
+        use core_crypto_keystore::entities::EntityBase as _;
+        let Some(store_value) = Self::RawStoreValue::find_one(keystore, &id.into()).await? else {
+            return Ok(None);
+        };
+
+        let conversation = Self::from_serialized_state(store_value.state.clone())?;
+        // If the conversation is not active, pretend it doesn't exist
+        Ok(if conversation.group.is_active() {
+            Some(conversation)
+        } else {
+            None
+        })
+    }
+}
+
+#[cfg(feature = "proteus")]
+#[async_trait::async_trait(?Send)]
+impl GroupStoreEntity for crate::proteus::ProteusConversationSession {
+    type RawStoreValue = core_crypto_keystore::entities::ProteusSession;
+    type IdentityType = std::sync::Arc<proteus_wasm::keys::IdentityKeyPair>;
+
+    async fn fetch_from_id(
+        id: &[u8],
+        identity: Option<Self::IdentityType>,
+        keystore: &mut core_crypto_keystore::connection::KeystoreDatabaseConnection,
+    ) -> crate::CryptoResult<Option<Self>> {
+        use core_crypto_keystore::entities::EntityBase as _;
+        let Some(store_value) = Self::RawStoreValue::find_one(keystore, &id.into()).await? else {
+            return Ok(None);
+        };
+
+        let Some(identity) = identity else {
+            return Err(crate::CryptoError::ProteusNotInitialized);
+        };
+
+        let session = proteus_wasm::session::Session::deserialise(identity, &store_value.session)
+            .map_err(crate::ProteusError::from)?;
+
+        Ok(Some(Self {
+            identifier: store_value.id.clone(),
+            session,
+        }))
+    }
+}
+
+pub type GroupStoreValue<V> = std::sync::Arc<async_lock::RwLock<V>>;
+
+pub(crate) type LruMap<V> = schnellru::LruMap<Vec<u8>, GroupStoreValue<V>, HybridMemoryLimiter>;
+
+/// LRU-cache based group/session store
+/// Uses a hybrid memory limiter based on both amount of elements and total memory usage
+/// As with all LRU caches, eviction is based on oldest elements
+pub struct GroupStore<V: GroupStoreEntity>(LruMap<V>);
+
+impl<V: GroupStoreEntity> std::fmt::Debug for GroupStore<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GroupStore")
+            .field("length", &self.0.len())
+            .field("memory_usage", &self.0.memory_usage())
+            .field(
+                "entries",
+                &self
+                    .0
+                    .iter()
+                    .map(|(k, v)| format!("{k:?}={v:?}"))
+                    .collect::<Vec<String>>()
+                    .join("\n"),
+            )
+            .finish()
+    }
+}
+
+impl<V: GroupStoreEntity> Default for GroupStore<V> {
+    fn default() -> Self {
+        Self(schnellru::LruMap::default())
+    }
+}
+
+#[cfg(test)]
+impl<V: GroupStoreEntity> std::ops::Deref for GroupStore<V> {
+    type Target = LruMap<V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+impl<V: GroupStoreEntity> std::ops::DerefMut for GroupStore<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<V: GroupStoreEntity> GroupStore<V> {
+    #[allow(dead_code)]
+    pub fn new_with_limit(len: u32) -> Self {
+        let limiter = HybridMemoryLimiter::new(Some(len), None);
+        let store = schnellru::LruMap::new(limiter);
+        Self(store)
+    }
+
+    #[allow(dead_code)]
+    pub fn new(count: Option<u32>, memory: Option<usize>) -> Self {
+        let limiter = HybridMemoryLimiter::new(count, memory);
+        let store = schnellru::LruMap::new(limiter);
+        Self(store)
+    }
+
+    #[allow(dead_code)]
+    pub fn contains_key(&self, k: &[u8]) -> bool {
+        self.0.peek(k).is_some()
+    }
+
+    pub async fn get_fetch(
+        &mut self,
+        k: &[u8],
+        keystore: &mut core_crypto_keystore::Connection,
+        identity: Option<V::IdentityType>,
+    ) -> crate::CryptoResult<Option<GroupStoreValue<V>>> {
+        // Optimistic cache lookup
+        if let Some(value) = self.0.get(k) {
+            return Ok(Some(value.clone()));
+        }
+
+        let mut keystore_connection = keystore
+            .borrow_conn()
+            .await
+            .map_err(|_| crate::CryptoError::LockPoisonError)?;
+
+        // Not in store, fetch the thing in the keystore
+        let mut value = V::fetch_from_id(k, identity, &mut keystore_connection).await?;
+        if let Some(value) = value.take() {
+            let value_to_insert = std::sync::Arc::new(async_lock::RwLock::new(value));
+            self.insert_prepped(k.to_vec(), value_to_insert.clone());
+
+            Ok(Some(value_to_insert))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn lru_will_be_full(&mut self, value: &GroupStoreValue<V>) -> bool {
+        if <HybridMemoryLimiter as schnellru::Limiter<Vec<u8>, GroupStoreValue<V>>>::is_over_the_limit(
+            self.0.limiter(),
+            self.0.len() + 1,
+        ) {
+            return true;
+        }
+
+        let new_memory_usage = self.0.memory_usage() + std::mem::size_of_val(value);
+        let can_grow = <HybridMemoryLimiter as schnellru::Limiter<Vec<u8>, GroupStoreValue<V>>>::on_grow(
+            self.0.limiter_mut(),
+            new_memory_usage,
+        );
+        if !can_grow {
+            return true;
+        }
+
+        false
+    }
+
+    fn compact(&mut self, value: &GroupStoreValue<V>) {
+        while self.lru_will_be_full(value) {
+            if self.0.pop_oldest().is_none() {
+                break;
+            }
+        }
+    }
+
+    fn insert_prepped(&mut self, k: Vec<u8>, prepped_entity: GroupStoreValue<V>) {
+        self.compact(&prepped_entity);
+        self.0.insert(k, prepped_entity);
+    }
+
+    pub fn insert(&mut self, k: Vec<u8>, entity: V) {
+        let value_to_insert = std::sync::Arc::new(async_lock::RwLock::new(entity));
+        self.insert_prepped(k, value_to_insert)
+    }
+
+    pub fn try_insert(&mut self, k: Vec<u8>, entity: V) -> Result<(), V> {
+        let value_to_insert = std::sync::Arc::new(async_lock::RwLock::new(entity));
+        if self.lru_will_be_full(&value_to_insert) {
+            // This is safe because we just built the value
+            return Err(std::sync::Arc::try_unwrap(value_to_insert).unwrap().into_inner());
+        }
+
+        if self.0.insert(k, value_to_insert.clone()) {
+            Ok(())
+        } else {
+            // This is safe because we just built the value
+            Err(std::sync::Arc::try_unwrap(value_to_insert).unwrap().into_inner())
+        }
+    }
+
+    pub fn remove(&mut self, k: &[u8]) -> Option<GroupStoreValue<V>> {
+        self.0.remove(k)
+    }
+
+    pub fn get(&mut self, k: &[u8]) -> Option<&mut GroupStoreValue<V>> {
+        self.0.get(k)
+    }
+}
+
+pub struct HybridMemoryLimiter {
+    mem: schnellru::ByMemoryUsage,
+    len: schnellru::ByLength,
+}
+
+pub const MEMORY_LIMIT: usize = 100_000_000;
+pub const ITEM_LIMIT: u32 = 100;
+
+impl HybridMemoryLimiter {
+    pub fn new(count: Option<u32>, memory: Option<usize>) -> Self {
+        let maybe_memory_limit = memory.or_else(|| {
+            cfg_if::cfg_if! {
+                if #[cfg(target_family = "wasm")] {
+                    None
+                } else {
+                    use sysinfo::SystemExt as _;
+                    let system = sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_memory());
+                    let available_sys_memory = system.available_memory();
+                    if available_sys_memory > 0 {
+                        Some(available_sys_memory as usize)
+                    } else {
+                        None
+                    }
+                }
+            }
+        });
+
+        let mem = schnellru::ByMemoryUsage::new(maybe_memory_limit.unwrap_or(MEMORY_LIMIT));
+        let len = schnellru::ByLength::new(count.unwrap_or(ITEM_LIMIT));
+
+        Self { mem, len }
+    }
+}
+
+impl Default for HybridMemoryLimiter {
+    fn default() -> Self {
+        Self::new(None, None)
+    }
+}
+
+impl<K, V> schnellru::Limiter<K, V> for HybridMemoryLimiter {
+    type KeyToInsert<'a> = K;
+    type LinkType = u32;
+
+    fn is_over_the_limit(&self, length: usize) -> bool {
+        <schnellru::ByLength as schnellru::Limiter<K, V>>::is_over_the_limit(&self.len, length)
+    }
+
+    fn on_insert(&mut self, length: usize, key: Self::KeyToInsert<'_>, value: V) -> Option<(K, V)> {
+        <schnellru::ByLength as schnellru::Limiter<K, V>>::on_insert(&mut self.len, length, key, value)
+    }
+
+    // Both underlying limiters have dummy implementations here
+    fn on_replace(
+        &mut self,
+        _length: usize,
+        _old_key: &mut K,
+        _new_key: Self::KeyToInsert<'_>,
+        _old_value: &mut V,
+        _new_value: &mut V,
+    ) -> bool {
+        true
+    }
+    fn on_removed(&mut self, _key: &mut K, _value: &mut V) {}
+    fn on_cleared(&mut self) {}
+
+    fn on_grow(&mut self, new_memory_usage: usize) -> bool {
+        <schnellru::ByMemoryUsage as schnellru::Limiter<K, V>>::on_grow(&mut self.mem, new_memory_usage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core_crypto_keystore::dummy_entity::{DummyStoreValue, DummyValue};
+    use wasm_bindgen_test::*;
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[async_trait::async_trait(?Send)]
+    impl GroupStoreEntity for DummyValue {
+        type RawStoreValue = DummyStoreValue;
+
+        type IdentityType = ();
+
+        async fn fetch_from_id(
+            id: &[u8],
+            _identity: Option<Self::IdentityType>,
+            _keystore: &mut core_crypto_keystore::connection::KeystoreDatabaseConnection,
+        ) -> crate::CryptoResult<Option<Self>> {
+            let id = std::str::from_utf8(id)?;
+            Ok(Some(id.into()))
+        }
+    }
+
+    type TestGroupStore = GroupStore<DummyValue>;
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    async fn group_store_init() {
+        let store = TestGroupStore::new_with_limit(1);
+        assert_eq!(store.len(), 0);
+        let store = TestGroupStore::new_with_limit(0);
+        assert_eq!(store.len(), 0);
+        let store = TestGroupStore::new(Some(0), Some(0));
+        assert_eq!(store.len(), 0);
+        let store = TestGroupStore::new(Some(0), Some(1));
+        assert_eq!(store.len(), 0);
+        let store = TestGroupStore::new(Some(1), Some(0));
+        assert_eq!(store.len(), 0);
+        let store = TestGroupStore::new(Some(1), Some(1));
+        assert_eq!(store.len(), 0);
+    }
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    async fn group_store_common_ops() {
+        let mut store = TestGroupStore::new(Some(u32::MAX), Some(usize::MAX));
+        for i in 1..=3 {
+            let i_str = i.to_string();
+            assert!(store
+                .try_insert(i_str.as_bytes().to_vec(), i_str.as_str().into())
+                .is_ok());
+            assert_eq!(store.len(), i);
+        }
+        for i in 4..=6 {
+            let i_str = i.to_string();
+            store.insert(i_str.as_bytes().to_vec(), i_str.as_str().into());
+            assert_eq!(store.len(), i);
+        }
+
+        for i in 1..=6 {
+            assert!(store.contains_key(&i.to_string().as_bytes()));
+        }
+    }
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    async fn group_store_operations_len_limiter() {
+        let mut store = TestGroupStore::new_with_limit(2);
+        assert!(store.try_insert(b"1".to_vec(), "1".into()).is_ok());
+        assert_eq!(store.len(), 1);
+        assert!(store.try_insert(b"2".to_vec(), "2".into()).is_ok());
+        assert_eq!(store.len(), 2);
+        assert!(store.try_insert(b"3".to_vec(), "3".into()).is_err());
+        assert_eq!(store.len(), 2);
+        store.insert(b"4".to_vec(), "4".into());
+        assert_eq!(store.len(), 2);
+    }
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    async fn group_store_operations_mem_limiter() {
+        use schnellru::{LruMap, UnlimitedCompact};
+        let mut lru: LruMap<usize, DummyValue, UnlimitedCompact> =
+            LruMap::<usize, DummyValue, UnlimitedCompact>::new(UnlimitedCompact);
+        assert_eq!(lru.guaranteed_capacity(), 0);
+        assert_eq!(lru.memory_usage(), 0);
+        lru.insert(1, "10".into());
+        let memory_usage_step_1 = lru.memory_usage();
+        lru.insert(2, "20".into());
+        lru.insert(3, "30".into());
+        lru.insert(4, "40".into());
+        let memory_usage_step_2 = lru.memory_usage();
+        assert_ne!(memory_usage_step_1, memory_usage_step_2);
+
+        let mut store = TestGroupStore::new(None, Some(memory_usage_step_2));
+        assert_eq!(store.guaranteed_capacity(), 0);
+        assert_eq!(store.memory_usage(), 0);
+        assert!(store.try_insert(1usize.to_le_bytes().to_vec(), "10".into()).is_ok());
+        assert_eq!(store.guaranteed_capacity(), 3);
+        assert_eq!(store.memory_usage(), memory_usage_step_1);
+        assert!(store.try_insert(2usize.to_le_bytes().to_vec(), "20".into()).is_ok());
+        assert!(store.try_insert(3usize.to_le_bytes().to_vec(), "30".into()).is_ok());
+        for i in 1..=3usize {
+            assert_eq!(
+                *(store.get(&i.to_le_bytes().to_vec()).unwrap().read().await),
+                DummyValue::from(format!("{}", i * 10).as_str())
+            );
+        }
+        assert_eq!(store.guaranteed_capacity(), 3);
+        assert_eq!(store.memory_usage(), memory_usage_step_1);
+        assert!(store.try_insert(4usize.to_le_bytes().to_vec(), "40".into()).is_ok());
+        for i in 4..=1usize {
+            assert_eq!(
+                *(store.get(&i.to_le_bytes().to_vec()).unwrap().read().await),
+                DummyValue::from(format!("{}", i * 10).as_str())
+            );
+        }
+        assert_eq!(store.guaranteed_capacity(), 7);
+        assert_eq!(store.memory_usage(), memory_usage_step_2);
+        assert!(store.try_insert(5usize.to_le_bytes().to_vec(), "50".into()).is_err());
+        assert!(store.try_insert(6usize.to_le_bytes().to_vec(), "60".into()).is_err());
+        assert!(store.try_insert(7usize.to_le_bytes().to_vec(), "70".into()).is_err());
+        for i in 7..=1usize {
+            // assert!(store.get(&i.to_le_bytes().to_vec()).is_none());
+
+            assert_eq!(
+                *(store
+                    .get(&i.to_le_bytes().to_vec())
+                    .expect(&format!("uh-oh, missing index {i}"))
+                    .read()
+                    .await),
+                DummyValue::from(format!("{}", i * 10).as_str())
+            );
+        }
+
+        store.insert(8usize.to_le_bytes().to_vec(), "80".into());
+        for i in 8..=2usize {
+            assert_eq!(
+                *(store.get(&i.to_le_bytes().to_vec()).unwrap().read().await),
+                DummyValue::from(format!("{}", i * 10).as_str())
+            );
+        }
+
+        assert_eq!(store.guaranteed_capacity(), 7);
+        assert_eq!(store.memory_usage(), memory_usage_step_2);
+        store.assert_check_internal_state();
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -48,6 +48,8 @@ pub mod e2e_identity;
 /// Proteus Abstraction
 pub mod proteus;
 
+mod group_store;
+
 /// Common imports that should be useful for most uses of the crate
 pub mod prelude {
     pub use openmls::group::{MlsGroup, MlsGroupConfig};

--- a/crypto/src/mls/conversation/durability.rs
+++ b/crypto/src/mls/conversation/durability.rs
@@ -33,6 +33,6 @@ impl MlsCentral {
             .map(|mut groups| groups.remove(id.as_slice()).unwrap())
             .unwrap();
         let group = MlsConversation::from_serialized_state(group).unwrap();
-        self.mls_groups.insert(id.clone(), group).unwrap();
+        self.mls_groups.insert(id.clone(), group);
     }
 }

--- a/crypto/src/mls/conversation/encrypt.rs
+++ b/crypto/src/mls/conversation/encrypt.rs
@@ -52,7 +52,10 @@ impl MlsCentral {
         conversation: &ConversationId,
         message: impl AsRef<[u8]>,
     ) -> CryptoResult<Vec<u8>> {
-        Self::get_conversation_mut(&mut self.mls_groups, conversation)?
+        self.get_conversation(conversation)
+            .await?
+            .write()
+            .await
             .encrypt_message(message, &self.mls_backend)
             .await
     }

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -149,9 +149,9 @@ pub mod tests {
                             .await
                             .unwrap();
 
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central.new_proposal(&id, MlsProposal::Update).await.unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Bob hasn't Alice's proposal but creates a commit
                         let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
@@ -163,12 +163,12 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice should renew the proposal because its her's
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
                         // It should also renew the proposal when in pending_commit
                         alice_central.commit_pending_proposals(&id).await.unwrap();
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert!(alice_central.pending_commit(&id).await.is_some());
                         let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
                         let proposals = alice_central
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -177,8 +177,8 @@ pub mod tests {
                             .proposals;
                         // Alice should renew the proposal because its her's
                         // It should also replace existing one
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -204,7 +204,7 @@ pub mod tests {
                             .unwrap();
 
                         alice_central.update_keying_material(&id).await.unwrap();
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // but Bob creates a commit meanwhile
                         let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
@@ -215,8 +215,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice should renew the proposal because its her's
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -241,13 +241,13 @@ pub mod tests {
                             .await
                             .unwrap();
 
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         let proposal = alice_central
                             .new_proposal(&id, MlsProposal::Update)
                             .await
                             .unwrap()
                             .proposal;
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Bob has Alice's update proposal
                         bob_central
@@ -265,8 +265,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice proposal should not be renew as it was in valid commit
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
                         // Same if proposal is also in pending commit
                         let proposal = alice_central
@@ -275,8 +275,8 @@ pub mod tests {
                             .unwrap()
                             .proposal;
                         alice_central.commit_pending_proposals(&id).await.unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert!(alice_central.pending_commit(&id).await.is_some());
                         bob_central
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
@@ -288,8 +288,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice should not be renew as it was in valid commit
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -329,12 +329,12 @@ pub mod tests {
                             .await
                             .unwrap()
                             .proposal;
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Charlie does not have other proposals, it creates a commit
                         let commit = charlie_central.update_keying_material(&id).await.unwrap().commit;
@@ -344,8 +344,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice should not renew Bob's update proposal
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -375,12 +375,12 @@ pub mod tests {
                             .unwrap();
 
                         let charlie_kp = charlie_central.get_one_key_package().await;
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .new_proposal(&id, MlsProposal::Add(charlie_kp))
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         let commit = bob_central
                             .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
@@ -393,8 +393,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice proposal is not renewed since she also wanted to add Charlie
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -420,16 +420,16 @@ pub mod tests {
                             .unwrap();
 
                         let charlie_kp = charlie_central.get_one_key_package().await;
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .new_proposal(&id, MlsProposal::Add(charlie_kp))
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Here Alice also creates a commit
                         alice_central.commit_pending_proposals(&id).await.unwrap();
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert!(alice_central.pending_commit(&id).await.is_some());
 
                         let commit = bob_central
                             .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
@@ -442,8 +442,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Alice proposal is not renewed since she also wanted to add Charlie
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -489,7 +489,7 @@ pub mod tests {
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // But Charlie will commit meanwhile
                         let commit = charlie_central.update_keying_material(&id).await.unwrap().commit;
@@ -499,8 +499,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // which Alice should not renew since it's not hers
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -527,12 +527,12 @@ pub mod tests {
 
                         // Alice proposes adding Charlie
                         let charlie_kp = charlie_central.get_one_key_package().await;
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .new_proposal(&id, MlsProposal::Add(charlie_kp))
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // But meanwhile Bob will create a commit without Alice's proposal
                         let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
@@ -543,12 +543,12 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // So Alice proposal should be renewed
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
                         // And same should happen when proposal is in pending commit
                         alice_central.commit_pending_proposals(&id).await.unwrap();
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert!(alice_central.pending_commit(&id).await.is_some());
                         let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
                         let proposals = alice_central
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -557,8 +557,8 @@ pub mod tests {
                             .proposals;
                         // So Alice proposal should also be renewed
                         // It should also replace existing one
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -588,7 +588,7 @@ pub mod tests {
                             .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
                             .await
                             .unwrap();
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // But meanwhile Bob will create a commit
                         let commit = bob_central.update_keying_material(&id).await.unwrap().commit;
@@ -598,8 +598,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // So Alice proposal should be renewed
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -638,12 +638,12 @@ pub mod tests {
                             .await
                             .unwrap();
 
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         let commit = bob_central
                             .remove_members_from_conversation(&id, &["charlie".into()])
@@ -656,8 +656,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Remove proposal is not renewed since commit does same
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -697,12 +697,12 @@ pub mod tests {
                             .await
                             .unwrap()
                             .proposal;
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         let commit = charlie_central.update_keying_material(&id).await.unwrap().commit;
                         let proposals = alice_central
@@ -711,8 +711,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Remove proposal is not renewed since by ref
-                        assert!(alice_central.pending_proposals(&id).is_empty());
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -758,12 +758,12 @@ pub mod tests {
                             .unwrap();
 
                         // Alice wants to remove Charlie
-                        assert!(alice_central.pending_proposals(&id).is_empty());
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
                             .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
                             .await
                             .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Whereas Bob wants to remove Debbie
                         let commit = bob_central
@@ -777,8 +777,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Remove is renewed since valid commit removes another
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -828,7 +828,7 @@ pub mod tests {
                             .remove_members_from_conversation(&id, &["charlie".into()])
                             .await
                             .unwrap();
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // Whereas Bob wants to remove Debbie
                         let commit = bob_central
@@ -842,8 +842,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Remove is renewed since valid commit removes another
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )
@@ -894,8 +894,8 @@ pub mod tests {
                             .await
                             .unwrap();
                         alice_central.commit_pending_proposals(&id).await.unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert!(alice_central.pending_commit(&id).is_some());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // Whereas Bob wants to remove Debbie
                         let commit = bob_central
@@ -909,8 +909,8 @@ pub mod tests {
                             .unwrap()
                             .proposals;
                         // Remove is renewed since valid commit removes another
-                        assert_eq!(alice_central.pending_proposals(&id).len(), 1);
-                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).len());
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
                     })
                 },
             )

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -240,19 +240,19 @@ mod tests {
                     assert_eq!(group_id.as_slice(), &id);
 
                     // Alice acks the request and adds the new member
-                    assert_eq!(alice_central[&id].members().len(), 1);
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
                     alice_central
                         .decrypt_message(&id, &external_commit.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    assert_eq!(alice_central[&id].members().len(), 2);
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                     // Let's say backend accepted our external commit.
                     // So Bob can merge the commit and update the local state
-                    assert!(bob_central.get_conversation(&id).is_err());
+                    assert!(bob_central.get_conversation(&id).await.is_err());
                     bob_central.merge_pending_group_from_external_commit(&id).await.unwrap();
-                    assert!(bob_central.get_conversation(&id).is_ok());
-                    assert_eq!(bob_central[&id].members().len(), 2);
+                    assert!(bob_central.get_conversation(&id).await.is_ok());
+                    assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
 
                     // Pending group removed from keystore
@@ -308,17 +308,17 @@ mod tests {
                     assert_eq!(conversation_id.as_slice(), &id);
 
                     // Alice decrypts the external commit and adds Bob
-                    assert_eq!(alice_central[&id].members().len(), 1);
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
                     alice_central
                         .decrypt_message(&id, &external_commit.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    assert_eq!(alice_central[&id].members().len(), 2);
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                     // And Bob can merge its external commit
                     bob_central.merge_pending_group_from_external_commit(&id).await.unwrap();
-                    assert!(bob_central.get_conversation(&id).is_ok());
-                    assert_eq!(bob_central[&id].members().len(), 2);
+                    assert!(bob_central.get_conversation(&id).await.is_ok());
+                    assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
                 })
             },
@@ -452,12 +452,12 @@ mod tests {
                         .decrypt_message(&id, &bob_external_commit.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    assert_eq!(alice_central[&id].members().len(), 2);
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                     // Bob merges the commit, he's also in !
                     bob_central.merge_pending_group_from_external_commit(&id).await.unwrap();
-                    assert!(bob_central.get_conversation(&id).is_ok());
-                    assert_eq!(bob_central[&id].members().len(), 2);
+                    assert!(bob_central.get_conversation(&id).await.is_ok());
+                    assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
 
                     // Now charlie wants to join with the [PublicGroupState] from Bob's external commit
@@ -479,16 +479,16 @@ mod tests {
                         .decrypt_message(&id, charlie_external_commit.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    assert_eq!(alice_central[&id].members().len(), 3);
-                    assert_eq!(bob_central[&id].members().len(), 3);
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 3);
+                    assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
                     // Charlie merges the commit, he's also in !
                     charlie_central
                         .merge_pending_group_from_external_commit(&id)
                         .await
                         .unwrap();
-                    assert!(charlie_central.get_conversation(&id).is_ok());
-                    assert_eq!(charlie_central[&id].members().len(), 3);
+                    assert!(charlie_central.get_conversation(&id).await.is_ok());
+                    assert_eq!(charlie_central.get_conversation_unchecked(&id).await.members().len(), 3);
                     assert!(charlie_central.talk_to(&id, &mut alice_central).await.is_ok());
                     assert!(charlie_central.talk_to(&id, &mut bob_central).await.is_ok());
                 })

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -82,7 +82,7 @@ impl EmulatedMlsClient for CoreCryptoNativeClient {
     }
 
     async fn add_client(&mut self, conversation_id: &[u8], client_id: &[u8], kp: &[u8]) -> Result<Vec<u8>> {
-        if !self.cc.conversation_exists(&conversation_id.to_vec()) {
+        if !self.cc.conversation_exists(&conversation_id.to_vec()).await {
             self.cc
                 .new_conversation(conversation_id.to_vec(), Default::default())
                 .await?;

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -285,7 +285,8 @@ async fn run_proteus_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<(
             "[Proteus] Step 2: Session master -> {fingerprint}@{}",
             client_type_mapping[&fingerprint]
         ));
-        let session = master_client.proteus_session_from_prekey(&fingerprint, &prekey).await?;
+        let session_arc = master_client.proteus_session_from_prekey(&fingerprint, &prekey).await?;
+        let mut session = session_arc.write().await;
         messages.insert(fingerprint, session.encrypt(PROTEUS_INITIAL_MESSAGE)?);
         master_sessions.push(session.identifier().to_string());
     }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -25,6 +25,7 @@ mls-keystore = ["dep:openmls_traits"]
 proteus-keystore = ["dep:proteus-traits"]
 ios-wal-compat = ["dep:security-framework"]
 idb-regression-test = []
+dummy-entity = ["dep:serde"]
 
 [dependencies]
 thiserror = "1.0"
@@ -40,6 +41,8 @@ sha2 = "0.10"
 security-framework = { version = "2.8", optional = true }
 
 openmls_traits = { version = "0.1", optional = true, features = ["single-threaded"] }
+
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dependencies.proteus-traits]
 optional = true
@@ -83,6 +86,7 @@ rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen-test = "0.3"
 uuid = { version = "1.0", features = ["v4", "js"] }
 rand = { version = "0.8", features = ["getrandom"] }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -24,7 +24,6 @@ default = ["mls-keystore", "proteus-keystore"]
 mls-keystore = ["dep:openmls_traits"]
 proteus-keystore = ["dep:proteus-traits"]
 ios-wal-compat = ["dep:security-framework"]
-memory-cache = ["dep:lru"]
 idb-regression-test = []
 
 [dependencies]
@@ -36,8 +35,6 @@ async-trait = "0.1"
 async-lock = "2.5"
 serde_json = "1.0"
 sha2 = "0.10"
-
-lru = { version = "0.9", optional = true }
 
 # iOS specific things
 security-framework = { version = "2.8", optional = true }
@@ -67,8 +64,6 @@ features = [
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.refinery]
 version = "0.8"
-# git = "https://github.com/rust-db/refinery"
-# rev = "36e2c219de236c95853a0aa6cd606a2d52d255f8"
 default-features = false
 features = ["rusqlite"]
 
@@ -106,7 +101,7 @@ git = "https://github.com/wireapp/proteus"
 branch = "otak/2.0-error-codes"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies.criterion]
-version = "0.3"
+version = "0.4"
 features = ["async_futures", "html_reports"]
 
 [package.metadata.wasm-pack.profile.release]

--- a/keystore/src/lib.rs
+++ b/keystore/src/lib.rs
@@ -37,8 +37,4 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(feature = "memory-cache")]
-#[allow(dead_code)]
-const LRU_CACHE_CAP: usize = 100;
-
 pub use connection::Connection;


### PR DESCRIPTION
Our previous `HashMap`-based cache could grow indefinitely in the case of massive accounts with many, many groups/conversations, each containing a ton of clients. This replaces this memory store by a LRU cache having the following properties: 

* Limited by number of entries AND occupied memory
	* Defaults for memory: All the available system memory on other platforms / 100MB on WASM
	* Defaults for number of entries: 
		* 100 MLS groups
		* 200 Proteus sessions
* Flow for retrieving a value
	1. Check the LRU store if the value exists, if yes, it's promoted as MRU (Most Recently Used) and returned
	2. If not found, it might have been evicted, so we search the keystore
	3. If found in the keystore, the value is placed as MRU and returned
		* Special case: we evict the store as much as needed to fit the new MRU value in this case. This is designed to infaillible.
	5. If not found, we return a `None` value
	
This approach potentially allows to have an unlimited number of groups/sessions as long as a single item does not exceed the maximum memory limit.

Note on the API breakage: This comes from the fact that some APIs became async due to the internal async lock used to perform proper inner mutability on the LRU map.

