### PR TITLE
feat!: init MLS group with x509 certificate from e2e identity [CL-152]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,12 @@ branch = "otak/2.0-error-codes"
 [patch.crates-io.openmls]
 package = "openmls"
 git = "https://github.com/wireapp/openmls"
-tag = "v0.5.3-pre.core-crypto-0.6.0"
-#branch = "feat/async"
+tag = "v0.5.4-pre.core-crypto-0.7.0"
 
 [patch.crates-io.openmls_traits]
 package = "openmls_traits"
 git = "https://github.com/wireapp/openmls"
-tag = "v0.5.3-pre.core-crypto-0.6.0"
-#branch = "feat/async"
+tag = "v0.5.4-pre.core-crypto-0.7.0"
 
 [patch.crates-io.hpke-rs]
 git = "https://github.com/wireapp/hpke-rs"
@@ -72,11 +70,11 @@ package = "openssl-src"
 [patch.crates-io.wire-e2e-identity]
 git = "https://github.com/wireapp/rusty-jwt-tools"
 package = "wire-e2e-identity"
-tag = "v0.3.0"
+tag = "v0.3.1"
 
 [patch.crates-io.jwt-simple]
 git = "https://github.com/wireapp/rust-jwt-simple"
-tag = "v0.11.3-pre.core-crypto-0.6.0"
+tag = "v0.11.4-pre.core-crypto-0.7.0"
 
 [patch.crates-io.biscuit]
 git = "https://github.com/beltram/biscuit"

--- a/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_3b31_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_fab4_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_3b31_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_fab4_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,335 +264,335 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_3b31_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_fab4_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_3b31_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_3b31_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_mls_generate_keypair(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_mls_generate_keypair(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKey`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_restore_from_disk(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_restore_from_disk(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_fab4_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_fab4_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_3b31_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_3b31_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_3b31_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+    fun CoreCrypto_fab4_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_fab4_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_fab4_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Short
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_3b31_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
+    fun CoreCrypto_fab4_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`e2ei`: Pointer,`certificateChain`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun CoreCrypto_fab4_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Int
 
-    fun ffi_CoreCrypto_3b31_WireE2eIdentity_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_fab4_WireE2eIdentity_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_new_account_request(`ptr`: Pointer,`directory`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_order_request(`ptr`: Pointer,`displayName`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`directory`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`dpopChallenge`: RustBuffer.ByValue,`backendNonce`: RustBuffer.ByValue,`expiryDays`: Int,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`dpopChallenge`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`oidcChallenge`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_3b31_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_finalize_request(`ptr`: Pointer,`order`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_certificate_request(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,`account`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`backendNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_3b31_WireE2eIdentity_certificate_response(`ptr`: Pointer,`certificateChain`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_3b31_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun CoreCrypto_fab4_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_fab4_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_3b31_version(
+    fun CoreCrypto_fab4_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_3b31_rustbuffer_alloc(`size`: Int,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun ffi_CoreCrypto_3b31_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun ffi_CoreCrypto_3b31_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun CoreCrypto_fab4_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_3b31_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun CoreCrypto_fab4_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_fab4_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun CoreCrypto_fab4_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_fab4_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun CoreCrypto_fab4_version(
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_fab4_rustbuffer_alloc(`size`: Int,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_fab4_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_fab4_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun ffi_CoreCrypto_fab4_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -1113,7 +1113,10 @@ public interface CoreCryptoInterface {
     fun `proteusCryptoboxMigrate`(`path`: String)
     
     @Throws(CryptoException::class)
-    fun `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName): WireE2eIdentity
+    fun `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity
+    
+    @Throws(CryptoException::class)
+    fun `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String)
     
     fun `proteusLastErrorCode`(): UInt
     
@@ -1125,7 +1128,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: ClientId, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1138,7 +1141,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_3b31_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_fab4_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1146,7 +1149,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInit`(`clientId`: ClientId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }
     
@@ -1154,7 +1157,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsGenerateKeypair`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_mls_generate_keypair(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_mls_generate_keypair(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1163,7 +1166,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceUByte.lower(`signaturePublicKey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceUByte.lower(`signaturePublicKey`),  _status)
 }
         }
     
@@ -1171,7 +1174,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `restoreFromDisk`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_restore_from_disk(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_restore_from_disk(it,  _status)
 }
         }
     
@@ -1179,7 +1182,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1187,7 +1190,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1196,7 +1199,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1205,7 +1208,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1214,7 +1217,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1222,7 +1225,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1230,7 +1233,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1239,7 +1242,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1248,7 +1251,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1257,7 +1260,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1266,7 +1269,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
 }
         }
     
@@ -1274,7 +1277,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1283,7 +1286,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1292,7 +1295,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1300,7 +1303,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1309,7 +1312,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1318,7 +1321,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1327,7 +1330,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1336,7 +1339,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1345,7 +1348,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1354,7 +1357,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1363,7 +1366,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1372,7 +1375,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1380,7 +1383,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1388,7 +1391,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1397,7 +1400,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1406,7 +1409,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1415,7 +1418,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1424,7 +1427,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1432,7 +1435,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1440,7 +1443,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1448,7 +1451,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1456,7 +1459,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1464,7 +1467,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1472,7 +1475,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1481,7 +1484,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1489,7 +1492,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1497,7 +1500,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionExists`(`sessionId`: String): Boolean =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1506,7 +1509,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1515,7 +1518,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1524,7 +1527,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1533,7 +1536,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1542,7 +1545,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekeyAuto`(): ProteusAutoPrekeyBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_new_prekey_auto(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_new_prekey_auto(it,  _status)
 }
         }.let {
             FfiConverterTypeProteusAutoPrekeyBundle.lift(it)
@@ -1551,7 +1554,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1560,7 +1563,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekeyId`(): UShort =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
 }
         }.let {
             FfiConverterUShort.lift(it)
@@ -1569,7 +1572,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1578,7 +1581,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintLocal`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1587,7 +1590,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintRemote`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1596,7 +1599,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintPrekeybundle`(`prekey`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1605,23 +1608,31 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
     
-    @Throws(CryptoException::class)override fun `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName): WireE2eIdentity =
+    @Throws(CryptoException::class)override fun `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_new_acme_enrollment(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_new_acme_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterTypeWireE2eIdentity.lift(it)
         }
+    
+    @Throws(CryptoException::class)override fun `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`e2ei`), FfiConverterString.lower(`certificateChain`),  _status)
+}
+        }
+    
     override fun `proteusLastErrorCode`(): UInt =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_proteus_last_error_code(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_proteus_last_error_code(it,  _status)
 }
         }.let {
             FfiConverterUInt.lift(it)
@@ -1632,7 +1643,7 @@ class CoreCrypto(
         fun `deferredInit`(`path`: String, `key`: String, `entropySeed`: List<UByte>?): CoreCrypto =
             CoreCrypto(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
         
     }
@@ -1667,55 +1678,52 @@ public object FfiConverterTypeCoreCrypto: FfiConverter<CoreCrypto, Pointer> {
 public interface WireE2eIdentityInterface {
     
     @Throws(E2eIdentityException::class)
-    fun `directoryResponse`(`directory`: JsonRawData): AcmeDirectory
+    fun `directoryResponse`(`directory`: List<UByte>): AcmeDirectory
     
     @Throws(E2eIdentityException::class)
-    fun `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String): JsonRawData
+    fun `newAccountRequest`(`previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `newAccountResponse`(`account`: JsonRawData): JsonRawData
+    fun `newAccountResponse`(`account`: List<UByte>)
     
     @Throws(E2eIdentityException::class)
-    fun `newOrderRequest`(`displayName`: String, `clientId`: String, `handle`: String, `expiryDays`: UInt, `directory`: AcmeDirectory, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
+    fun `newOrderRequest`(`previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `newOrderResponse`(`order`: JsonRawData): NewAcmeOrder
+    fun `newOrderResponse`(`order`: List<UByte>): NewAcmeOrder
     
     @Throws(E2eIdentityException::class)
-    fun `newAuthzRequest`(`url`: String, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
+    fun `newAuthzRequest`(`url`: String, `previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `newAuthzResponse`(`authz`: JsonRawData): NewAcmeAuthz
+    fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz
     
     @Throws(E2eIdentityException::class)
-    fun `createDpopToken`(`accessTokenUrl`: String, `clientId`: String, `dpopChallenge`: AcmeChallenge, `backendNonce`: String, `expiryDays`: UInt): String
+    fun `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String): String
     
     @Throws(E2eIdentityException::class)
-    fun `newDpopChallengeRequest`(`accessToken`: String, `dpopChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
+    fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `newOidcChallengeRequest`(`idToken`: String, `oidcChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
+    fun `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `newChallengeResponse`(`challenge`: JsonRawData)
+    fun `newChallengeResponse`(`challenge`: List<UByte>)
     
     @Throws(E2eIdentityException::class)
-    fun `checkOrderRequest`(`orderUrl`: String, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
+    fun `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `checkOrderResponse`(`order`: JsonRawData): AcmeOrder
+    fun `checkOrderResponse`(`order`: List<UByte>)
     
     @Throws(E2eIdentityException::class)
-    fun `finalizeRequest`(`order`: AcmeOrder, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
+    fun `finalizeRequest`(`previousNonce`: String): List<UByte>
     
     @Throws(E2eIdentityException::class)
-    fun `finalizeResponse`(`finalize`: JsonRawData): AcmeFinalize
+    fun `finalizeResponse`(`finalize`: List<UByte>)
     
     @Throws(E2eIdentityException::class)
-    fun `certificateRequest`(`finalize`: AcmeFinalize, `account`: AcmeAccount, `previousNonce`: String): JsonRawData
-    
-    @Throws(E2eIdentityException::class)
-    fun `certificateResponse`(`certificateChain`: String): List<String>
+    fun `certificateRequest`(`previousNonce`: String): List<UByte>
     
 }
 
@@ -1733,161 +1741,149 @@ class WireE2eIdentity(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_3b31_WireE2eIdentity_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_fab4_WireE2eIdentity_object_free(this.pointer, status)
         }
     }
 
     
-    @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: JsonRawData): AcmeDirectory =
+    @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: List<UByte>): AcmeDirectory =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_directory_response(it, FfiConverterTypeJsonRawData.lower(`directory`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
 }
         }.let {
             FfiConverterTypeAcmeDirectory.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_account_request(it, FfiConverterTypeAcmeDirectory.lower(`directory`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeJsonRawData.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: JsonRawData): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_account_response(it, FfiConverterTypeJsonRawData.lower(`account`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
+}
+        }
+    
+    
+    @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`previousNonce`: String): List<UByte> =
+        callWithPointer {
+    rustCallWithError(E2eIdentityException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeJsonRawData.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`displayName`: String, `clientId`: String, `handle`: String, `expiryDays`: UInt, `directory`: AcmeDirectory, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: List<UByte>): NewAcmeOrder =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`displayName`), FfiConverterString.lower(`clientId`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeAcmeDirectory.lower(`directory`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
-}
-        }.let {
-            FfiConverterTypeJsonRawData.lift(it)
-        }
-    
-    @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: JsonRawData): NewAcmeOrder =
-        callWithPointer {
-    rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_order_response(it, FfiConverterTypeJsonRawData.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeOrder.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeJsonRawData.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: JsonRawData): NewAcmeAuthz =
+    @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_authz_response(it, FfiConverterTypeJsonRawData.lower(`authz`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeAuthz.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `createDpopToken`(`accessTokenUrl`: String, `clientId`: String, `dpopChallenge`: AcmeChallenge, `backendNonce`: String, `expiryDays`: UInt): String =
+    @Throws(E2eIdentityException::class)override fun `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterString.lower(`clientId`), FfiConverterTypeAcmeChallenge.lower(`dpopChallenge`), FfiConverterString.lower(`backendNonce`), FfiConverterUInt.lower(`expiryDays`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterString.lower(`backendNonce`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newDpopChallengeRequest`(`accessToken`: String, `dpopChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterTypeAcmeChallenge.lower(`dpopChallenge`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeJsonRawData.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newOidcChallengeRequest`(`idToken`: String, `oidcChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterTypeAcmeChallenge.lower(`oidcChallenge`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeJsonRawData.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: JsonRawData) =
+    @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_new_challenge_response(it, FfiConverterTypeJsonRawData.lower(`challenge`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
 }
         }
     
     
-    @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
-}
-        }.let {
-            FfiConverterTypeJsonRawData.lift(it)
-        }
-    
-    @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: JsonRawData): AcmeOrder =
-        callWithPointer {
-    rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_check_order_response(it, FfiConverterTypeJsonRawData.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeAcmeOrder.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`order`: AcmeOrder, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_finalize_request(it, FfiConverterTypeAcmeOrder.lower(`order`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
-        }.let {
-            FfiConverterTypeJsonRawData.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: JsonRawData): AcmeFinalize =
+    
+    @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_finalize_response(it, FfiConverterTypeJsonRawData.lower(`finalize`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterTypeAcmeFinalize.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `certificateRequest`(`finalize`: AcmeFinalize, `account`: AcmeAccount, `previousNonce`: String): JsonRawData =
+    @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_certificate_request(it, FfiConverterTypeAcmeFinalize.lower(`finalize`), FfiConverterTypeAcmeAccount.lower(`account`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
 }
-        }.let {
-            FfiConverterTypeJsonRawData.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `certificateResponse`(`certificateChain`: String): List<String> =
+    
+    @Throws(E2eIdentityException::class)override fun `certificateRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_WireE2eIdentity_certificate_response(it, FfiConverterString.lower(`certificateChain`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
-            FfiConverterSequenceString.lift(it)
+            FfiConverterSequenceUByte.lift(it)
         }
     
 
@@ -1920,7 +1916,7 @@ public object FfiConverterTypeWireE2eIdentity: FfiConverter<WireE2eIdentity, Poi
 
 
 data class AcmeChallenge (
-    var `delegate`: JsonRawData, 
+    var `delegate`: List<UByte>, 
     var `url`: String
 ) {
     
@@ -1929,18 +1925,18 @@ data class AcmeChallenge (
 public object FfiConverterTypeAcmeChallenge: FfiConverterRustBuffer<AcmeChallenge> {
     override fun read(buf: ByteBuffer): AcmeChallenge {
         return AcmeChallenge(
-            FfiConverterTypeJsonRawData.read(buf),
+            FfiConverterSequenceUByte.read(buf),
             FfiConverterString.read(buf),
         )
     }
 
     override fun allocationSize(value: AcmeChallenge) = (
-            FfiConverterTypeJsonRawData.allocationSize(value.`delegate`) +
+            FfiConverterSequenceUByte.allocationSize(value.`delegate`) +
             FfiConverterString.allocationSize(value.`url`)
     )
 
     override fun write(value: AcmeChallenge, buf: ByteBuffer) {
-            FfiConverterTypeJsonRawData.write(value.`delegate`, buf)
+            FfiConverterSequenceUByte.write(value.`delegate`, buf)
             FfiConverterString.write(value.`url`, buf)
     }
 }
@@ -1975,35 +1971,6 @@ public object FfiConverterTypeAcmeDirectory: FfiConverterRustBuffer<AcmeDirector
             FfiConverterString.write(value.`newNonce`, buf)
             FfiConverterString.write(value.`newAccount`, buf)
             FfiConverterString.write(value.`newOrder`, buf)
-    }
-}
-
-
-
-
-data class AcmeFinalize (
-    var `delegate`: JsonRawData, 
-    var `certificateUrl`: String
-) {
-    
-}
-
-public object FfiConverterTypeAcmeFinalize: FfiConverterRustBuffer<AcmeFinalize> {
-    override fun read(buf: ByteBuffer): AcmeFinalize {
-        return AcmeFinalize(
-            FfiConverterTypeJsonRawData.read(buf),
-            FfiConverterString.read(buf),
-        )
-    }
-
-    override fun allocationSize(value: AcmeFinalize) = (
-            FfiConverterTypeJsonRawData.allocationSize(value.`delegate`) +
-            FfiConverterString.allocationSize(value.`certificateUrl`)
-    )
-
-    override fun write(value: AcmeFinalize, buf: ByteBuffer) {
-            FfiConverterTypeJsonRawData.write(value.`delegate`, buf)
-            FfiConverterString.write(value.`certificateUrl`, buf)
     }
 }
 
@@ -2279,7 +2246,7 @@ public object FfiConverterTypeNewAcmeAuthz: FfiConverterRustBuffer<NewAcmeAuthz>
 
 
 data class NewAcmeOrder (
-    var `delegate`: JsonRawData, 
+    var `delegate`: List<UByte>, 
     var `authorizations`: List<String>
 ) {
     
@@ -2288,18 +2255,18 @@ data class NewAcmeOrder (
 public object FfiConverterTypeNewAcmeOrder: FfiConverterRustBuffer<NewAcmeOrder> {
     override fun read(buf: ByteBuffer): NewAcmeOrder {
         return NewAcmeOrder(
-            FfiConverterTypeJsonRawData.read(buf),
+            FfiConverterSequenceUByte.read(buf),
             FfiConverterSequenceString.read(buf),
         )
     }
 
     override fun allocationSize(value: NewAcmeOrder) = (
-            FfiConverterTypeJsonRawData.allocationSize(value.`delegate`) +
+            FfiConverterSequenceUByte.allocationSize(value.`delegate`) +
             FfiConverterSequenceString.allocationSize(value.`authorizations`)
     )
 
     override fun write(value: NewAcmeOrder, buf: ByteBuffer) {
-            FfiConverterTypeJsonRawData.write(value.`delegate`, buf)
+            FfiConverterSequenceUByte.write(value.`delegate`, buf)
             FfiConverterSequenceString.write(value.`authorizations`, buf)
     }
 }
@@ -2756,13 +2723,16 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
 sealed class E2eIdentityException(message: String): Exception(message) {
         // Each variant is a nested class
         // Flat enums carries a string error message, so no special implementation is necessary.
+        class ImplementationException(message: String) : E2eIdentityException(message)
         class NotYetSupported(message: String) : E2eIdentityException(message)
+        class E2eiInvalidDomain(message: String) : E2eIdentityException(message)
         class CryptoException(message: String) : E2eIdentityException(message)
         class IdentityException(message: String) : E2eIdentityException(message)
         class UrlException(message: String) : E2eIdentityException(message)
         class JsonException(message: String) : E2eIdentityException(message)
-        class E2eiInvalidDomain(message: String) : E2eIdentityException(message)
         class Utf8Exception(message: String) : E2eIdentityException(message)
+        class MlsException(message: String) : E2eIdentityException(message)
+        class LockPoisonException(message: String) : E2eIdentityException(message)
         
 
     companion object ErrorHandler : CallStatusErrorHandler<E2eIdentityException> {
@@ -2774,13 +2744,16 @@ public object FfiConverterTypeE2eIdentityError : FfiConverterRustBuffer<E2eIdent
     override fun read(buf: ByteBuffer): E2eIdentityException {
         
             return when(buf.getInt()) {
-            1 -> E2eIdentityException.NotYetSupported(FfiConverterString.read(buf))
-            2 -> E2eIdentityException.CryptoException(FfiConverterString.read(buf))
-            3 -> E2eIdentityException.IdentityException(FfiConverterString.read(buf))
-            4 -> E2eIdentityException.UrlException(FfiConverterString.read(buf))
-            5 -> E2eIdentityException.JsonException(FfiConverterString.read(buf))
-            6 -> E2eIdentityException.E2eiInvalidDomain(FfiConverterString.read(buf))
-            7 -> E2eIdentityException.Utf8Exception(FfiConverterString.read(buf))
+            1 -> E2eIdentityException.ImplementationException(FfiConverterString.read(buf))
+            2 -> E2eIdentityException.NotYetSupported(FfiConverterString.read(buf))
+            3 -> E2eIdentityException.E2eiInvalidDomain(FfiConverterString.read(buf))
+            4 -> E2eIdentityException.CryptoException(FfiConverterString.read(buf))
+            5 -> E2eIdentityException.IdentityException(FfiConverterString.read(buf))
+            6 -> E2eIdentityException.UrlException(FfiConverterString.read(buf))
+            7 -> E2eIdentityException.JsonException(FfiConverterString.read(buf))
+            8 -> E2eIdentityException.Utf8Exception(FfiConverterString.read(buf))
+            9 -> E2eIdentityException.MlsException(FfiConverterString.read(buf))
+            10 -> E2eIdentityException.LockPoisonException(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
         
@@ -2792,32 +2765,44 @@ public object FfiConverterTypeE2eIdentityError : FfiConverterRustBuffer<E2eIdent
 
     override fun write(value: E2eIdentityException, buf: ByteBuffer) {
         when(value) {
-            is E2eIdentityException.NotYetSupported -> {
+            is E2eIdentityException.ImplementationException -> {
                 buf.putInt(1)
                 Unit
             }
-            is E2eIdentityException.CryptoException -> {
+            is E2eIdentityException.NotYetSupported -> {
                 buf.putInt(2)
                 Unit
             }
-            is E2eIdentityException.IdentityException -> {
+            is E2eIdentityException.E2eiInvalidDomain -> {
                 buf.putInt(3)
                 Unit
             }
-            is E2eIdentityException.UrlException -> {
+            is E2eIdentityException.CryptoException -> {
                 buf.putInt(4)
                 Unit
             }
-            is E2eIdentityException.JsonException -> {
+            is E2eIdentityException.IdentityException -> {
                 buf.putInt(5)
                 Unit
             }
-            is E2eIdentityException.E2eiInvalidDomain -> {
+            is E2eIdentityException.UrlException -> {
                 buf.putInt(6)
                 Unit
             }
-            is E2eIdentityException.Utf8Exception -> {
+            is E2eIdentityException.JsonException -> {
                 buf.putInt(7)
+                Unit
+            }
+            is E2eIdentityException.Utf8Exception -> {
+                buf.putInt(8)
+                Unit
+            }
+            is E2eIdentityException.MlsException -> {
+                buf.putInt(9)
+                Unit
+            }
+            is E2eIdentityException.LockPoisonException -> {
+                buf.putInt(10)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -3056,7 +3041,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_3b31_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_fab4_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -3515,26 +3500,6 @@ public object FfiConverterMapStringListUByte: FfiConverterRustBuffer<Map<String,
  * is needed because the UDL type name is used in function/method signatures.
  * It's also what we have an external type that references a custom type.
  */
-public typealias AcmeAccount = List<UByte>
-public typealias FfiConverterTypeAcmeAccount = FfiConverterSequenceUByte
-
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- * It's also what we have an external type that references a custom type.
- */
-public typealias AcmeOrder = List<UByte>
-public typealias FfiConverterTypeAcmeOrder = FfiConverterSequenceUByte
-
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- * It's also what we have an external type that references a custom type.
- */
 public typealias ClientId = List<UByte>
 public typealias FfiConverterTypeClientId = FfiConverterSequenceUByte
 
@@ -3555,23 +3520,13 @@ public typealias FfiConverterTypeConversationId = FfiConverterSequenceUByte
  * is needed because the UDL type name is used in function/method signatures.
  * It's also what we have an external type that references a custom type.
  */
-public typealias JsonRawData = List<UByte>
-public typealias FfiConverterTypeJsonRawData = FfiConverterSequenceUByte
-
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- * It's also what we have an external type that references a custom type.
- */
 public typealias MemberId = List<UByte>
 public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_3b31_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_fab4_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -766,7 +766,6 @@ public class CoreCryptoWrapper {
     /// returned from all operation creating a proposal
     public func clearPendingProposal(conversationId: ConversationId, proposalRef: [UInt8]) throws {
         try self.coreCrypto.clearPendingProposal(conversationId: conversationId, proposalRef: proposalRef)
-
     }
 
     /// Allows to remove a pending commit. Use this when backend rejects the commit
@@ -782,7 +781,7 @@ public class CoreCryptoWrapper {
         try self.coreCrypto.clearPendingCommit(conversationId: conversationId)
     }
 
-    /// Initiailizes the proteus client
+    /// Initializes the proteus client
     public func proteusInit() throws {
         try self.coreCrypto.proteusInit()
     }
@@ -920,14 +919,26 @@ public class CoreCryptoWrapper {
     /// Creates an enrollment instance with private key material you can use in order to fetch
     /// a new x509 certificate from the acme server.
     ///
+    /// - parameter clientId: client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
+    /// - parameter displayName: human readable name displayed in the application e.g. `Smith, Alice M (QA)`
+    /// - parameter handle: user handle e.g. `alice.smith.qa@example.com`
+    /// - parameter expiryDays: generated x509 certificate expiry
     /// - parameter ciphersuite: For generating signing key material. Only ``CoreCryptoSwift.CiphersuiteName.mls128Dhkemx25519Aes128gcmSha256Ed25519`` is supported currently
     /// - returns: The new ``CoreCryptoSwift.WireE2eIdentity`` object
-    public func newAcmeEnrollment(ciphersuite: CoreCryptoSwift.CiphersuiteName = CoreCryptoSwift.CiphersuiteName.mls128Dhkemx25519Aes128gcmSha256Ed25519) throws -> CoreCryptoSwift.WireE2eIdentity {
+    public func newAcmeEnrollment(clientId: String, displayName: String, handle: String, expiryDays: UInt32, ciphersuite: CoreCryptoSwift.CiphersuiteName = CoreCryptoSwift.CiphersuiteName.mls128Dhkemx25519Aes128gcmSha256Ed25519) throws -> CoreCryptoSwift.WireE2eIdentity {
         if ciphersuite != CoreCryptoSwift.CiphersuiteName.mls128Dhkemx25519Aes128gcmSha256Ed25519 {
             throw CoreCryptoSwift.E2eIdentityError.NotYetSupported(message: "This ACME ciphersuite isn't supported. Only `Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` is as of now")
         }
 
-        return try self.coreCrypto.newAcmeEnrollment(ciphersuite: ciphersuite)
+        return try self.coreCrypto.newAcmeEnrollment(clientId: clientId, displayName: displayName, handle: handle, expiryDays: expiryDays, ciphersuite: ciphersuite)
+    }
+
+    /// Parses the ACME server response from the endpoint fetching x509 certificates and uses it to initialize the MLS client with a certificate
+    ///
+    /// - parameter e2ei: the enrollment instance used to fetch the certificates
+    /// - parameter certificateChain: the raw response from ACME server
+    public func e2eiMlsInit(e2ei: CoreCryptoSwift.WireE2eIdentity, certificateChain: String) throws {
+        return try self.coreCrypto.e2eiMlsInit(e2ei: e2ei, certificateChain: certificateChain)
     }
 
     /// - returns: The CoreCrypto version

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_3b31_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_fab4_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_3b31_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_fab4_rustbuffer_free(self, $0) }
     }
 }
 
@@ -472,7 +472,8 @@ public protocol CoreCryptoProtocol {
     func `proteusFingerprintRemote`(`sessionId`: String) throws -> String
     func `proteusFingerprintPrekeybundle`(`prekey`: [UInt8]) throws -> String
     func `proteusCryptoboxMigrate`(`path`: String) throws
-    func `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity
+    func `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt32, `ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity
+    func `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) throws
     func `proteusLastErrorCode`()  -> UInt32
     
 }
@@ -491,7 +492,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_3b31_CoreCrypto_new(
+    CoreCrypto_fab4_CoreCrypto_new(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterTypeClientId.lower(`clientId`), 
@@ -500,7 +501,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_3b31_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_fab4_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -509,7 +510,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_3b31_CoreCrypto_deferred_init(
+    CoreCrypto_fab4_CoreCrypto_deferred_init(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterOptionSequenceUInt8.lower(`entropySeed`), $0)
@@ -521,7 +522,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInit`(`clientId`: ClientId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_mls_init(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_mls_init(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
 }
@@ -530,7 +531,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_mls_generate_keypair(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_mls_generate_keypair(self.pointer, $0
     )
 }
         )
@@ -538,7 +539,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_mls_init_with_client_id(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_mls_init_with_client_id(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceUInt8.lower(`signaturePublicKey`), $0
     )
@@ -547,14 +548,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `restoreFromDisk`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_restore_from_disk(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_restore_from_disk(self.pointer, $0
     )
 }
     }
     public func `setCallbacks`(`callbacks`: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(`callbacks`), $0
     )
 }
@@ -563,7 +564,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -572,7 +573,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(`amountRequested`), $0
     )
 }
@@ -582,7 +583,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -590,7 +591,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeConversationConfiguration.lower(`config`), $0
     )
@@ -600,7 +601,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -611,7 +612,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_3b31_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -621,7 +622,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(`welcomeMessage`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -632,7 +633,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeInvitee.lower(`clients`), $0
     )
@@ -643,7 +644,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeClientId.lower(`clients`), $0
     )
@@ -653,7 +654,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
         FfiConverterTypeConversationId.lower(`childId`), 
         FfiConverterTypeConversationId.lower(`parentId`), $0
     )
@@ -663,7 +664,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -673,7 +674,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -682,7 +683,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `wipeConversation`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -691,7 +692,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`payload`), $0
     )
@@ -702,7 +703,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`message`), $0
     )
@@ -713,7 +714,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`keyPackage`), $0
     )
@@ -724,7 +725,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -734,7 +735,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
@@ -745,7 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), $0
     )
@@ -756,7 +757,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterSequenceUInt8.lower(`keyPackageRef`), $0
@@ -768,7 +769,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(`publicGroupState`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -778,7 +779,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -786,7 +787,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -795,7 +796,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -805,7 +806,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt32.lower(`keyLength`), $0
     )
@@ -816,7 +817,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_get_client_ids(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -826,7 +827,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(`length`), $0
     )
 }
@@ -835,7 +836,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `reseedRng`(`seed`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(`seed`), $0
     )
 }
@@ -843,7 +844,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `commitAccepted`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -851,7 +852,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`proposalRef`), $0
     )
@@ -860,7 +861,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -868,14 +869,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusInit`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
@@ -885,7 +886,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`envelope`), $0
     )
@@ -895,7 +896,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionSave`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -903,7 +904,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionDelete`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -912,7 +913,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterBool.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_session_exists(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_session_exists(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -922,7 +923,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`ciphertext`), $0
     )
@@ -933,7 +934,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -944,7 +945,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -955,7 +956,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(`prekeyId`), $0
     )
 }
@@ -965,7 +966,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProteusAutoPrekeyBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
     )
 }
         )
@@ -974,7 +975,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
     )
 }
         )
@@ -983,7 +984,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt16.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
     )
 }
         )
@@ -992,7 +993,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -1001,7 +1002,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_local(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_local(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1011,7 +1012,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1021,7 +1022,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
 }
@@ -1030,27 +1031,40 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusCryptoboxMigrate`(`path`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(`path`), $0
     )
 }
     }
-    public func `newAcmeEnrollment`(`ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity {
+    public func `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt32, `ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity {
         return try FfiConverterTypeWireE2eIdentity.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_3b31_CoreCrypto_new_acme_enrollment(self.pointer, 
+    CoreCrypto_fab4_CoreCrypto_new_acme_enrollment(self.pointer, 
+        FfiConverterString.lower(`clientId`), 
+        FfiConverterString.lower(`displayName`), 
+        FfiConverterString.lower(`handle`), 
+        FfiConverterUInt32.lower(`expiryDays`), 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), $0
     )
 }
         )
+    }
+    public func `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) throws {
+        try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_fab4_CoreCrypto_e2ei_mls_init(self.pointer, 
+        FfiConverterTypeWireE2eIdentity.lower(`e2ei`), 
+        FfiConverterString.lower(`certificateChain`), $0
+    )
+}
     }
     public func `proteusLastErrorCode`()  -> UInt32 {
         return try! FfiConverterUInt32.lift(
             try!
     rustCall() {
     
-    CoreCrypto_3b31_CoreCrypto_proteus_last_error_code(self.pointer, $0
+    CoreCrypto_fab4_CoreCrypto_proteus_last_error_code(self.pointer, $0
     )
 }
         )
@@ -1091,23 +1105,22 @@ public struct FfiConverterTypeCoreCrypto: FfiConverter {
 
 
 public protocol WireE2eIdentityProtocol {
-    func `directoryResponse`(`directory`: JsonRawData) throws -> AcmeDirectory
-    func `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String) throws -> JsonRawData
-    func `newAccountResponse`(`account`: JsonRawData) throws -> JsonRawData
-    func `newOrderRequest`(`displayName`: String, `clientId`: String, `handle`: String, `expiryDays`: UInt32, `directory`: AcmeDirectory, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `newOrderResponse`(`order`: JsonRawData) throws -> NewAcmeOrder
-    func `newAuthzRequest`(`url`: String, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `newAuthzResponse`(`authz`: JsonRawData) throws -> NewAcmeAuthz
-    func `createDpopToken`(`accessTokenUrl`: String, `clientId`: String, `dpopChallenge`: AcmeChallenge, `backendNonce`: String, `expiryDays`: UInt32) throws -> String
-    func `newDpopChallengeRequest`(`accessToken`: String, `dpopChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `newOidcChallengeRequest`(`idToken`: String, `oidcChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `newChallengeResponse`(`challenge`: JsonRawData) throws
-    func `checkOrderRequest`(`orderUrl`: String, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `checkOrderResponse`(`order`: JsonRawData) throws -> AcmeOrder
-    func `finalizeRequest`(`order`: AcmeOrder, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `finalizeResponse`(`finalize`: JsonRawData) throws -> AcmeFinalize
-    func `certificateRequest`(`finalize`: AcmeFinalize, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData
-    func `certificateResponse`(`certificateChain`: String) throws -> [String]
+    func `directoryResponse`(`directory`: [UInt8]) throws -> AcmeDirectory
+    func `newAccountRequest`(`previousNonce`: String) throws -> [UInt8]
+    func `newAccountResponse`(`account`: [UInt8]) throws
+    func `newOrderRequest`(`previousNonce`: String) throws -> [UInt8]
+    func `newOrderResponse`(`order`: [UInt8]) throws -> NewAcmeOrder
+    func `newAuthzRequest`(`url`: String, `previousNonce`: String) throws -> [UInt8]
+    func `newAuthzResponse`(`authz`: [UInt8]) throws -> NewAcmeAuthz
+    func `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String) throws -> String
+    func `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String) throws -> [UInt8]
+    func `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String) throws -> [UInt8]
+    func `newChallengeResponse`(`challenge`: [UInt8]) throws
+    func `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String) throws -> [UInt8]
+    func `checkOrderResponse`(`order`: [UInt8]) throws
+    func `finalizeRequest`(`previousNonce`: String) throws -> [UInt8]
+    func `finalizeResponse`(`finalize`: [UInt8]) throws
+    func `certificateRequest`(`previousNonce`: String) throws -> [UInt8]
     
 }
 
@@ -1122,201 +1135,165 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_3b31_WireE2eIdentity_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_fab4_WireE2eIdentity_object_free(pointer, $0) }
     }
 
     
 
     
-    public func `directoryResponse`(`directory`: JsonRawData) throws -> AcmeDirectory {
+    public func `directoryResponse`(`directory`: [UInt8]) throws -> AcmeDirectory {
         return try FfiConverterTypeAcmeDirectory.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_directory_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`directory`), $0
+    CoreCrypto_fab4_WireE2eIdentity_directory_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`directory`), $0
     )
 }
         )
     }
-    public func `newAccountRequest`(`directory`: AcmeDirectory, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `newAccountRequest`(`previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_account_request(self.pointer, 
-        FfiConverterTypeAcmeDirectory.lower(`directory`), 
+    CoreCrypto_fab4_WireE2eIdentity_new_account_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `newAccountResponse`(`account`: JsonRawData) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
-            try
+    public func `newAccountResponse`(`account`: [UInt8]) throws {
+        try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_account_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`account`), $0
+    CoreCrypto_fab4_WireE2eIdentity_new_account_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`account`), $0
     )
 }
-        )
     }
-    public func `newOrderRequest`(`displayName`: String, `clientId`: String, `handle`: String, `expiryDays`: UInt32, `directory`: AcmeDirectory, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `newOrderRequest`(`previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_order_request(self.pointer, 
-        FfiConverterString.lower(`displayName`), 
-        FfiConverterString.lower(`clientId`), 
-        FfiConverterString.lower(`handle`), 
-        FfiConverterUInt32.lower(`expiryDays`), 
-        FfiConverterTypeAcmeDirectory.lower(`directory`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
+    CoreCrypto_fab4_WireE2eIdentity_new_order_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `newOrderResponse`(`order`: JsonRawData) throws -> NewAcmeOrder {
+    public func `newOrderResponse`(`order`: [UInt8]) throws -> NewAcmeOrder {
         return try FfiConverterTypeNewAcmeOrder.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_order_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`order`), $0
+    CoreCrypto_fab4_WireE2eIdentity_new_order_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
         )
     }
-    public func `newAuthzRequest`(`url`: String, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `newAuthzRequest`(`url`: String, `previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_authz_request(self.pointer, 
+    CoreCrypto_fab4_WireE2eIdentity_new_authz_request(self.pointer, 
         FfiConverterString.lower(`url`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `newAuthzResponse`(`authz`: JsonRawData) throws -> NewAcmeAuthz {
+    public func `newAuthzResponse`(`authz`: [UInt8]) throws -> NewAcmeAuthz {
         return try FfiConverterTypeNewAcmeAuthz.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_authz_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`authz`), $0
+    CoreCrypto_fab4_WireE2eIdentity_new_authz_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`authz`), $0
     )
 }
         )
     }
-    public func `createDpopToken`(`accessTokenUrl`: String, `clientId`: String, `dpopChallenge`: AcmeChallenge, `backendNonce`: String, `expiryDays`: UInt32) throws -> String {
+    public func `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String) throws -> String {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_create_dpop_token(self.pointer, 
+    CoreCrypto_fab4_WireE2eIdentity_create_dpop_token(self.pointer, 
         FfiConverterString.lower(`accessTokenUrl`), 
-        FfiConverterString.lower(`clientId`), 
-        FfiConverterTypeAcmeChallenge.lower(`dpopChallenge`), 
-        FfiConverterString.lower(`backendNonce`), 
-        FfiConverterUInt32.lower(`expiryDays`), $0
+        FfiConverterString.lower(`backendNonce`), $0
     )
 }
         )
     }
-    public func `newDpopChallengeRequest`(`accessToken`: String, `dpopChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
+    CoreCrypto_fab4_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
         FfiConverterString.lower(`accessToken`), 
-        FfiConverterTypeAcmeChallenge.lower(`dpopChallenge`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `newOidcChallengeRequest`(`idToken`: String, `oidcChallenge`: AcmeChallenge, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
+    CoreCrypto_fab4_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
         FfiConverterString.lower(`idToken`), 
-        FfiConverterTypeAcmeChallenge.lower(`oidcChallenge`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `newChallengeResponse`(`challenge`: JsonRawData) throws {
+    public func `newChallengeResponse`(`challenge`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_new_challenge_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`challenge`), $0
+    CoreCrypto_fab4_WireE2eIdentity_new_challenge_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`challenge`), $0
     )
 }
     }
-    public func `checkOrderRequest`(`orderUrl`: String, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_check_order_request(self.pointer, 
+    CoreCrypto_fab4_WireE2eIdentity_check_order_request(self.pointer, 
         FfiConverterString.lower(`orderUrl`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `checkOrderResponse`(`order`: JsonRawData) throws -> AcmeOrder {
-        return try FfiConverterTypeAcmeOrder.lift(
-            try
+    public func `checkOrderResponse`(`order`: [UInt8]) throws {
+        try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_check_order_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`order`), $0
+    CoreCrypto_fab4_WireE2eIdentity_check_order_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
-        )
     }
-    public func `finalizeRequest`(`order`: AcmeOrder, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `finalizeRequest`(`previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_finalize_request(self.pointer, 
-        FfiConverterTypeAcmeOrder.lower(`order`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
+    CoreCrypto_fab4_WireE2eIdentity_finalize_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
         )
     }
-    public func `finalizeResponse`(`finalize`: JsonRawData) throws -> AcmeFinalize {
-        return try FfiConverterTypeAcmeFinalize.lift(
-            try
+    public func `finalizeResponse`(`finalize`: [UInt8]) throws {
+        try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_finalize_response(self.pointer, 
-        FfiConverterTypeJsonRawData.lower(`finalize`), $0
+    CoreCrypto_fab4_WireE2eIdentity_finalize_response(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`finalize`), $0
     )
 }
-        )
     }
-    public func `certificateRequest`(`finalize`: AcmeFinalize, `account`: AcmeAccount, `previousNonce`: String) throws -> JsonRawData {
-        return try FfiConverterTypeJsonRawData.lift(
+    public func `certificateRequest`(`previousNonce`: String) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_certificate_request(self.pointer, 
-        FfiConverterTypeAcmeFinalize.lower(`finalize`), 
-        FfiConverterTypeAcmeAccount.lower(`account`), 
+    CoreCrypto_fab4_WireE2eIdentity_certificate_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
-    )
-}
-        )
-    }
-    public func `certificateResponse`(`certificateChain`: String) throws -> [String] {
-        return try FfiConverterSequenceString.lift(
-            try
-    rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_3b31_WireE2eIdentity_certificate_response(self.pointer, 
-        FfiConverterString.lower(`certificateChain`), $0
     )
 }
         )
@@ -1357,12 +1334,12 @@ public struct FfiConverterTypeWireE2eIdentity: FfiConverter {
 
 
 public struct AcmeChallenge {
-    public var `delegate`: JsonRawData
+    public var `delegate`: [UInt8]
     public var `url`: String
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(`delegate`: JsonRawData, `url`: String) {
+    public init(`delegate`: [UInt8], `url`: String) {
         self.`delegate` = `delegate`
         self.`url` = `url`
     }
@@ -1390,13 +1367,13 @@ extension AcmeChallenge: Equatable, Hashable {
 public struct FfiConverterTypeAcmeChallenge: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AcmeChallenge {
         return try AcmeChallenge(
-            `delegate`: FfiConverterTypeJsonRawData.read(from: &buf), 
+            `delegate`: FfiConverterSequenceUInt8.read(from: &buf), 
             `url`: FfiConverterString.read(from: &buf)
         )
     }
 
     public static func write(_ value: AcmeChallenge, into buf: inout [UInt8]) {
-        FfiConverterTypeJsonRawData.write(value.`delegate`, into: &buf)
+        FfiConverterSequenceUInt8.write(value.`delegate`, into: &buf)
         FfiConverterString.write(value.`url`, into: &buf)
     }
 }
@@ -1452,52 +1429,6 @@ public struct FfiConverterTypeAcmeDirectory: FfiConverterRustBuffer {
         FfiConverterString.write(value.`newNonce`, into: &buf)
         FfiConverterString.write(value.`newAccount`, into: &buf)
         FfiConverterString.write(value.`newOrder`, into: &buf)
-    }
-}
-
-
-public struct AcmeFinalize {
-    public var `delegate`: JsonRawData
-    public var `certificateUrl`: String
-
-    // Default memberwise initializers are never public by default, so we
-    // declare one manually.
-    public init(`delegate`: JsonRawData, `certificateUrl`: String) {
-        self.`delegate` = `delegate`
-        self.`certificateUrl` = `certificateUrl`
-    }
-}
-
-
-extension AcmeFinalize: Equatable, Hashable {
-    public static func ==(lhs: AcmeFinalize, rhs: AcmeFinalize) -> Bool {
-        if lhs.`delegate` != rhs.`delegate` {
-            return false
-        }
-        if lhs.`certificateUrl` != rhs.`certificateUrl` {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(`delegate`)
-        hasher.combine(`certificateUrl`)
-    }
-}
-
-
-public struct FfiConverterTypeAcmeFinalize: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AcmeFinalize {
-        return try AcmeFinalize(
-            `delegate`: FfiConverterTypeJsonRawData.read(from: &buf), 
-            `certificateUrl`: FfiConverterString.read(from: &buf)
-        )
-    }
-
-    public static func write(_ value: AcmeFinalize, into buf: inout [UInt8]) {
-        FfiConverterTypeJsonRawData.write(value.`delegate`, into: &buf)
-        FfiConverterString.write(value.`certificateUrl`, into: &buf)
     }
 }
 
@@ -1943,12 +1874,12 @@ public struct FfiConverterTypeNewAcmeAuthz: FfiConverterRustBuffer {
 
 
 public struct NewAcmeOrder {
-    public var `delegate`: JsonRawData
+    public var `delegate`: [UInt8]
     public var `authorizations`: [String]
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(`delegate`: JsonRawData, `authorizations`: [String]) {
+    public init(`delegate`: [UInt8], `authorizations`: [String]) {
         self.`delegate` = `delegate`
         self.`authorizations` = `authorizations`
     }
@@ -1976,13 +1907,13 @@ extension NewAcmeOrder: Equatable, Hashable {
 public struct FfiConverterTypeNewAcmeOrder: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NewAcmeOrder {
         return try NewAcmeOrder(
-            `delegate`: FfiConverterTypeJsonRawData.read(from: &buf), 
+            `delegate`: FfiConverterSequenceUInt8.read(from: &buf), 
             `authorizations`: FfiConverterSequenceString.read(from: &buf)
         )
     }
 
     public static func write(_ value: NewAcmeOrder, into buf: inout [UInt8]) {
-        FfiConverterTypeJsonRawData.write(value.`delegate`, into: &buf)
+        FfiConverterSequenceUInt8.write(value.`delegate`, into: &buf)
         FfiConverterSequenceString.write(value.`authorizations`, into: &buf)
     }
 }
@@ -2768,7 +2699,13 @@ public enum E2eIdentityError {
     
     
     // Simple error enums only carry a message
+    case ImplementationError(message: String)
+    
+    // Simple error enums only carry a message
     case NotYetSupported(message: String)
+    
+    // Simple error enums only carry a message
+    case E2eiInvalidDomain(message: String)
     
     // Simple error enums only carry a message
     case CryptoError(message: String)
@@ -2783,10 +2720,13 @@ public enum E2eIdentityError {
     case JsonError(message: String)
     
     // Simple error enums only carry a message
-    case E2eiInvalidDomain(message: String)
+    case Utf8Error(message: String)
     
     // Simple error enums only carry a message
-    case Utf8Error(message: String)
+    case MlsError(message: String)
+    
+    // Simple error enums only carry a message
+    case LockPoisonError(message: String)
     
 }
 
@@ -2800,31 +2740,43 @@ public struct FfiConverterTypeE2eIdentityError: FfiConverterRustBuffer {
         
 
         
-        case 1: return .NotYetSupported(
+        case 1: return .ImplementationError(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 2: return .CryptoError(
+        case 2: return .NotYetSupported(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 3: return .IdentityError(
+        case 3: return .E2eiInvalidDomain(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 4: return .UrlError(
+        case 4: return .CryptoError(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 5: return .JsonError(
+        case 5: return .IdentityError(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 6: return .E2eiInvalidDomain(
+        case 6: return .UrlError(
             message: try FfiConverterString.read(from: &buf)
         )
         
-        case 7: return .Utf8Error(
+        case 7: return .JsonError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 8: return .Utf8Error(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 9: return .MlsError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
+        case 10: return .LockPoisonError(
             message: try FfiConverterString.read(from: &buf)
         )
         
@@ -2839,26 +2791,35 @@ public struct FfiConverterTypeE2eIdentityError: FfiConverterRustBuffer {
         
 
         
-        case let .NotYetSupported(message):
+        case let .ImplementationError(message):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(message, into: &buf)
-        case let .CryptoError(message):
+        case let .NotYetSupported(message):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(message, into: &buf)
-        case let .IdentityError(message):
+        case let .E2eiInvalidDomain(message):
             writeInt(&buf, Int32(3))
             FfiConverterString.write(message, into: &buf)
-        case let .UrlError(message):
+        case let .CryptoError(message):
             writeInt(&buf, Int32(4))
             FfiConverterString.write(message, into: &buf)
-        case let .JsonError(message):
+        case let .IdentityError(message):
             writeInt(&buf, Int32(5))
             FfiConverterString.write(message, into: &buf)
-        case let .E2eiInvalidDomain(message):
+        case let .UrlError(message):
             writeInt(&buf, Int32(6))
             FfiConverterString.write(message, into: &buf)
-        case let .Utf8Error(message):
+        case let .JsonError(message):
             writeInt(&buf, Int32(7))
+            FfiConverterString.write(message, into: &buf)
+        case let .Utf8Error(message):
+            writeInt(&buf, Int32(8))
+            FfiConverterString.write(message, into: &buf)
+        case let .MlsError(message):
+            writeInt(&buf, Int32(9))
+            FfiConverterString.write(message, into: &buf)
+        case let .LockPoisonError(message):
+            writeInt(&buf, Int32(10))
             FfiConverterString.write(message, into: &buf)
 
         
@@ -3052,7 +3013,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_3b31_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_fab4_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3448,54 +3409,6 @@ fileprivate struct FfiConverterDictionaryStringSequenceUInt8: FfiConverterRustBu
  * Typealias from the type name used in the UDL file to the builtin type.  This
  * is needed because the UDL type name is used in function/method signatures.
  */
-public typealias AcmeAccount = [UInt8]
-public struct FfiConverterTypeAcmeAccount: FfiConverter {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AcmeAccount {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
-    }
-
-    public static func write(_ value: AcmeAccount, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
-    }
-
-    public static func lift(_ value: RustBuffer) throws -> AcmeAccount {
-        return try FfiConverterSequenceUInt8.lift(value)
-    }
-
-    public static func lower(_ value: AcmeAccount) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
-    }
-}
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- */
-public typealias AcmeOrder = [UInt8]
-public struct FfiConverterTypeAcmeOrder: FfiConverter {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AcmeOrder {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
-    }
-
-    public static func write(_ value: AcmeOrder, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
-    }
-
-    public static func lift(_ value: RustBuffer) throws -> AcmeOrder {
-        return try FfiConverterSequenceUInt8.lift(value)
-    }
-
-    public static func lower(_ value: AcmeOrder) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
-    }
-}
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- */
 public typealias ClientId = [UInt8]
 public struct FfiConverterTypeClientId: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ClientId {
@@ -3544,30 +3457,6 @@ public struct FfiConverterTypeConversationId: FfiConverter {
  * Typealias from the type name used in the UDL file to the builtin type.  This
  * is needed because the UDL type name is used in function/method signatures.
  */
-public typealias JsonRawData = [UInt8]
-public struct FfiConverterTypeJsonRawData: FfiConverter {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> JsonRawData {
-        return try FfiConverterSequenceUInt8.read(from: &buf)
-    }
-
-    public static func write(_ value: JsonRawData, into buf: inout [UInt8]) {
-        return FfiConverterSequenceUInt8.write(value, into: &buf)
-    }
-
-    public static func lift(_ value: RustBuffer) throws -> JsonRawData {
-        return try FfiConverterSequenceUInt8.lift(value)
-    }
-
-    public static func lower(_ value: JsonRawData) -> RustBuffer {
-        return FfiConverterSequenceUInt8.lower(value)
-    }
-}
-
-
-/**
- * Typealias from the type name used in the UDL file to the builtin type.  This
- * is needed because the UDL type name is used in function/method signatures.
- */
 public typealias MemberId = [UInt8]
 public struct FfiConverterTypeMemberId: FfiConverter {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MemberId {
@@ -3593,7 +3482,7 @@ public func `version`()  -> String {
     
     rustCall() {
     
-    CoreCrypto_3b31_version($0)
+    CoreCrypto_fab4_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,335 +46,335 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_3b31_CoreCrypto_object_free(
+void ffi_CoreCrypto_fab4_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_3b31_CoreCrypto_new(
+void*_Nonnull CoreCrypto_fab4_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_3b31_CoreCrypto_deferred_init(
+void*_Nonnull CoreCrypto_fab4_CoreCrypto_deferred_init(
       RustBuffer path,RustBuffer key,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_mls_init(
+void CoreCrypto_fab4_CoreCrypto_mls_init(
       void*_Nonnull ptr,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_mls_generate_keypair(
+RustBuffer CoreCrypto_fab4_CoreCrypto_mls_generate_keypair(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_mls_init_with_client_id(
+void CoreCrypto_fab4_CoreCrypto_mls_init_with_client_id(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer signature_public_key,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_restore_from_disk(
+void CoreCrypto_fab4_CoreCrypto_restore_from_disk(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_set_callbacks(
+void CoreCrypto_fab4_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_fab4_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_fab4_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_3b31_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_fab4_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_create_conversation(
+void CoreCrypto_fab4_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_3b31_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_fab4_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_3b31_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_fab4_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_fab4_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_fab4_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_fab4_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_mark_conversation_as_child_of(
+void CoreCrypto_fab4_CoreCrypto_mark_conversation_as_child_of(
       void*_Nonnull ptr,RustBuffer child_id,RustBuffer parent_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_fab4_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_fab4_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_wipe_conversation(
+void CoreCrypto_fab4_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_fab4_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_fab4_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_fab4_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_fab4_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_fab4_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_fab4_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_fab4_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_fab4_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_fab4_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_fab4_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_fab4_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_fab4_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_get_client_ids(
+RustBuffer CoreCrypto_fab4_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_fab4_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_reseed_rng(
+void CoreCrypto_fab4_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_commit_accepted(
+void CoreCrypto_fab4_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_fab4_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_clear_pending_commit(
+void CoreCrypto_fab4_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_proteus_init(
+void CoreCrypto_fab4_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_fab4_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_proteus_session_save(
+void CoreCrypto_fab4_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_proteus_session_delete(
+void CoreCrypto_fab4_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_3b31_CoreCrypto_proteus_session_exists(
+int8_t CoreCrypto_fab4_CoreCrypto_proteus_session_exists(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_new_prekey_auto(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_new_prekey_auto(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-uint16_t CoreCrypto_3b31_CoreCrypto_proteus_last_resort_prekey_id(
+uint16_t CoreCrypto_fab4_CoreCrypto_proteus_last_resort_prekey_id(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_local(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_local(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_remote(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_remote(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_CoreCrypto_proteus_fingerprint_prekeybundle(
+RustBuffer CoreCrypto_fab4_CoreCrypto_proteus_fingerprint_prekeybundle(
       void*_Nonnull ptr,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_fab4_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_3b31_CoreCrypto_new_acme_enrollment(
-      void*_Nonnull ptr,RustBuffer ciphersuite,
+void*_Nonnull CoreCrypto_fab4_CoreCrypto_new_acme_enrollment(
+      void*_Nonnull ptr,RustBuffer client_id,RustBuffer display_name,RustBuffer handle,uint32_t expiry_days,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-uint32_t CoreCrypto_3b31_CoreCrypto_proteus_last_error_code(
+void CoreCrypto_fab4_CoreCrypto_e2ei_mls_init(
+      void*_Nonnull ptr,void*_Nonnull e2ei,RustBuffer certificate_chain,
+    RustCallStatus *_Nonnull out_status
+    );
+uint32_t CoreCrypto_fab4_CoreCrypto_proteus_last_error_code(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_3b31_WireE2eIdentity_object_free(
+void ffi_CoreCrypto_fab4_WireE2eIdentity_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_directory_response(
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_directory_response(
       void*_Nonnull ptr,RustBuffer directory,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_account_request(
-      void*_Nonnull ptr,RustBuffer directory,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_account_request(
+      void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_account_response(
+void CoreCrypto_fab4_WireE2eIdentity_new_account_response(
       void*_Nonnull ptr,RustBuffer account,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_order_request(
-      void*_Nonnull ptr,RustBuffer display_name,RustBuffer client_id,RustBuffer handle,uint32_t expiry_days,RustBuffer directory,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_order_request(
+      void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_order_response(
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_authz_request(
-      void*_Nonnull ptr,RustBuffer url,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_authz_request(
+      void*_Nonnull ptr,RustBuffer url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_authz_response(
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_authz_response(
       void*_Nonnull ptr,RustBuffer authz,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_create_dpop_token(
-      void*_Nonnull ptr,RustBuffer access_token_url,RustBuffer client_id,RustBuffer dpop_challenge,RustBuffer backend_nonce,uint32_t expiry_days,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_create_dpop_token(
+      void*_Nonnull ptr,RustBuffer access_token_url,RustBuffer backend_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_dpop_challenge_request(
-      void*_Nonnull ptr,RustBuffer access_token,RustBuffer dpop_challenge,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_dpop_challenge_request(
+      void*_Nonnull ptr,RustBuffer access_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_new_oidc_challenge_request(
-      void*_Nonnull ptr,RustBuffer id_token,RustBuffer oidc_challenge,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_new_oidc_challenge_request(
+      void*_Nonnull ptr,RustBuffer id_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_3b31_WireE2eIdentity_new_challenge_response(
+void CoreCrypto_fab4_WireE2eIdentity_new_challenge_response(
       void*_Nonnull ptr,RustBuffer challenge,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_check_order_request(
-      void*_Nonnull ptr,RustBuffer order_url,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_check_order_request(
+      void*_Nonnull ptr,RustBuffer order_url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_check_order_response(
+void CoreCrypto_fab4_WireE2eIdentity_check_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_finalize_request(
-      void*_Nonnull ptr,RustBuffer order,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_finalize_request(
+      void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_finalize_response(
+void CoreCrypto_fab4_WireE2eIdentity_finalize_response(
       void*_Nonnull ptr,RustBuffer finalize,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_certificate_request(
-      void*_Nonnull ptr,RustBuffer finalize,RustBuffer account,RustBuffer previous_nonce,
+RustBuffer CoreCrypto_fab4_WireE2eIdentity_certificate_request(
+      void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_WireE2eIdentity_certificate_response(
-      void*_Nonnull ptr,RustBuffer certificate_chain,
-    RustCallStatus *_Nonnull out_status
-    );
-void ffi_CoreCrypto_3b31_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_fab4_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_3b31_version(
+RustBuffer CoreCrypto_fab4_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_3b31_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_fab4_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_3b31_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_fab4_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_3b31_rustbuffer_free(
+void ffi_CoreCrypto_fab4_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_3b31_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_fab4_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -309,29 +309,26 @@ interface CoreCrypto {
     void proteus_cryptobox_migrate([ByRef] string path);
 
     [Throws=CryptoError]
-    WireE2eIdentity new_acme_enrollment(CiphersuiteName ciphersuite);
+    WireE2eIdentity new_acme_enrollment(string client_id, string display_name, string handle, u32 expiry_days, CiphersuiteName ciphersuite);
+
+    [Throws=CryptoError]
+    void e2ei_mls_init(WireE2eIdentity e2ei, string certificate_chain);
 
     u32 proteus_last_error_code();
 };
 
-[Custom]
-typedef sequence<u8> JsonRawData;
-
-[Custom]
-typedef sequence<u8> AcmeAccount;
-
-[Custom]
-typedef sequence<u8> AcmeOrder;
-
 [Error]
 enum E2eIdentityError {
+    "ImplementationError",
     "NotYetSupported",
+    "E2eiInvalidDomain",
     "CryptoError",
     "IdentityError",
     "UrlError",
     "JsonError",
-    "E2eiInvalidDomain",
     "Utf8Error",
+    "MlsError",
+    "LockPoisonError",
 };
 
 dictionary AcmeDirectory {
@@ -341,7 +338,7 @@ dictionary AcmeDirectory {
 };
 
 dictionary NewAcmeOrder {
-    JsonRawData delegate;
+    sequence<u8> delegate;
     sequence<string> authorizations;
 };
 
@@ -352,67 +349,59 @@ dictionary NewAcmeAuthz {
 };
 
 dictionary AcmeChallenge {
-    JsonRawData delegate;
+    sequence<u8> delegate;
     string url;
-};
-
-dictionary AcmeFinalize {
-    JsonRawData delegate;
-    string certificate_url;
 };
 
 interface WireE2eIdentity {
 
     [Throws=E2eIdentityError]
-    AcmeDirectory directory_response(JsonRawData directory);
+    AcmeDirectory directory_response(sequence<u8> directory);
 
     [Throws=E2eIdentityError]
-    JsonRawData new_account_request(AcmeDirectory directory, string previous_nonce);
+    sequence<u8> new_account_request(string previous_nonce);
 
     [Throws=E2eIdentityError]
-    JsonRawData new_account_response(JsonRawData account);
+    void new_account_response(sequence<u8> account);
 
     [Throws=E2eIdentityError]
-    JsonRawData new_order_request(string display_name, string client_id, string handle, u32 expiry_days, AcmeDirectory directory, AcmeAccount account, string previous_nonce);
+    sequence<u8> new_order_request(string previous_nonce);
 
     [Throws=E2eIdentityError]
-    NewAcmeOrder new_order_response(JsonRawData order);
+    NewAcmeOrder new_order_response(sequence<u8> order);
 
     [Throws=E2eIdentityError]
-    JsonRawData new_authz_request(string url, AcmeAccount account, string previous_nonce);
+    sequence<u8> new_authz_request(string url, string previous_nonce);
 
     [Throws=E2eIdentityError]
-    NewAcmeAuthz new_authz_response(JsonRawData authz);
+    NewAcmeAuthz new_authz_response(sequence<u8> authz);
 
     [Throws=E2eIdentityError]
-    string create_dpop_token(string access_token_url, string client_id, AcmeChallenge dpop_challenge, string backend_nonce, u32 expiry_days);
+    string create_dpop_token(string access_token_url, string backend_nonce);
 
     [Throws=E2eIdentityError]
-    JsonRawData new_dpop_challenge_request(string access_token, AcmeChallenge dpop_challenge, AcmeAccount account, string previous_nonce);
+    sequence<u8> new_dpop_challenge_request(string access_token, string previous_nonce);
 
     [Throws=E2eIdentityError]
-    JsonRawData new_oidc_challenge_request(string id_token, AcmeChallenge oidc_challenge, AcmeAccount account, string previous_nonce);
+    sequence<u8> new_oidc_challenge_request(string id_token, string previous_nonce);
 
     [Throws=E2eIdentityError]
-    void new_challenge_response(JsonRawData challenge);
+    void new_challenge_response(sequence<u8> challenge);
 
     [Throws=E2eIdentityError]
-    JsonRawData check_order_request(string order_url, AcmeAccount account, string previous_nonce);
+    sequence<u8> check_order_request(string order_url, string previous_nonce);
 
     [Throws=E2eIdentityError]
-    AcmeOrder check_order_response(JsonRawData order);
+    void check_order_response(sequence<u8> order);
 
     [Throws=E2eIdentityError]
-    JsonRawData finalize_request(AcmeOrder order, AcmeAccount account, string previous_nonce);
+    sequence<u8> finalize_request(string previous_nonce);
 
     [Throws=E2eIdentityError]
-    AcmeFinalize finalize_response(JsonRawData finalize);
+    void finalize_response(sequence<u8> finalize);
 
     [Throws=E2eIdentityError]
-    JsonRawData certificate_request(AcmeFinalize finalize, AcmeAccount account, string previous_nonce);
-
-    [Throws=E2eIdentityError]
-    sequence<string> certificate_response(string certificate_chain);
+    sequence<u8> certificate_request(string previous_nonce);
 };
 
 namespace CoreCrypto {

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -39,7 +39,8 @@ async-trait = "0.1"
 async-lock = "2.6"
 schnellru = "0.2"
 
-wire-e2e-identity = "0.2.0"
+wire-e2e-identity = "0.3.0"
+zeroize = "1.5"
 
 [dependencies.proteus-wasm]
 version = "2.0"

--- a/crypto/benches/utils/mls.rs
+++ b/crypto/benches/utils/mls.rs
@@ -142,18 +142,20 @@ pub fn setup_mls(
 
 pub fn new_central(
     ciphersuite: MlsCiphersuite,
-    credential: &Option<CertificateBundle>,
+    // TODO: always None for the moment. Need to update the benches with some realistic certificates
+    _credential: &Option<CertificateBundle>,
     in_memory: bool,
 ) -> (MlsCentral, tempfile::TempDir) {
     let (path, tmp_file) = tmp_db_file();
     let client_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 10);
     let secret = Alphanumeric.sample_string(&mut rand::thread_rng(), 10);
     let ciphersuites = vec![ciphersuite];
-    let cfg = MlsCentralConfiguration::try_new(path, secret, Some(client_id.as_bytes().into()), ciphersuites).unwrap();
+    let cfg =
+        MlsCentralConfiguration::try_new(path, secret, Some(client_id.as_bytes().into()), ciphersuites, None).unwrap();
     let central = if in_memory {
-        block_on(async { MlsCentral::try_new_in_memory(cfg, credential.clone()).await.unwrap() })
+        block_on(async { MlsCentral::try_new_in_memory(cfg).await.unwrap() })
     } else {
-        block_on(async { MlsCentral::try_new(cfg, credential.clone()).await.unwrap() })
+        block_on(async { MlsCentral::try_new(cfg).await.unwrap() })
     };
     (central, tmp_file)
 }

--- a/crypto/src/e2e_identity/crypto.rs
+++ b/crypto/src/e2e_identity/crypto.rs
@@ -5,10 +5,7 @@ use openmls_traits::{crypto::OpenMlsCrypto, types::Ciphersuite, OpenMlsCryptoPro
 use wire_e2e_identity::prelude::JwsAlgorithm;
 
 impl super::WireE2eIdentity {
-    pub(super) fn new_sign_keypair(
-        ciphersuite: MlsCiphersuite,
-        backend: &MlsCryptoProvider,
-    ) -> E2eIdentityResult<Vec<u8>> {
+    pub(super) fn new_sign_key(ciphersuite: MlsCiphersuite, backend: &MlsCryptoProvider) -> E2eIdentityResult<Vec<u8>> {
         let crypto = backend.crypto();
         let cs = openmls_traits::types::Ciphersuite::from(ciphersuite);
         let (sk, _pk) = crypto.signature_key_gen(cs.signature_algorithm())?;

--- a/crypto/src/e2e_identity/error.rs
+++ b/crypto/src/e2e_identity/error.rs
@@ -1,11 +1,16 @@
 //! End to end identity errors
 
+use crate::CryptoError;
+
 /// Wrapper over a [Result] of an end to end identity error
 pub type E2eIdentityResult<T> = Result<T, E2eIdentityError>;
 
 /// End to end identity errors
 #[derive(Debug, thiserror::Error)]
 pub enum E2eIdentityError {
+    /// Client misused this library
+    #[error("Incorrect usage of this API")]
+    ImplementationError,
     /// Incoming support
     #[error("Not yet supported")]
     NotYetSupported,
@@ -27,4 +32,10 @@ pub enum E2eIdentityError {
     /// Utf8 error
     #[error(transparent)]
     Utf8Error(#[from] ::core::str::Utf8Error),
+    /// MLS error
+    #[error(transparent)]
+    MlsError(#[from] CryptoError),
+    /// !!!! Something went very wrong and one of our locks has been poisoned by an in-thread panic !!!!
+    #[error("One of the locks has been poisoned")]
+    LockPoisonError,
 }

--- a/crypto/src/e2e_identity/mod.rs
+++ b/crypto/src/e2e_identity/mod.rs
@@ -1,10 +1,10 @@
+use openmls::prelude::SignaturePrivateKey;
 use wire_e2e_identity::prelude::RustyE2eIdentity;
 
 use error::*;
 use mls_crypto_provider::MlsCryptoProvider;
 
-use crate::prelude::ClientId;
-use crate::{prelude::MlsCentral, prelude::MlsCiphersuite};
+use crate::prelude::{CertificateBundle, ClientId, MlsCentral, MlsCiphersuite};
 
 mod crypto;
 pub mod error;
@@ -17,28 +17,97 @@ impl MlsCentral {
     /// a new x509 certificate from the acme server.
     /// Make sure to call [WireE2eIdentity::free] (not yet available) to dispose this instance and its associated
     /// keying material.
-    pub fn new_acme_enrollment(&self, ciphersuite: MlsCiphersuite) -> E2eIdentityResult<WireE2eIdentity> {
-        WireE2eIdentity::try_new(&self.mls_backend, ciphersuite)
+    ///
+    /// # Parameters
+    /// * `client_id` - client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
+    /// * `display_name` - human readable name displayed in the application e.g. `Smith, Alice M (QA)`
+    /// * `handle` - user handle e.g. `alice.smith.qa@example.com`
+    /// * `expiry_days` - generated x509 certificate expiry in days
+    pub fn new_acme_enrollment(
+        &self,
+        client_id: ClientId,
+        display_name: String,
+        handle: String,
+        expiry_days: u32,
+        ciphersuite: MlsCiphersuite,
+    ) -> E2eIdentityResult<WireE2eIdentity> {
+        WireE2eIdentity::try_new(
+            client_id,
+            display_name,
+            handle,
+            expiry_days,
+            &self.mls_backend,
+            ciphersuite,
+        )
+    }
+
+    /// Parses the ACME server response from the endpoint fetching x509 certificates and uses it
+    /// to initialize the MLS client with a certificate
+    pub async fn e2ei_mls_init(&mut self, e2ei: WireE2eIdentity, certificate_chain: String) -> E2eIdentityResult<()> {
+        e2ei.certificate_response(self, certificate_chain).await
     }
 }
 
 /// Wire end to end identity solution for fetching a x509 certificate which identifies a client.
-///
-/// Here are the steps to follow to implement it:
 #[derive(Debug)]
-pub struct WireE2eIdentity(RustyE2eIdentity);
+pub struct WireE2eIdentity {
+    delegate: RustyE2eIdentity,
+    sign_sk: Vec<u8>,
+    client_id: String,
+    display_name: String,
+    handle: String,
+    expiry: core::time::Duration,
+    directory: Option<types::E2eiAcmeDirectory>,
+    account: Option<wire_e2e_identity::prelude::E2eiAcmeAccount>,
+    authz: Option<wire_e2e_identity::prelude::E2eiNewAcmeAuthz>,
+    valid_order: Option<wire_e2e_identity::prelude::E2eiAcmeOrder>,
+    finalize: Option<wire_e2e_identity::prelude::E2eiAcmeFinalize>,
+    ciphersuite: MlsCiphersuite,
+}
+
+impl std::ops::Deref for WireE2eIdentity {
+    type Target = RustyE2eIdentity;
+
+    fn deref(&self) -> &Self::Target {
+        &self.delegate
+    }
+}
 
 impl WireE2eIdentity {
     /// Builds an instance holding private key material. This instance has to be used in the whole
     /// enrollment process then dropped to clear secret key material.
     ///
     /// # Parameters
-    /// * `sign_alg` - Signature algorithm (only Ed25519 for now)
-    /// * `raw_sign_kp` - Signature keypair in PEM format
-    pub fn try_new(backend: &MlsCryptoProvider, ciphersuite: MlsCiphersuite) -> E2eIdentityResult<Self> {
+    /// * `client_id` - client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
+    /// * `display_name` - human readable name displayed in the application e.g. `Smith, Alice M (QA)`
+    /// * `handle` - user handle e.g. `alice.smith.qa@example.com`
+    /// * `expiry_days` - generated x509 certificate expiry in days
+    pub fn try_new(
+        client_id: ClientId,
+        display_name: String,
+        handle: String,
+        expiry_days: u32,
+        backend: &MlsCryptoProvider,
+        ciphersuite: MlsCiphersuite,
+    ) -> E2eIdentityResult<Self> {
         let alg = ciphersuite.try_into()?;
-        let sign_kp = Self::new_sign_keypair(ciphersuite, backend)?;
-        Ok(Self(RustyE2eIdentity::try_new(alg, sign_kp)?))
+        let sign_sk = Self::new_sign_key(ciphersuite, backend)?;
+        let client_id = std::str::from_utf8(&client_id[..])?.to_string();
+        let expiry = core::time::Duration::from_secs(u64::from(expiry_days) * 24 * 3600);
+        Ok(Self {
+            delegate: RustyE2eIdentity::try_new(alg, sign_sk.clone())?,
+            sign_sk,
+            client_id,
+            display_name,
+            handle,
+            expiry,
+            directory: None,
+            account: None,
+            authz: None,
+            valid_order: None,
+            finalize: None,
+            ciphersuite,
+        })
     }
 
     /// Parses the response from `GET /acme/{provisioner-name}/directory`.
@@ -49,9 +118,11 @@ impl WireE2eIdentity {
     ///
     /// # Parameters
     /// * `directory` - http response body
-    pub fn directory_response(&self, directory: Json) -> E2eIdentityResult<types::E2eiAcmeDirectory> {
+    pub fn directory_response(&mut self, directory: Json) -> E2eIdentityResult<types::E2eiAcmeDirectory> {
         let directory = serde_json::from_slice(&directory[..])?;
-        Ok(self.0.acme_directory_response(directory)?.into())
+        let directory: types::E2eiAcmeDirectory = self.acme_directory_response(directory)?.into();
+        self.directory = Some(directory.clone());
+        Ok(directory)
     }
 
     /// For creating a new acme account. This returns a signed JWS-alike request body to send to
@@ -62,14 +133,9 @@ impl WireE2eIdentity {
     /// # Parameters
     /// * `directory` - you got from [Self::acme_directory_response]
     /// * `previous_nonce` - you got from calling `HEAD {directory.new_nonce}`
-    pub fn new_account_request(
-        &self,
-        directory: types::E2eiAcmeDirectory,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let account = self
-            .0
-            .acme_new_account_request(&directory.try_into()?, previous_nonce)?;
+    pub fn new_account_request(&self, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let directory = self.directory.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let account = self.acme_new_account_request(&directory.try_into()?, previous_nonce)?;
         let account = serde_json::to_vec(&account)?;
         Ok(account)
     }
@@ -80,9 +146,11 @@ impl WireE2eIdentity {
     ///
     /// # Parameters
     /// * `account` - http response body
-    pub fn new_account_response(&self, account: Json) -> E2eIdentityResult<types::E2eiAcmeAccount> {
+    pub fn new_account_response(&mut self, account: Json) -> E2eIdentityResult<()> {
         let account = serde_json::from_slice(&account[..])?;
-        self.0.acme_new_account_response(account)?.try_into()
+        let account = self.acme_new_account_response(account)?;
+        self.account = Some(account);
+        Ok(())
     }
 
     /// Creates a new acme order for the handle (userId + display name) and the clientId.
@@ -90,34 +158,18 @@ impl WireE2eIdentity {
     /// See [RFC 8555 Section 7.4](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4).
     ///
     /// # Parameters
-    /// * `display_name` - human readable name displayed in the application e.g. `Smith, Alice M (QA)`
-    /// * `client_id` - client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
-    /// * `handle` - user handle e.g. `alice.smith.qa@example.com`
-    /// * `expiry_days` - generated x509 certificate expiry in days
-    /// * `directory` - you got from [Self::acme_directory_response]
-    /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/new-account`
     #[allow(clippy::too_many_arguments)]
-    pub fn new_order_request(
-        &self,
-        display_name: &str,
-        client_id: ClientId,
-        handle: &str,
-        expiry_days: u32,
-        directory: types::E2eiAcmeDirectory,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let client_id: Vec<u8> = client_id.into();
-        let client_id = std::str::from_utf8(client_id.as_slice())?;
-        let expiry = core::time::Duration::from_secs(u64::from(expiry_days) * 3600 * 24);
-        let order = self.0.acme_new_order_request(
-            display_name,
-            client_id,
-            handle,
-            expiry,
+    pub fn new_order_request(&mut self, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let directory = self.directory.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let account = self.account.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let order = self.acme_new_order_request(
+            &self.display_name,
+            &self.client_id,
+            &self.handle,
+            self.expiry,
             &directory.try_into()?,
-            &account.try_into()?,
+            account,
             previous_nonce,
         )?;
         let order = serde_json::to_vec(&order)?;
@@ -132,7 +184,7 @@ impl WireE2eIdentity {
     /// * `new_order` - http response body
     pub fn new_order_response(&self, order: Json) -> E2eIdentityResult<types::E2eiNewAcmeOrder> {
         let order = serde_json::from_slice(&order[..])?;
-        self.0.acme_new_order_response(order)?.try_into()
+        self.acme_new_order_response(order)?.try_into()
     }
 
     /// Creates a new authorization request.
@@ -144,15 +196,9 @@ impl WireE2eIdentity {
     /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/new-order`
     /// (or from the previous to this method if you are creating the second authorization)
-    pub fn new_authz_request(
-        &self,
-        url: String,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let authz = self
-            .0
-            .acme_new_authz_request(&url.parse()?, &account.try_into()?, previous_nonce)?;
+    pub fn new_authz_request(&self, url: String, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let account = self.account.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let authz = self.acme_new_authz_request(&url.parse()?, account, previous_nonce)?;
         let authz = serde_json::to_vec(&authz)?;
         Ok(authz)
     }
@@ -163,9 +209,11 @@ impl WireE2eIdentity {
     ///
     /// # Parameters
     /// * `new_authz` - http response body
-    pub fn new_authz_response(&self, authz: Json) -> E2eIdentityResult<types::E2eiNewAcmeAuthz> {
+    pub fn new_authz_response(&mut self, authz: Json) -> E2eIdentityResult<types::E2eiNewAcmeAuthz> {
         let authz = serde_json::from_slice(&authz[..])?;
-        self.0.acme_new_authz_response(authz)?.try_into()
+        let authz = self.acme_new_authz_response(authz)?;
+        self.authz = Some(authz.clone());
+        authz.try_into()
     }
 
     /// Generates a new client Dpop JWT token. It demonstrates proof of possession of the nonces
@@ -178,30 +226,22 @@ impl WireE2eIdentity {
     ///
     /// # Parameters
     /// * `access_token_url` - backend endpoint where this token will be sent. Should be [this one](https://staging-nginz-https.zinfra.io/api/swagger-ui/#/default/post_clients__cid__access_token)
-    /// * `client_id` - client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
-    /// * `dpop_challenge` - you found after [Self::acme_new_authz_response]
     /// * `backend_nonce` - you get by calling `GET /clients/token/nonce` on wire-server.
     /// See endpoint [definition](https://staging-nginz-https.zinfra.io/api/swagger-ui/#/default/get_clients__client__nonce)
-    /// * `backend_nonce` - you get by calling `GET /clients/token/nonce` on wire-server.
     /// * `expiry` - token expiry
     #[allow(clippy::too_many_arguments)]
-    pub fn create_dpop_token(
-        &self,
-        access_token_url: String,
-        client_id: ClientId,
-        dpop_challenge: types::E2eiAcmeChallenge,
-        backend_nonce: String,
-        expiry_days: u32,
-    ) -> E2eIdentityResult<String> {
-        let client_id: Vec<u8> = client_id.into();
-        let client_id = std::str::from_utf8(client_id.as_slice())?;
-        let expiry = core::time::Duration::from_secs(u64::from(expiry_days) * 3600 * 24);
-        Ok(self.0.new_dpop_token(
+    pub fn create_dpop_token(&self, access_token_url: String, backend_nonce: String) -> E2eIdentityResult<String> {
+        let authz = self.authz.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let dpop_challenge = authz
+            .wire_dpop_challenge
+            .as_ref()
+            .ok_or(E2eIdentityError::ImplementationError)?;
+        Ok(self.new_dpop_token(
             &access_token_url.parse()?,
-            client_id,
-            &dpop_challenge.try_into()?,
+            &self.client_id,
+            dpop_challenge,
             backend_nonce,
-            expiry,
+            self.expiry,
         )?)
     }
 
@@ -214,19 +254,14 @@ impl WireE2eIdentity {
     /// * `dpop_challenge` - you found after [Self::acme_new_authz_response]
     /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/authz/{authz-id}`
-    pub fn new_dpop_challenge_request(
-        &self,
-        access_token: String,
-        dpop_challenge: types::E2eiAcmeChallenge,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let challenge = self.0.acme_dpop_challenge_request(
-            access_token,
-            &dpop_challenge.try_into()?,
-            &account.try_into()?,
-            previous_nonce,
-        )?;
+    pub fn new_dpop_challenge_request(&self, access_token: String, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let authz = self.authz.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let dpop_challenge = authz
+            .wire_dpop_challenge
+            .as_ref()
+            .ok_or(E2eIdentityError::ImplementationError)?;
+        let account = self.account.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let challenge = self.acme_dpop_challenge_request(access_token, dpop_challenge, account, previous_nonce)?;
         let challenge = serde_json::to_vec(&challenge)?;
         Ok(challenge)
     }
@@ -240,19 +275,14 @@ impl WireE2eIdentity {
     /// * `oidc_challenge` - you found after [Self::acme_new_authz_response]
     /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/authz/{authz-id}`
-    pub fn new_oidc_challenge_request(
-        &self,
-        id_token: String,
-        oidc_challenge: types::E2eiAcmeChallenge,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let challenge = self.0.acme_oidc_challenge_request(
-            id_token,
-            &oidc_challenge.try_into()?,
-            &account.try_into()?,
-            previous_nonce,
-        )?;
+    pub fn new_oidc_challenge_request(&self, id_token: String, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let authz = self.authz.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let oidc_challenge = authz
+            .wire_oidc_challenge
+            .as_ref()
+            .ok_or(E2eIdentityError::ImplementationError)?;
+        let account = self.account.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let challenge = self.acme_oidc_challenge_request(id_token, oidc_challenge, account, previous_nonce)?;
         let challenge = serde_json::to_vec(&challenge)?;
         Ok(challenge)
     }
@@ -265,7 +295,7 @@ impl WireE2eIdentity {
     /// * `challenge` - http response body
     pub fn new_challenge_response(&self, challenge: Json) -> E2eIdentityResult<()> {
         let challenge = serde_json::from_slice(&challenge[..])?;
-        Ok(self.0.acme_new_challenge_response(challenge)?)
+        Ok(self.acme_new_challenge_response(challenge)?)
     }
 
     /// Verifies that the previous challenge has been completed.
@@ -276,15 +306,9 @@ impl WireE2eIdentity {
     /// * `order_url` - `location` header from http response you got from [Self::acme_new_order_response]
     /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/challenge/{challenge-id}`
-    pub fn check_order_request(
-        &self,
-        order_url: String,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let order = self
-            .0
-            .acme_check_order_request(order_url.parse()?, &account.try_into()?, previous_nonce)?;
+    pub fn check_order_request(&self, order_url: String, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let account = self.account.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let order = self.acme_check_order_request(order_url.parse()?, account, previous_nonce)?;
         let order = serde_json::to_vec(&order)?;
         Ok(order)
     }
@@ -295,9 +319,11 @@ impl WireE2eIdentity {
     ///
     /// # Parameters
     /// * `order` - http response body
-    pub fn check_order_response(&self, order: Json) -> E2eIdentityResult<types::E2eiAcmeOrder> {
+    pub fn check_order_response(&mut self, order: Json) -> E2eIdentityResult<()> {
         let order = serde_json::from_slice(&order[..])?;
-        self.0.acme_check_order_response(order)?.try_into()
+        let valid_order = self.acme_check_order_response(order)?;
+        self.valid_order = Some(valid_order);
+        Ok(())
     }
 
     /// Final step before fetching the certificate.
@@ -309,15 +335,10 @@ impl WireE2eIdentity {
     /// * `order` - you got from [Self::acme_check_order_response]
     /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/order/{order-id}`
-    pub fn finalize_request(
-        &self,
-        order: types::E2eiAcmeOrder,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let finalize = self
-            .0
-            .acme_finalize_request(order.try_into()?, &account.try_into()?, previous_nonce)?;
+    pub fn finalize_request(&mut self, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let account = self.account.as_ref().ok_or(E2eIdentityError::ImplementationError)?;
+        let order = self.valid_order.take().ok_or(E2eIdentityError::ImplementationError)?;
+        let finalize = self.acme_finalize_request(order, account, previous_nonce)?;
         let finalize = serde_json::to_vec(&finalize)?;
         Ok(finalize)
     }
@@ -328,9 +349,11 @@ impl WireE2eIdentity {
     ///
     /// # Parameters
     /// * `finalize` - http response body
-    pub fn finalize_response(&self, finalize: Json) -> E2eIdentityResult<types::E2eiAcmeFinalize> {
+    pub fn finalize_response(&mut self, finalize: Json) -> E2eIdentityResult<()> {
         let finalize = serde_json::from_slice(&finalize[..])?;
-        self.0.acme_finalize_response(finalize)?.try_into()
+        let finalize = self.acme_finalize_response(finalize)?;
+        self.finalize = Some(finalize);
+        Ok(())
     }
 
     /// Creates a request for finally fetching the x509 certificate.
@@ -341,50 +364,55 @@ impl WireE2eIdentity {
     /// * `finalize` - you got from [Self::finalize_response]
     /// * `account` - you got from [Self::acme_new_account_response]
     /// * `previous_nonce` - `replay-nonce` response header from `POST /acme/{provisioner-name}/order/{order-id}/finalize`
-    pub fn certificate_request(
-        &self,
-        finalize: types::E2eiAcmeFinalize,
-        account: types::E2eiAcmeAccount,
-        previous_nonce: String,
-    ) -> E2eIdentityResult<Json> {
-        let certificate =
-            self.0
-                .acme_x509_certificate_request(finalize.try_into()?, account.try_into()?, previous_nonce)?;
+    pub fn certificate_request(&mut self, previous_nonce: String) -> E2eIdentityResult<Json> {
+        let account = self.account.take().ok_or(E2eIdentityError::ImplementationError)?;
+        let finalize = self.finalize.take().ok_or(E2eIdentityError::ImplementationError)?;
+        let certificate = self.acme_x509_certificate_request(finalize, account, previous_nonce)?;
         let certificate = serde_json::to_vec(&certificate)?;
         Ok(certificate)
     }
 
-    /// Parses the response from `POST /acme/{provisioner-name}/certificate/{certificate-id}`.
-    ///
-    /// See [RFC 8555 Section 7.4.2](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4.2)
-    ///
-    /// # Parameters
-    /// * `response` - http string response body
-    pub fn certificate_response(&self, certificate_chain: String) -> E2eIdentityResult<Vec<String>> {
-        Ok(self.0.acme_x509_certificate_response(certificate_chain)?)
-    }
-
-    // TODO: expose this across the FFI
-    /// Drops this instance and all its associated private key material
-    pub fn free(self) {
-        drop(self)
+    async fn certificate_response(
+        self,
+        mls_central: &mut MlsCentral,
+        certificate_chain: String,
+    ) -> E2eIdentityResult<()> {
+        let certificate_chain = self.acme_x509_certificate_response(certificate_chain)?;
+        let private_key = SignaturePrivateKey {
+            value: self.sign_sk,
+            signature_scheme: self.ciphersuite.signature_algorithm(),
+        };
+        let cb = CertificateBundle {
+            certificate_chain,
+            private_key,
+        };
+        let client_id = ClientId::from(self.client_id.as_bytes());
+        mls_central
+            .mls_init(client_id, vec![self.ciphersuite], Some(cb))
+            .await?;
+        Ok(())
     }
 }
 
 #[cfg(test)]
 pub mod tests {
-    use crate::prelude::ClientId;
     use openmls::prelude::SignatureScheme;
     use serde_json::json;
     use wasm_bindgen_test::*;
 
+    use crate::prelude::ClientId;
     use crate::test_utils::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
+    // #[async_std::test]
     pub async fn e2e_identity_should_work(case: TestCase) {
+        /*let case = TestCase::new(
+            crate::mls::credential::CertificateBundle::rand_basic(),
+            openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+        );*/
         #[cfg(not(target_family = "wasm"))]
         let supported_alg = [
             SignatureScheme::ED25519,
@@ -396,20 +424,27 @@ pub mod tests {
         let supported_alg = [SignatureScheme::ED25519];
 
         if supported_alg.contains(&case.signature_scheme()) {
-            run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
+            run_test_wo_clients(case.clone(), move |mut cc| {
                 Box::pin(async move {
-                    let enrollment = cc.new_acme_enrollment(case.ciphersuite()).unwrap();
+                    let display_name = "Smith, Alice M (QA)".to_string();
+                    let domain = "example.com";
+                    let client_id: ClientId =
+                        format!("NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@{domain}").as_str().into();
+                    let handle = format!("alice.smith.qa@{domain}");
+                    let expiry = 90;
+
+                    let mut enrollment = cc.new_acme_enrollment(client_id, display_name, handle, expiry, case.ciphersuite()).unwrap();
                     let directory = json!({
                         "newNonce": "https://example.com/acme/new-nonce",
                         "newAccount": "https://example.com/acme/new-account",
                         "newOrder": "https://example.com/acme/new-order"
                     });
                     let directory = serde_json::to_vec(&directory).unwrap();
-                    let directory = enrollment.directory_response(directory).unwrap();
+                    enrollment.directory_response(directory).unwrap();
 
                     let previous_nonce = "YUVndEZQVTV6ZUNlUkJxRG10c0syQmNWeW1kanlPbjM";
                     let _account_req = enrollment
-                        .new_account_request(directory.clone(), previous_nonce.to_string())
+                        .new_account_request( previous_nonce.to_string())
                         .unwrap();
 
                     let account_resp = json!({
@@ -417,25 +452,9 @@ pub mod tests {
                         "orders": "https://example.com/acme/acct/evOfKhNU60wg/orders"
                     });
                     let account_resp = serde_json::to_vec(&account_resp).unwrap();
-                    let account = enrollment.new_account_response(account_resp).unwrap();
+                    enrollment.new_account_response(account_resp).unwrap();
 
-                    let display_name = "Smith, Alice M (QA)".to_string();
-                    let domain = "example.com";
-                    let client_id: ClientId =
-                        format!("NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@{domain}").as_str().into();
-                    let handle = format!("alice.smith.qa@{domain}");
-
-                    let _order_req = enrollment
-                        .new_order_request(
-                            &display_name,
-                            client_id.clone(),
-                            &handle,
-                            90,
-                            directory,
-                            account.clone(),
-                            previous_nonce.to_string(),
-                        )
-                        .unwrap();
+                    let _order_req = enrollment.new_order_request(previous_nonce.to_string()).unwrap();
 
                     let order_resp = json!({
                         "status": "pending",
@@ -459,7 +478,7 @@ pub mod tests {
 
                     let authz_url = new_order.authorizations.get(0).unwrap();
                     let _authz_req = enrollment
-                        .new_authz_request(authz_url.to_string(), account.clone(), previous_nonce.to_string())
+                        .new_authz_request(authz_url.to_string(), previous_nonce.to_string())
                         .unwrap();
 
                     let authz_resp = json!({
@@ -485,31 +504,16 @@ pub mod tests {
                         ]
                     });
                     let authz_resp = serde_json::to_vec(&authz_resp).unwrap();
-                    let authz = enrollment.new_authz_response(authz_resp).unwrap();
-
-                    let (dpop_chall, oidc_chall) = {
-                        (
-                            authz.wire_dpop_challenge.clone().unwrap(),
-                            authz.wire_oidc_challenge.unwrap(),
-                        )
-                    };
+                     enrollment.new_authz_response(authz_resp).unwrap();
 
                     let backend_nonce = "U09ZR0tnWE5QS1ozS2d3bkF2eWJyR3ZVUHppSTJsMnU";
-                    let dpop_url = format!("https://example.org/clients/42/access-token");
+                    let dpop_url = "https://example.org/clients/42/access-token".to_string();
 
-                    let _dpop_token = enrollment
-                        .create_dpop_token(
-                            dpop_url,
-                            client_id,
-                            dpop_chall.clone(),
-                            backend_nonce.to_string(),
-                            90,
-                        )
-                        .unwrap();
+                    let _dpop_token = enrollment.create_dpop_token(dpop_url, backend_nonce.to_string()).unwrap();
 
                     let access_token = "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InlldjZPWlVudWlwbmZrMHRWZFlLRnM5MWpSdjVoVmF6a2llTEhBTmN1UEUifX0.eyJpYXQiOjE2NzU5NjE3NTYsImV4cCI6MTY4MzczNzc1NiwibmJmIjoxNjc1OTYxNzU2LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjU5MzA3LyIsInN1YiI6ImltcHA6d2lyZWFwcD1OREV5WkdZd05qYzJNekZrTkRCaU5UbGxZbVZtTWpReVpUSXpOVGM0TldRLzY1YzNhYzFhMTYzMWMxMzZAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjU5MzA3LyIsImp0aSI6Ijk4NGM1OTA0LWZhM2UtNDVhZi1iZGM1LTlhODMzNjkxOGUyYiIsIm5vbmNlIjoiYjNWSU9YTk9aVE4xVUV0b2FXSk9VM1owZFVWdWJFMDNZV1ZIUVdOb2NFMCIsImNoYWwiOiJTWTc0dEptQUlJaGR6UnRKdnB4Mzg5ZjZFS0hiWHV4USIsImNuZiI6eyJraWQiOiJocG9RV2xNUmtjUURKN2xNcDhaSHp4WVBNVDBJM0Vhc2VqUHZhWmlGUGpjIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pZVVGM1QxVmZTMXBpYUV0SFIxUjRaMGQ0WTJsa1VVZHFiMUpXWkdOdFlWQmpSblI0VG5Gd1gydzJTU0o5ZlEuZXlKcFlYUWlPakUyTnpVNU5qRTNOVFlzSW1WNGNDSTZNVFkzTmpBME9ERTFOaXdpYm1KbUlqb3hOamMxT1RZeE56VTJMQ0p6ZFdJaU9pSnBiWEJ3T25kcGNtVmhjSEE5VGtSRmVWcEhXWGRPYW1NeVRYcEdhMDVFUW1sT1ZHeHNXVzFXYlUxcVVYbGFWRWw2VGxSak5FNVhVUzgyTldNellXTXhZVEUyTXpGak1UTTJRR1Y0WVcxd2JHVXVZMjl0SWl3aWFuUnBJam9pTlRBM09HWmtaVEl0TlRCaU9DMDBabVZtTFdJeE5EQXRNekJrWVRrellqQmtZems1SWl3aWJtOXVZMlVpT2lKaU0xWkpUMWhPVDFwVVRqRlZSWFJ2WVZkS1QxVXpXakJrVlZaMVlrVXdNMWxYVmtoUlYwNXZZMFV3SWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5c2IyTmhiR2h2YzNRNk5Ua3pNRGN2SWl3aVkyaGhiQ0k2SWxOWk56UjBTbTFCU1Vsb1pIcFNkRXAyY0hnek9EbG1Oa1ZMU0dKWWRYaFJJbjAuQk1MS1Y1OG43c1dITXkxMlUtTHlMc0ZJSkd0TVNKcXVoUkZvYnV6ZTlGNEpBN1NjdlFWSEdUTFF2ZVZfUXBfUTROZThyeU9GcEphUTc1VW5ORHR1RFEiLCJjbGllbnRfaWQiOiJpbXBwOndpcmVhcHA9TkRFeVpHWXdOamMyTXpGa05EQmlOVGxsWW1WbU1qUXlaVEl6TlRjNE5XUS82NWMzYWMxYTE2MzFjMTM2QGV4YW1wbGUuY29tIiwiYXBpX3ZlcnNpb24iOjMsInNjb3BlIjoid2lyZV9jbGllbnRfaWQifQ.Tf10dkKrNikGNgGhIdkrMHb0v6Jpde09MaIyBeuY6KORcxuglMGY7_V9Kd0LcVVPMDy1q4xbd39ZqosGz1NUBQ".to_string();
                     let _dpop_chall_req = enrollment
-                        .new_dpop_challenge_request(access_token, dpop_chall, account.clone(), previous_nonce.to_string())
+                        .new_dpop_challenge_request(access_token, previous_nonce.to_string())
                         .unwrap();
                     let dpop_chall_resp = json!({
                         "type": "wire-dpop-01",
@@ -522,7 +526,7 @@ pub mod tests {
 
                     let id_token = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NzU5NjE3NTYsImV4cCI6MTY3NjA0ODE1NiwibmJmIjoxNjc1OTYxNzU2LCJpc3MiOiJodHRwOi8vaWRwLyIsInN1YiI6ImltcHA6d2lyZWFwcD1OREV5WkdZd05qYzJNekZrTkRCaU5UbGxZbVZtTWpReVpUSXpOVGM0TldRLzY1YzNhYzFhMTYzMWMxMzZAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwOi8vaWRwLyIsIm5hbWUiOiJTbWl0aCwgQWxpY2UgTSAoUUEpIiwiaGFuZGxlIjoiaW1wcDp3aXJlYXBwPWFsaWNlLnNtaXRoLnFhQGV4YW1wbGUuY29tIiwia2V5YXV0aCI6IlNZNzR0Sm1BSUloZHpSdEp2cHgzODlmNkVLSGJYdXhRLi15V29ZVDlIQlYwb0ZMVElSRGw3cjhPclZGNFJCVjhOVlFObEw3cUxjbWcifQ.0iiq3p5Bmmp8ekoFqv4jQu_GrnPbEfxJ36SCuw-UvV6hCi6GlxOwU7gwwtguajhsd1sednGWZpN8QssKI5_CDQ".to_string();
                     let _oidc_chall_req = enrollment
-                        .new_oidc_challenge_request(id_token, oidc_chall, account.clone(), previous_nonce.to_string())
+                        .new_oidc_challenge_request(id_token, previous_nonce.to_string())
                         .unwrap();
                     let oidc_chall_resp = json!({
                         "type": "wire-oidc-01",
@@ -534,7 +538,7 @@ pub mod tests {
                     enrollment.new_challenge_response(oidc_chall_resp).unwrap();
 
                     let _get_order_req = enrollment
-                        .check_order_request(order_url.to_string(), account.clone(), previous_nonce.to_string())
+                        .check_order_request(order_url.to_string(), previous_nonce.to_string())
                         .unwrap();
 
                     let order_resp = json!({
@@ -554,10 +558,10 @@ pub mod tests {
                       "notAfter": "2032-02-09T15:59:20.442908Z"
                     });
                     let order_resp = serde_json::to_vec(&order_resp).unwrap();
-                    let order = enrollment.check_order_response(order_resp).unwrap();
+                    enrollment.check_order_response(order_resp).unwrap();
 
                     let _finalize_req = enrollment
-                        .finalize_request(order, account.clone(), previous_nonce.to_string())
+                        .finalize_request( previous_nonce.to_string())
                         .unwrap();
                     let finalize_resp = json!({
                       "certificate": "https://localhost:55170/acme/acme/certificate/rLhCIYygqzWhUmP1i5tmtZxFUvJPFxSL",
@@ -577,10 +581,10 @@ pub mod tests {
                       "notAfter": "2032-02-09T15:59:20.442908Z"
                     });
                     let finalize_resp = serde_json::to_vec(&finalize_resp).unwrap();
-                    let finalize = enrollment.finalize_response(finalize_resp).unwrap();
+                     enrollment.finalize_response(finalize_resp).unwrap();
 
                     let _certificate_req = enrollment
-                        .certificate_request(finalize, account, previous_nonce.to_string())
+                        .certificate_request( previous_nonce.to_string())
                         .unwrap();
 
                     let certificate_resp = r#"-----BEGIN CERTIFICATE-----
@@ -610,8 +614,7 @@ gBTqNi9/bemraZjLYA8TGat3ianEizAKBggqhkjOPQQDAgNIADBFAiEAuo8JLvys
 IvUCvPUJi1++80IgPeRxxRvn5zlHDh3qKZECIHONc1xx1ixlIyp9mOtdeTvG5Dql
 RheWYpDHRiLax1Id
 -----END CERTIFICATE-----"#;
-                    enrollment.certificate_response(certificate_resp.to_string()).unwrap();
-                    enrollment.free();
+                    cc.e2ei_mls_init(enrollment, certificate_resp.to_string()).await.unwrap();
                 })
             })
             .await

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -27,14 +27,14 @@
 use rstest_reuse;
 
 #[cfg(test)]
-#[macro_use]
-pub mod test_utils;
-// both imports above have to be defined at the beginning of the crate for rstest to work
+pub use core_crypto_attributes::durable;
 
 pub use self::error::*;
 
 #[cfg(test)]
-pub use core_crypto_attributes::durable;
+#[macro_use]
+pub mod test_utils;
+// both imports above have to be defined at the beginning of the crate for rstest to work
 
 mod error;
 
@@ -67,10 +67,7 @@ pub mod prelude {
     pub use crate::{
         e2e_identity::{
             error::{E2eIdentityError, E2eIdentityResult},
-            types::{
-                E2eiAcmeAccount, E2eiAcmeChallenge, E2eiAcmeDirectory, E2eiAcmeFinalize, E2eiAcmeOrder,
-                E2eiNewAcmeAuthz, E2eiNewAcmeOrder,
-            },
+            types::{E2eiAcmeChallenge, E2eiAcmeDirectory, E2eiNewAcmeAuthz, E2eiNewAcmeOrder},
             WireE2eIdentity,
         },
         error::*,

--- a/crypto/src/mls/client.rs
+++ b/crypto/src/mls/client.rs
@@ -40,7 +40,7 @@ const KEYPACKAGE_DEFAULT_LIFETIME: std::time::Duration = std::time::Duration::fr
 /// mobile, etc. Users can have multiple clients.
 /// More information [here](https://messaginglayersecurity.rocks/mls-architecture/draft-ietf-mls-architecture.html#name-group-members-and-clients)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::Deref)]
-pub struct ClientId(Vec<u8>);
+pub struct ClientId(pub(crate) Vec<u8>);
 
 impl From<&[u8]> for ClientId {
     fn from(value: &[u8]) -> Self {
@@ -595,7 +595,6 @@ impl Client {
 
 #[cfg(test)]
 pub mod tests {
-    use super::identity_key;
     use openmls::prelude::{KeyPackageBundle, KeyPackageRef};
     use wasm_bindgen_test::*;
 
@@ -603,6 +602,7 @@ pub mod tests {
 
     use crate::test_utils::*;
 
+    use super::identity_key;
     use super::Client;
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -396,9 +396,10 @@ pub mod tests {
                         name.clone(),
                         Some(name.as_str().into()),
                         vec![case.ciphersuite()],
+                        None,
                     )
                     .unwrap();
-                    let central = MlsCentral::try_new(config, case.credential()).await.unwrap();
+                    let central = MlsCentral::try_new(config).await.unwrap();
                     bob_and_friends.push(central);
                 }
 

--- a/crypto/src/proteus.rs
+++ b/crypto/src/proteus.rs
@@ -951,9 +951,15 @@ mod tests {
     async fn cc_can_init(case: TestCase) {
         let (path, db_file) = tmp_db_file();
         let client_id = "alice".into();
-        let cfg = MlsCentralConfiguration::try_new(path, "test".to_string(), Some(client_id), vec![case.ciphersuite()])
-            .unwrap();
-        let mut cc: CoreCrypto = MlsCentral::try_new(cfg, case.credential()).await.unwrap().into();
+        let cfg = MlsCentralConfiguration::try_new(
+            path,
+            "test".to_string(),
+            Some(client_id),
+            vec![case.ciphersuite()],
+            None,
+        )
+        .unwrap();
+        let mut cc: CoreCrypto = MlsCentral::try_new(cfg).await.unwrap().into();
         assert!(cc.proteus_init().await.is_ok());
         assert!(cc.proteus_new_prekey(1).await.is_ok());
         drop(db_file);
@@ -964,8 +970,9 @@ mod tests {
     async fn cc_can_2_phase_init(case: TestCase) {
         let (path, db_file) = tmp_db_file();
         // we are deferring MLS initialization here, not passing a MLS 'client_id' yet
-        let cfg = MlsCentralConfiguration::try_new(path, "test".to_string(), None, vec![case.ciphersuite()]).unwrap();
-        let mut cc: CoreCrypto = MlsCentral::try_new(cfg, case.credential()).await.unwrap().into();
+        let cfg =
+            MlsCentralConfiguration::try_new(path, "test".to_string(), None, vec![case.ciphersuite()], None).unwrap();
+        let mut cc: CoreCrypto = MlsCentral::try_new(cfg).await.unwrap().into();
         assert!(cc.proteus_init().await.is_ok());
         // proteus is initialized, prekeys can be generated
         assert!(cc.proteus_new_prekey(1).await.is_ok());

--- a/interop/src/clients/corecrypto/e2ei.js
+++ b/interop/src/clients/corecrypto/e2ei.js
@@ -1,5 +1,11 @@
 const [callback] = arguments;
 
+let clientConfig = {
+    "databaseName": "db-e2ei",
+    "key": "test"
+}
+window.cc = await window.CoreCrypto.deferredInit(clientConfig);
+
 const encoder = new TextEncoder();
 
 const jsonToByteArray = function (json) {
@@ -7,29 +13,30 @@ const jsonToByteArray = function (json) {
     return encoder.encode(str);
 };
 
-let enrollment = await window.cc.newAcmeEnrollment();
+let clientId = "NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@example.com";
+let displayName = "Smith, Alice M (QA)";
+let handle = "alice.smith.qa@example.com";
+let expiry = 90;
+
+let enrollment = await window.cc.newAcmeEnrollment(clientId, displayName, handle, expiry);
 
 let directoryResp = {
     "newNonce": "https://example.com/acme/new-nonce",
     "newAccount": "https://example.com/acme/new-account",
     "newOrder": "https://example.com/acme/new-order"
 };
-let directory = enrollment.directoryResponse(jsonToByteArray(directoryResp));
+enrollment.directoryResponse(jsonToByteArray(directoryResp));
 
 let previousNonce = "YUVndEZQVTV6ZUNlUkJxRG10c0syQmNWeW1kanlPbjM";
-let accountReq = enrollment.newAccountRequest(directory, previousNonce);
+let accountReq = enrollment.newAccountRequest(previousNonce);
 
 let accountResp = {
     "status": "valid",
     "orders": "https://example.com/acme/acct/evOfKhNU60wg/orders"
 };
-let account = enrollment.newAccountResponse(jsonToByteArray(accountResp));
+enrollment.newAccountResponse(jsonToByteArray(accountResp));
 
-let displayName = "Smith, Alice M (QA)";
-let utf8Encode = new TextEncoder();
-let clientId = "NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@example.com";
-let handle = "alice.smith.qa@example.com";
-let newOrderReq = enrollment.newOrderRequest(displayName, clientId, handle, 90, directory, account, previousNonce);
+let newOrderReq = enrollment.newOrderRequest(previousNonce);
 
 let newOrderResp = {
     "status": "pending",
@@ -50,7 +57,7 @@ let newOrderResp = {
 let newOrder = enrollment.newOrderResponse(jsonToByteArray(newOrderResp));
 
 let authzUrl = "https://example.com/acme/wire-acme/authz/1Mw1NcVgu1cusB9RTdtFVdEo6UQDueZm";
-let authzReq = enrollment.newAuthzRequest(authzUrl, account, previousNonce);
+let authzReq = enrollment.newAuthzRequest(authzUrl, previousNonce);
 
 let authzResp = {
     "status": "pending",
@@ -76,35 +83,32 @@ let authzResp = {
 };
 let authz = enrollment.newAuthzResponse(jsonToByteArray(authzResp));
 
-let dpopChall = authz.wireDpopChallenge;
-let oidcChall = authz.wireOidcChallenge;
-
 let accessTokenUrl = "https://example.org/clients/42/access-token";
 let backendNonce = "U09ZR0tnWE5QS1ozS2d3bkF2eWJyR3ZVUHppSTJsMnU";
-let clientDpopToken = enrollment.createDpopToken(accessTokenUrl, clientId, dpopChall, backendNonce, 90);
+let clientDpopToken = enrollment.createDpopToken(accessTokenUrl, backendNonce);
 
 let accessToken = "eyJhbGciOiJFZERTQSIsInR5cCI6ImF0K2p3dCIsImp3ayI6eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InlldjZPWlVudWlwbmZrMHRWZFlLRnM5MWpSdjVoVmF6a2llTEhBTmN1UEUifX0.eyJpYXQiOjE2NzU5NjE3NTYsImV4cCI6MTY4MzczNzc1NiwibmJmIjoxNjc1OTYxNzU2LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjU5MzA3LyIsInN1YiI6ImltcHA6d2lyZWFwcD1OREV5WkdZd05qYzJNekZrTkRCaU5UbGxZbVZtTWpReVpUSXpOVGM0TldRLzY1YzNhYzFhMTYzMWMxMzZAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwOi8vbG9jYWxob3N0OjU5MzA3LyIsImp0aSI6Ijk4NGM1OTA0LWZhM2UtNDVhZi1iZGM1LTlhODMzNjkxOGUyYiIsIm5vbmNlIjoiYjNWSU9YTk9aVE4xVUV0b2FXSk9VM1owZFVWdWJFMDNZV1ZIUVdOb2NFMCIsImNoYWwiOiJTWTc0dEptQUlJaGR6UnRKdnB4Mzg5ZjZFS0hiWHV4USIsImNuZiI6eyJraWQiOiJocG9RV2xNUmtjUURKN2xNcDhaSHp4WVBNVDBJM0Vhc2VqUHZhWmlGUGpjIn0sInByb29mIjoiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNkltUndiM0FyYW5kMElpd2lhbmRySWpwN0ltdDBlU0k2SWs5TFVDSXNJbU55ZGlJNklrVmtNalUxTVRraUxDSjRJam9pZVVGM1QxVmZTMXBpYUV0SFIxUjRaMGQ0WTJsa1VVZHFiMUpXWkdOdFlWQmpSblI0VG5Gd1gydzJTU0o5ZlEuZXlKcFlYUWlPakUyTnpVNU5qRTNOVFlzSW1WNGNDSTZNVFkzTmpBME9ERTFOaXdpYm1KbUlqb3hOamMxT1RZeE56VTJMQ0p6ZFdJaU9pSnBiWEJ3T25kcGNtVmhjSEE5VGtSRmVWcEhXWGRPYW1NeVRYcEdhMDVFUW1sT1ZHeHNXVzFXYlUxcVVYbGFWRWw2VGxSak5FNVhVUzgyTldNellXTXhZVEUyTXpGak1UTTJRR1Y0WVcxd2JHVXVZMjl0SWl3aWFuUnBJam9pTlRBM09HWmtaVEl0TlRCaU9DMDBabVZtTFdJeE5EQXRNekJrWVRrellqQmtZems1SWl3aWJtOXVZMlVpT2lKaU0xWkpUMWhPVDFwVVRqRlZSWFJ2WVZkS1QxVXpXakJrVlZaMVlrVXdNMWxYVmtoUlYwNXZZMFV3SWl3aWFIUnRJam9pVUU5VFZDSXNJbWgwZFNJNkltaDBkSEE2THk5c2IyTmhiR2h2YzNRNk5Ua3pNRGN2SWl3aVkyaGhiQ0k2SWxOWk56UjBTbTFCU1Vsb1pIcFNkRXAyY0hnek9EbG1Oa1ZMU0dKWWRYaFJJbjAuQk1MS1Y1OG43c1dITXkxMlUtTHlMc0ZJSkd0TVNKcXVoUkZvYnV6ZTlGNEpBN1NjdlFWSEdUTFF2ZVZfUXBfUTROZThyeU9GcEphUTc1VW5ORHR1RFEiLCJjbGllbnRfaWQiOiJpbXBwOndpcmVhcHA9TkRFeVpHWXdOamMyTXpGa05EQmlOVGxsWW1WbU1qUXlaVEl6TlRjNE5XUS82NWMzYWMxYTE2MzFjMTM2QGV4YW1wbGUuY29tIiwiYXBpX3ZlcnNpb24iOjMsInNjb3BlIjoid2lyZV9jbGllbnRfaWQifQ.Tf10dkKrNikGNgGhIdkrMHb0v6Jpde09MaIyBeuY6KORcxuglMGY7_V9Kd0LcVVPMDy1q4xbd39ZqosGz1NUBQ";
-let dpopChallengeReq = enrollment.newDpopChallengeRequest(accessToken, dpopChall, account, previousNonce);
+let dpopChallengeReq = enrollment.newDpopChallengeRequest(accessToken, previousNonce);
 let dpopChallengeResp = {
     "type": "wire-dpop-01",
     "url": "https://example.com/acme/chall/prV_B7yEyA4",
     "status": "valid",
     "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
 };
-let dpopChallenge = enrollment.newChallengeResponse(jsonToByteArray(dpopChallengeResp));
+enrollment.newChallengeResponse(jsonToByteArray(dpopChallengeResp));
 
 let idToken = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NzU5NjE3NTYsImV4cCI6MTY3NjA0ODE1NiwibmJmIjoxNjc1OTYxNzU2LCJpc3MiOiJodHRwOi8vaWRwLyIsInN1YiI6ImltcHA6d2lyZWFwcD1OREV5WkdZd05qYzJNekZrTkRCaU5UbGxZbVZtTWpReVpUSXpOVGM0TldRLzY1YzNhYzFhMTYzMWMxMzZAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwOi8vaWRwLyIsIm5hbWUiOiJTbWl0aCwgQWxpY2UgTSAoUUEpIiwiaGFuZGxlIjoiaW1wcDp3aXJlYXBwPWFsaWNlLnNtaXRoLnFhQGV4YW1wbGUuY29tIiwia2V5YXV0aCI6IlNZNzR0Sm1BSUloZHpSdEp2cHgzODlmNkVLSGJYdXhRLi15V29ZVDlIQlYwb0ZMVElSRGw3cjhPclZGNFJCVjhOVlFObEw3cUxjbWcifQ.0iiq3p5Bmmp8ekoFqv4jQu_GrnPbEfxJ36SCuw-UvV6hCi6GlxOwU7gwwtguajhsd1sednGWZpN8QssKI5_CDQ";
-let oidcChallengeReq = enrollment.newOidcChallengeRequest(idToken, oidcChall, account, previousNonce);
+let oidcChallengeReq = enrollment.newOidcChallengeRequest(idToken, previousNonce);
 let oidcChallengeResp = {
     "type": "wire-oidc-01",
     "url": "https://localhost:55794/acme/acme/challenge/tR33VAzGrR93UnBV5mTV9nVdTZrG2Ln0/QXgyA324mTntfVAIJKw2cF23i4UFJltk",
     "status": "valid",
     "token": "2FpTOmNQvNfWDktNWt1oIJnjLE3MkyFb"
 };
-let oidcChallenge = enrollment.newChallengeResponse(jsonToByteArray(oidcChallengeResp));
+enrollment.newChallengeResponse(jsonToByteArray(oidcChallengeResp));
 
 let orderUrl = "https://example.com/acme/wire-acme/order/C7uOXEgg5KPMPtbdE3aVMzv7cJjwUVth";
-let checkOrderReq = enrollment.checkOrderRequest(orderUrl, account, previousNonce);
+let checkOrderReq = enrollment.checkOrderRequest(orderUrl, previousNonce);
 
 let checkOrderResp = {
     "status": "ready",
@@ -122,9 +126,9 @@ let checkOrderResp = {
     "notBefore": "2013-02-09T14:59:20.442908Z",
     "notAfter": "2032-02-09T15:59:20.442908Z"
 };
-let order = enrollment.checkOrderResponse(jsonToByteArray(checkOrderResp));
+enrollment.checkOrderResponse(jsonToByteArray(checkOrderResp));
 
-let finalizeReq = enrollment.finalizeRequest(order, account, previousNonce);
+let finalizeReq = enrollment.finalizeRequest(previousNonce);
 let finalizeResp = {
     "certificate": "https://localhost:55170/acme/acme/certificate/rLhCIYygqzWhUmP1i5tmtZxFUvJPFxSL",
     "status": "valid",
@@ -142,9 +146,9 @@ let finalizeResp = {
     "notBefore": "2013-02-09T14:59:20.442908Z",
     "notAfter": "2032-02-09T15:59:20.442908Z"
 };
-let finalize = enrollment.finalizeResponse(jsonToByteArray(finalizeResp));
+enrollment.finalizeResponse(jsonToByteArray(finalizeResp));
 
-let certificateReq = enrollment.certificateRequest(finalize, account, previousNonce);
+let certificateReq = enrollment.certificateRequest(previousNonce);
 
 let certificateResp = "-----BEGIN CERTIFICATE-----\n" +
     "MIIB7DCCAZKgAwIBAgIRAIErw6bhWUQXxeS0xsdMvyEwCgYIKoZIzj0EAwIwLjEN\n" +
@@ -171,6 +175,6 @@ let certificateResp = "-----BEGIN CERTIFICATE-----\n" +
     "LdKVfvqnrQ/H3a4uIPgJz0+YQI1Y0eYuMB4CIQCYMrIYAqC7nqjqVXrROShrISO+\n" +
     "S26guHAMqXDlqqueOQ==\n" +
     "-----END CERTIFICATE-----";
-let certificateChain = enrollment.certificateResponse(certificateResp);
+window.cc.e2eiMlsInit(enrollment, certificateResp);
 
 callback();

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -132,8 +132,9 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<()> {
         "test".into(),
         Some(MLS_MAIN_CLIENTID.into()),
         ciphersuites,
+        None,
     )?;
-    let mut master_client = MlsCentral::try_new_in_memory(configuration, None).await?;
+    let mut master_client = MlsCentral::try_new_in_memory(configuration).await?;
 
     let conversation_id = MLS_CONVERSATION_ID.to_vec();
     master_client
@@ -251,8 +252,9 @@ async fn run_proteus_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<(
         "test".into(),
         Some(MLS_MAIN_CLIENTID.into()),
         vec![MlsCiphersuite::default()],
+        None,
     )?;
-    let mut master_client = CoreCrypto::from(MlsCentral::try_new_in_memory(configuration, None).await?);
+    let mut master_client = CoreCrypto::from(MlsCentral::try_new_in_memory(configuration).await?);
     master_client.proteus_init().await?;
 
     let master_fingerprint = master_client.proteus_fingerprint()?;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Finally merge end-to-end identity with core-crypto. This bridges the certificate enrollmwnt flow and the MLS group initialization by allowing creating a group from a x509 certificate

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
