### PR TITLE
fix: enable ios-wal-compat for iOS builds by default [CL-146]

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -62,9 +62,11 @@ serde-wasm-bindgen = "0.4"
 rexie = { version = "0.4", optional = true }
 base64 = { version = "0.21", optional = true }
 
-[dependencies.core-crypto-keystore]
-version = "^0.6.3"
-path = "../keystore"
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+core-crypto-keystore = { version = "^0.6.3", path = "../keystore" }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+core-crypto-keystore = { version = "^0.6.3", path = "../keystore", features = ["ios-wal-compat"] }
 
 [dependencies.mls-crypto-provider]
 version = "^0.6.3"

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -37,9 +37,11 @@ hpke-rs-rust-crypto = "0.2"
 zeroize = "1.5"
 thiserror = "1.0"
 
-[dependencies.core-crypto-keystore]
-version = "^0.6.3"
-path = "../keystore"
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+core-crypto-keystore = { version = "^0.6.3", path = "../keystore" }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+core-crypto-keystore = { version = "^0.6.3", path = "../keystore", features = ["ios-wal-compat"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Enable the `ios-wal-compat` feature for ios builds

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
