### PR TITLE
fix: Proteus auto prekey ids not incrementing [CL-150]

### DIFF
--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -41,7 +41,6 @@ sha2 = "0.10"
 security-framework = { version = "2.8", optional = true }
 
 openmls_traits = { version = "0.1", optional = true, features = ["single-threaded"] }
-
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dependencies.proteus-traits]

--- a/keystore/src/entities/proteus.rs
+++ b/keystore/src/entities/proteus.rs
@@ -82,8 +82,19 @@ impl ProteusPrekey {
     }
 
     pub async fn get_free_id(conn: &crate::Connection) -> crate::CryptoKeystoreResult<u16> {
-        let count = conn.count::<Self>().await?;
-        Ok((count % (u16::MAX - 1) as usize) as u16)
+        let mut id = 1u16;
+        let limit = u16::MAX;
+        while id <= limit {
+            if id == limit {
+                return Err(crate::CryptoKeystoreError::NoFreePrekeyId);
+            }
+            if conn.find::<Self>(id.to_le_bytes()).await?.is_none() {
+                break;
+            }
+            id += 1;
+        }
+
+        Ok(id)
     }
 }
 

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -96,6 +96,9 @@ pub enum CryptoKeystoreError {
     #[cfg(feature = "proteus-keystore")]
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
+    #[cfg(feature = "proteus-keystore")]
+    #[error("Could not find a free prekey id")]
+    NoFreePrekeyId,
     #[error("{0}")]
     MlsKeyStoreError(String),
     #[error(transparent)]


### PR DESCRIPTION
In case of "gaps" in the prekey id sequence, the previous algorithm (using the number of prekeys stored) would return the same ID over and over.
As a consequence, the same prekey id would be overwritten over and over.
