### PR TITLE
feat: decrypt messages returns identity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,17 @@ branch = "otak/2.0-error-codes"
 [patch.crates-io.openmls]
 package = "openmls"
 git = "https://github.com/wireapp/openmls"
-tag = "v0.5.5-pre.core-crypto-0.7.0"
+tag = "v0.5.6-pre.core-crypto-0.7.0"
 
 [patch.crates-io.openmls_traits]
 package = "openmls_traits"
 git = "https://github.com/wireapp/openmls"
-tag = "v0.5.5-pre.core-crypto-0.7.0"
+tag = "v0.5.6-pre.core-crypto-0.7.0"
+
+[patch.crates-io.wire-e2e-identity]
+git = "https://github.com/wireapp/rusty-jwt-tools"
+package = "wire-e2e-identity"
+branch = "main"
 
 [patch.crates-io.hpke-rs]
 git = "https://github.com/wireapp/hpke-rs"
@@ -60,10 +65,6 @@ package = "hpke-rs-crypto"
 git = "https://github.com/wireapp/hpke-rs"
 branch = "feat/0.2"
 package = "hpke-rs-rust-crypto"
-
-[patch.crates-io.rcgen]
-git = "https://github.com/wireapp/rcgen"
-tag = "v1.2.0-pre.core-crypto-0.6.0"
 
 # aarch64-apple-ios-sim target support has not yet been released
 [patch.crates-io.openssl-src]

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0"
 cfg-if = "1.0"
 futures-util = "0.3"
 async-trait = "0.1"
+either = "1.8"
 
 # UniFFI - Android + iOS bindings - Runtime support
 uniffi = { version = "0.23", optional = true }

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -417,6 +417,34 @@ export interface DecryptedMessage {
      * true when the decrypted message resulted in an epoch change i.e. it was a commit
      */
     hasEpochChanged: boolean;
+    /**
+     * Identity claims present in the sender credential
+     * Only present when the credential is a x509 certificate
+     * Present for all messages
+     */
+    identity?: WireIdentity;
+}
+
+/**
+ * Represents the identity claims identifying a client. Those claims are verifiable by any member in the group
+ */
+export interface WireIdentity {
+    /**
+     * Represents the identity claims identifying a client. Those claims are verifiable by any member in the group
+     */
+    clientId: string;
+    /**
+     * user handle e.g. `john_wire`
+     */
+    handle: string;
+    /**
+     * Name as displayed in the messaging application e.g. `John Fitzgerald Kennedy`
+     */
+    displayName: string;
+    /**
+     * DNS domain for which this identity proof was generated e.g. `whitehouse.gov`
+     */
+    domain: string;
 }
 
 /**

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.js
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.js
@@ -829,9 +829,9 @@ test("end-to-end-identity", async () => {
     const encoder = new TextEncoder();
     const jsonToByteArray = json => encoder.encode(JSON.stringify(json, null, 0));
 
-    const clientId = "NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@example.com";
-    const displayName = "Smith, Alice M (QA)";
-    const handle = "alice.smith.qa@example.com";
+    const clientId = "NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg:6c1866f567616f31@wire.com";
+    const displayName = "Alice Smith";
+    const handle = "alice_wire";
     const expiry = 90;
 
     const enrollment = await cc.newAcmeEnrollment(clientId, displayName, handle, expiry);
@@ -862,7 +862,7 @@ test("end-to-end-identity", async () => {
         "identifiers": [
             {
                 "type": "wireapp-id",
-                "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+                "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
             }
         ],
         "authorizations": [
@@ -880,7 +880,7 @@ test("end-to-end-identity", async () => {
         "expires": "2016-01-02T14:09:30Z",
         "identifier": {
             "type": "wireapp-id",
-            "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+            "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
         },
         "challenges": [
             {
@@ -932,7 +932,7 @@ test("end-to-end-identity", async () => {
         "identifiers": [
             {
                 "type": "wireapp-id",
-                "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+                "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
             }
         ],
         "authorizations": [
@@ -952,7 +952,7 @@ test("end-to-end-identity", async () => {
         "identifiers": [
             {
                 "type": "wireapp-id",
-                "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+                "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
             }
         ],
         "authorizations": [
@@ -967,31 +967,30 @@ test("end-to-end-identity", async () => {
     const certificateReq = enrollment.certificateRequest(previousNonce);
 
     const certificateResp = "-----BEGIN CERTIFICATE-----\n" +
-        "MIICaDCCAg6gAwIBAgIQH3CanUzXJpP+pbXNUVpp7TAKBggqhkjOPQQDAjAuMQ0w\n" +
+        "MIICLjCCAdSgAwIBAgIQIi6jHWSEF/LHAkiyoiSHbjAKBggqhkjOPQQDAjAuMQ0w\n" +
         "CwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3aXJlIEludGVybWVkaWF0ZSBDQTAeFw0y\n" +
-        "MzAyMDkxNDU5MjBaFw0yMzAyMDkxNTU5MjBaMDQxFDASBgNVBAoTC2V4YW1wbGUu\n" +
-        "Y29tMRwwGgYDVQQDExNTbWl0aCwgQWxpY2UgTSAoUUEpMCowBQYDK2VwAyEAVCw/\n" +
-        "lxGMV2Zx723yhVv94Fb+LCARV0h1F1/zmvRZGy6jggE1MIIBMTAOBgNVHQ8BAf8E\n" +
-        "BAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB0GA1UdDgQWBBSr\n" +
-        "zp+ejXBydYcjmBr4cTp931ceUTAfBgNVHSMEGDAWgBS04sLODR52O3cPNlNdK3f6\n" +
-        "tinkIzCBoAYDVR0RBIGYMIGVghNzbWl0aCwgYWxpY2UgbSAocWEphidpbXBwOndp\n" +
-        "cmVhcHA9YWxpY2Uuc21pdGgucWFAZXhhbXBsZS5jb22GVWltcHA6d2lyZWFwcD1u\n" +
-        "amppeXRyam10aXlvZGpqbmR5NXltZTVuZ3ptbWpoaG5qZmtvZGEwbmprL2QyYmEy\n" +
-        "YzFhNTc1ODhlZTRAZXhhbXBsZS5jb20wHQYMKwYBBAGCpGTGKEABBA0wCwIBBgQE\n" +
-        "YWNtZQQAMAoGCCqGSM49BAMCA0gAMEUCIG6cfFB2En9YKVPuQhEZcoELtZbkFsTJ\n" +
-        "PeWa6zTkrI47AiEApQP8piMQWhofGLL6oTWoks3+6JfPRWZP9Z7JkhdiBmY=\n" +
+        "MzA0MDUwOTI2NThaFw0yMzA0MDUxMDI2NThaMCkxETAPBgNVBAoTCHdpcmUuY29t\n" +
+        "MRQwEgYDVQQDEwtBbGljZSBTbWl0aDAqMAUGAytlcAMhAGzbFXHk2ngUGpBYzabE\n" +
+        "AtDJIefbX1/wDUSDJbEL/nJNo4IBBjCCAQIwDgYDVR0PAQH/BAQDAgeAMB0GA1Ud\n" +
+        "JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQUhifYTPG7M3pyQMrz\n" +
+        "HYmakvfDG80wHwYDVR0jBBgwFoAUHPSH1n7X87LAYJnc+cFG2a3ZAQ4wcgYDVR0R\n" +
+        "BGswaYZQaW06d2lyZWFwcD1OamhsTXpJeE9XRmpPRFJpTkRBd1lqazBaR0ZoWkRB\n" +
+        "Mk56RXhOVEV5TlRnLzZjMTg2NmY1Njc2MTZmMzFAd2lyZS5jb22GFWltOndpcmVh\n" +
+        "cHA9YWxpY2Vfd2lyZTAdBgwrBgEEAYKkZMYoQAEEDTALAgEGBAR3aXJlBAAwCgYI\n" +
+        "KoZIzj0EAwIDSAAwRQIhAKY0Zs8SYwS7mFFenPDoCDHPQbCbV9VdvYpBQncOFD5K\n" +
+        "AiAisX68Di4B0dN059YsVDXpM0drnkrVTRKHV+F+ipDjZQ==\n" +
         "-----END CERTIFICATE-----\n" +
         "-----BEGIN CERTIFICATE-----\n" +
-        "MIIBuDCCAV6gAwIBAgIQP5i/9/vpRPXels/aSa5lZTAKBggqhkjOPQQDAjAmMQ0w\n" +
-        "CwYDVQQKEwR3aXJlMRUwEwYDVQQDEwx3aXJlIFJvb3QgQ0EwHhcNMjMwMjA5MTQ1\n" +
-        "OTE4WhcNMzMwMjA2MTQ1OTE4WjAuMQ0wCwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3\n" +
-        "aXJlIEludGVybWVkaWF0ZSBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABFNd\n" +
-        "5wbJjtVSmXxftBSmHgTJS3F1LGMlb789KtcSTjjJVO//VNdg3XDYvhHyitHx/Bz+\n" +
-        "5yxkrPaRzeGeJkZfkuejZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAG\n" +
-        "AQH/AgEAMB0GA1UdDgQWBBS04sLODR52O3cPNlNdK3f6tinkIzAfBgNVHSMEGDAW\n" +
-        "gBTqNi9/bemraZjLYA8TGat3ianEizAKBggqhkjOPQQDAgNIADBFAiEAuo8JLvys\n" +
-        "IvUCvPUJi1++80IgPeRxxRvn5zlHDh3qKZECIHONc1xx1ixlIyp9mOtdeTvG5Dql\n" +
-        "RheWYpDHRiLax1Id\n" +
+        "MIIBtzCCAV6gAwIBAgIQPbElEJQ58HlbQf7bqrJjXTAKBggqhkjOPQQDAjAmMQ0w\n" +
+        "CwYDVQQKEwR3aXJlMRUwEwYDVQQDEwx3aXJlIFJvb3QgQ0EwHhcNMjMwNDA1MDky\n" +
+        "NjUzWhcNMzMwNDAyMDkyNjUzWjAuMQ0wCwYDVQQKEwR3aXJlMR0wGwYDVQQDExR3\n" +
+        "aXJlIEludGVybWVkaWF0ZSBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABGbM\n" +
+        "rA1eqJE9xlGOwO+sYbexThtlU/to9jJj5SBoKPx7Q8QMBlmPTjqDVumXhUvSe+xY\n" +
+        "JE7M+lBXfVZCywzIIPWjZjBkMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAG\n" +
+        "AQH/AgEAMB0GA1UdDgQWBBQc9IfWftfzssBgmdz5wUbZrdkBDjAfBgNVHSMEGDAW\n" +
+        "gBQY+1rDw64QLm/weFQC1mo9y29ddTAKBggqhkjOPQQDAgNHADBEAiARvd7RBuuv\n" +
+        "OhUy7ncjd/nzoN5Qs0p6D+ujdSLDqLlNIAIgfkwAAgsQMDF3ClqVM/p9cmS95B0g\n" +
+        "CAdIObqPoNL5MJo=\n" +
         "-----END CERTIFICATE-----";
 
     await cc.e2eiMlsInit(enrollment, certificateResp);

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_552_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_552_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,335 +264,335 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_552_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_6af_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_552_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_552_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_mls_generate_keypair(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_mls_generate_keypair(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKey`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_restore_from_disk(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_restore_from_disk(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_6af_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_6af_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_552_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_552_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_552_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+    fun CoreCrypto_6af_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_6af_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_6af_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_552_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_6af_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Short
 
-    fun CoreCrypto_552_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_552_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`e2ei`: Pointer,`certificateChain`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`e2ei`: Pointer,`certificateChain`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
+    fun CoreCrypto_6af_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Int
 
-    fun ffi_CoreCrypto_552_WireE2eIdentity_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_6af_WireE2eIdentity_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`backendNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`backendNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_552_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_6af_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_552_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_552_version(
+    fun CoreCrypto_6af_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_552_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_6af_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_552_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_6af_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_552_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_6af_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_552_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_6af_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -1128,7 +1128,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: ClientId, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1141,7 +1141,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_552_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1149,7 +1149,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInit`(`clientId`: ClientId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }
     
@@ -1157,7 +1157,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsGenerateKeypair`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_mls_generate_keypair(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mls_generate_keypair(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1166,7 +1166,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceUByte.lower(`signaturePublicKey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceUByte.lower(`signaturePublicKey`),  _status)
 }
         }
     
@@ -1174,7 +1174,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `restoreFromDisk`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_restore_from_disk(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_restore_from_disk(it,  _status)
 }
         }
     
@@ -1182,7 +1182,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1190,7 +1190,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1199,7 +1199,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1208,7 +1208,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1217,7 +1217,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1225,7 +1225,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1233,7 +1233,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1242,7 +1242,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1251,7 +1251,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1260,7 +1260,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1269,7 +1269,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
 }
         }
     
@@ -1277,7 +1277,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1286,7 +1286,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1295,7 +1295,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1303,7 +1303,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1312,7 +1312,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1321,7 +1321,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1330,7 +1330,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1339,7 +1339,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1348,7 +1348,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1357,7 +1357,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1366,7 +1366,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1375,7 +1375,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1383,7 +1383,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1391,7 +1391,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1400,7 +1400,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1409,7 +1409,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1418,7 +1418,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1427,7 +1427,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1435,7 +1435,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1443,7 +1443,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1451,7 +1451,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1459,7 +1459,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1467,7 +1467,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1475,7 +1475,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1484,7 +1484,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1492,7 +1492,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1500,7 +1500,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionExists`(`sessionId`: String): Boolean =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1509,7 +1509,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1518,7 +1518,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1527,7 +1527,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1536,7 +1536,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1545,7 +1545,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekeyAuto`(): ProteusAutoPrekeyBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_new_prekey_auto(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(it,  _status)
 }
         }.let {
             FfiConverterTypeProteusAutoPrekeyBundle.lift(it)
@@ -1554,7 +1554,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1563,7 +1563,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekeyId`(): UShort =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
 }
         }.let {
             FfiConverterUShort.lift(it)
@@ -1572,7 +1572,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1581,7 +1581,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintLocal`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1590,7 +1590,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintRemote`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1599,7 +1599,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintPrekeybundle`(`prekey`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1608,7 +1608,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
@@ -1616,7 +1616,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_new_acme_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_acme_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterTypeWireE2eIdentity.lift(it)
@@ -1625,14 +1625,14 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`e2ei`), FfiConverterString.lower(`certificateChain`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`e2ei`), FfiConverterString.lower(`certificateChain`),  _status)
 }
         }
     
     override fun `proteusLastErrorCode`(): UInt =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_proteus_last_error_code(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_last_error_code(it,  _status)
 }
         }.let {
             FfiConverterUInt.lift(it)
@@ -1643,7 +1643,7 @@ class CoreCrypto(
         fun `deferredInit`(`path`: String, `key`: String, `entropySeed`: List<UByte>?): CoreCrypto =
             CoreCrypto(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
         
     }
@@ -1741,7 +1741,7 @@ class WireE2eIdentity(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_552_WireE2eIdentity_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_WireE2eIdentity_object_free(this.pointer, status)
         }
     }
 
@@ -1749,7 +1749,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: List<UByte>): AcmeDirectory =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
 }
         }.let {
             FfiConverterTypeAcmeDirectory.lift(it)
@@ -1758,7 +1758,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1767,7 +1767,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
 }
         }
     
@@ -1775,7 +1775,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1784,7 +1784,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: List<UByte>): NewAcmeOrder =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeOrder.lift(it)
@@ -1793,7 +1793,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1802,7 +1802,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeAuthz.lift(it)
@@ -1811,7 +1811,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterString.lower(`backendNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterString.lower(`backendNonce`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1820,7 +1820,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1829,7 +1829,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1838,7 +1838,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
 }
         }
     
@@ -1846,7 +1846,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1855,7 +1855,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }
     
@@ -1863,7 +1863,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1872,7 +1872,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
 }
         }
     
@@ -1880,7 +1880,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `certificateRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2111,7 +2111,8 @@ data class DecryptedMessage (
     var `isActive`: Boolean, 
     var `commitDelay`: ULong?, 
     var `senderClientId`: ClientId?, 
-    var `hasEpochChanged`: Boolean
+    var `hasEpochChanged`: Boolean, 
+    var `identity`: WireIdentity?
 ) {
     
 }
@@ -2125,6 +2126,7 @@ public object FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer<Decrypted
             FfiConverterOptionalULong.read(buf),
             FfiConverterOptionalTypeClientId.read(buf),
             FfiConverterBoolean.read(buf),
+            FfiConverterOptionalTypeWireIdentity.read(buf),
         )
     }
 
@@ -2134,7 +2136,8 @@ public object FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer<Decrypted
             FfiConverterBoolean.allocationSize(value.`isActive`) +
             FfiConverterOptionalULong.allocationSize(value.`commitDelay`) +
             FfiConverterOptionalTypeClientId.allocationSize(value.`senderClientId`) +
-            FfiConverterBoolean.allocationSize(value.`hasEpochChanged`)
+            FfiConverterBoolean.allocationSize(value.`hasEpochChanged`) +
+            FfiConverterOptionalTypeWireIdentity.allocationSize(value.`identity`)
     )
 
     override fun write(value: DecryptedMessage, buf: ByteBuffer) {
@@ -2144,6 +2147,7 @@ public object FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer<Decrypted
             FfiConverterOptionalULong.write(value.`commitDelay`, buf)
             FfiConverterOptionalTypeClientId.write(value.`senderClientId`, buf)
             FfiConverterBoolean.write(value.`hasEpochChanged`, buf)
+            FfiConverterOptionalTypeWireIdentity.write(value.`identity`, buf)
     }
 }
 
@@ -2365,6 +2369,43 @@ public object FfiConverterTypePublicGroupStateBundle: FfiConverterRustBuffer<Pub
 
 
 
+data class WireIdentity (
+    var `clientId`: String, 
+    var `handle`: String, 
+    var `displayName`: String, 
+    var `domain`: String
+) {
+    
+}
+
+public object FfiConverterTypeWireIdentity: FfiConverterRustBuffer<WireIdentity> {
+    override fun read(buf: ByteBuffer): WireIdentity {
+        return WireIdentity(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: WireIdentity) = (
+            FfiConverterString.allocationSize(value.`clientId`) +
+            FfiConverterString.allocationSize(value.`handle`) +
+            FfiConverterString.allocationSize(value.`displayName`) +
+            FfiConverterString.allocationSize(value.`domain`)
+    )
+
+    override fun write(value: WireIdentity, buf: ByteBuffer) {
+            FfiConverterString.write(value.`clientId`, buf)
+            FfiConverterString.write(value.`handle`, buf)
+            FfiConverterString.write(value.`displayName`, buf)
+            FfiConverterString.write(value.`domain`, buf)
+    }
+}
+
+
+
+
 enum class CiphersuiteName {
     MLS_128_DHKEMX25519_AES128GCM_SHA256_ED25519,MLS_128_DHKEMP256_AES128GCM_SHA256_P256,MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_ED25519,MLS_256_DHKEMX448_AES256GCM_SHA512_ED448,MLS_256_DHKEMP521_AES256GCM_SHA512_P521,MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_ED448,MLS_256_DHKEMP384_AES256GCM_SHA384_P384;
 }
@@ -2499,6 +2540,7 @@ sealed class CryptoException(message: String): Exception(message) {
         class NoProvisionalIdentityFound(message: String) : CryptoException(message)
         class TooManyIdentitiesPresent(message: String) : CryptoException(message)
         class ParentGroupNotFound(message: String) : CryptoException(message)
+        class InvalidIdentity(message: String) : CryptoException(message)
         
 
     companion object ErrorHandler : CallStatusErrorHandler<CryptoException> {
@@ -2548,6 +2590,7 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
             36 -> CryptoException.NoProvisionalIdentityFound(FfiConverterString.read(buf))
             37 -> CryptoException.TooManyIdentitiesPresent(FfiConverterString.read(buf))
             38 -> CryptoException.ParentGroupNotFound(FfiConverterString.read(buf))
+            39 -> CryptoException.InvalidIdentity(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
         
@@ -2709,6 +2752,10 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
             }
             is CryptoException.ParentGroupNotFound -> {
                 buf.putInt(38)
+                Unit
+            }
+            is CryptoException.InvalidIdentity -> {
+                buf.putInt(39)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -3041,7 +3088,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_552_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -3158,6 +3205,35 @@ public object FfiConverterOptionalTypeCommitBundle: FfiConverterRustBuffer<Commi
         } else {
             buf.put(1)
             FfiConverterTypeCommitBundle.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeWireIdentity: FfiConverterRustBuffer<WireIdentity?> {
+    override fun read(buf: ByteBuffer): WireIdentity? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeWireIdentity.read(buf)
+    }
+
+    override fun allocationSize(value: WireIdentity?): Int {
+        if (value == null) {
+            return 1
+        } else {
+            return 1 + FfiConverterTypeWireIdentity.allocationSize(value)
+        }
+    }
+
+    override fun write(value: WireIdentity?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeWireIdentity.write(value, buf)
         }
     }
 }
@@ -3526,7 +3602,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_552_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_6af_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_552_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_6af_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_552_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_6af_rustbuffer_free(self, $0) }
     }
 }
 
@@ -492,7 +492,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_552_CoreCrypto_new(
+    CoreCrypto_6af_CoreCrypto_new(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterTypeClientId.lower(`clientId`), 
@@ -501,7 +501,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_552_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_6af_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -510,7 +510,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_552_CoreCrypto_deferred_init(
+    CoreCrypto_6af_CoreCrypto_deferred_init(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterOptionSequenceUInt8.lower(`entropySeed`), $0)
@@ -522,7 +522,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInit`(`clientId`: ClientId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_mls_init(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_mls_init(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
 }
@@ -531,7 +531,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_mls_generate_keypair(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_mls_generate_keypair(self.pointer, $0
     )
 }
         )
@@ -539,7 +539,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_mls_init_with_client_id(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceUInt8.lower(`signaturePublicKey`), $0
     )
@@ -548,14 +548,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `restoreFromDisk`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_restore_from_disk(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_restore_from_disk(self.pointer, $0
     )
 }
     }
     public func `setCallbacks`(`callbacks`: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(`callbacks`), $0
     )
 }
@@ -564,7 +564,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -573,7 +573,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(`amountRequested`), $0
     )
 }
@@ -583,7 +583,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -591,7 +591,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeConversationConfiguration.lower(`config`), $0
     )
@@ -601,7 +601,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -612,7 +612,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_552_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -622,7 +622,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(`welcomeMessage`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -633,7 +633,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeInvitee.lower(`clients`), $0
     )
@@ -644,7 +644,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeClientId.lower(`clients`), $0
     )
@@ -654,7 +654,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
         FfiConverterTypeConversationId.lower(`childId`), 
         FfiConverterTypeConversationId.lower(`parentId`), $0
     )
@@ -664,7 +664,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -674,7 +674,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -683,7 +683,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `wipeConversation`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -692,7 +692,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`payload`), $0
     )
@@ -703,7 +703,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`message`), $0
     )
@@ -714,7 +714,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`keyPackage`), $0
     )
@@ -725,7 +725,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -735,7 +735,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
@@ -746,7 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), $0
     )
@@ -757,7 +757,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterSequenceUInt8.lower(`keyPackageRef`), $0
@@ -769,7 +769,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(`publicGroupState`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -779,7 +779,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -787,7 +787,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -796,7 +796,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -806,7 +806,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt32.lower(`keyLength`), $0
     )
@@ -817,7 +817,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_get_client_ids(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -827,7 +827,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(`length`), $0
     )
 }
@@ -836,7 +836,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `reseedRng`(`seed`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(`seed`), $0
     )
 }
@@ -844,7 +844,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `commitAccepted`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -852,7 +852,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`proposalRef`), $0
     )
@@ -861,7 +861,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -869,14 +869,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusInit`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
@@ -886,7 +886,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`envelope`), $0
     )
@@ -896,7 +896,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionSave`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -904,7 +904,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionDelete`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -913,7 +913,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterBool.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_session_exists(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_session_exists(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -923,7 +923,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`ciphertext`), $0
     )
@@ -934,7 +934,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -945,7 +945,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -956,7 +956,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(`prekeyId`), $0
     )
 }
@@ -966,7 +966,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProteusAutoPrekeyBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
     )
 }
         )
@@ -975,7 +975,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
     )
 }
         )
@@ -984,7 +984,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt16.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
     )
 }
         )
@@ -993,7 +993,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -1002,7 +1002,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_fingerprint_local(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1012,7 +1012,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1022,7 +1022,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
 }
@@ -1031,7 +1031,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusCryptoboxMigrate`(`path`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(`path`), $0
     )
 }
@@ -1040,7 +1040,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeWireE2eIdentity.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_new_acme_enrollment(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_new_acme_enrollment(self.pointer, 
         FfiConverterString.lower(`clientId`), 
         FfiConverterString.lower(`displayName`), 
         FfiConverterString.lower(`handle`), 
@@ -1053,7 +1053,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_552_CoreCrypto_e2ei_mls_init(self.pointer, 
+    CoreCrypto_6af_CoreCrypto_e2ei_mls_init(self.pointer, 
         FfiConverterTypeWireE2eIdentity.lower(`e2ei`), 
         FfiConverterString.lower(`certificateChain`), $0
     )
@@ -1064,7 +1064,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_552_CoreCrypto_proteus_last_error_code(self.pointer, $0
+    CoreCrypto_6af_CoreCrypto_proteus_last_error_code(self.pointer, $0
     )
 }
         )
@@ -1135,7 +1135,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_552_WireE2eIdentity_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_6af_WireE2eIdentity_object_free(pointer, $0) }
     }
 
     
@@ -1145,7 +1145,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeAcmeDirectory.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_directory_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_directory_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`directory`), $0
     )
 }
@@ -1155,7 +1155,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_account_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_account_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1164,7 +1164,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newAccountResponse`(`account`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_account_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_account_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`account`), $0
     )
 }
@@ -1173,7 +1173,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_order_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_order_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1183,7 +1183,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeOrder.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_order_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1193,7 +1193,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_authz_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_authz_request(self.pointer, 
         FfiConverterString.lower(`url`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1204,7 +1204,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeAuthz.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_authz_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_authz_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`authz`), $0
     )
 }
@@ -1214,7 +1214,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_create_dpop_token(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_create_dpop_token(self.pointer, 
         FfiConverterString.lower(`accessTokenUrl`), 
         FfiConverterString.lower(`backendNonce`), $0
     )
@@ -1225,7 +1225,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
         FfiConverterString.lower(`accessToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1236,7 +1236,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
         FfiConverterString.lower(`idToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1246,7 +1246,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newChallengeResponse`(`challenge`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_new_challenge_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_new_challenge_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`challenge`), $0
     )
 }
@@ -1255,7 +1255,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_check_order_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_check_order_request(self.pointer, 
         FfiConverterString.lower(`orderUrl`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1265,7 +1265,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `checkOrderResponse`(`order`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_check_order_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_check_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1274,7 +1274,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_finalize_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_finalize_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1283,7 +1283,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `finalizeResponse`(`finalize`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_finalize_response(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_finalize_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`finalize`), $0
     )
 }
@@ -1292,7 +1292,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_552_WireE2eIdentity_certificate_request(self.pointer, 
+    CoreCrypto_6af_WireE2eIdentity_certificate_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1702,16 +1702,18 @@ public struct DecryptedMessage {
     public var `commitDelay`: UInt64?
     public var `senderClientId`: ClientId?
     public var `hasEpochChanged`: Bool
+    public var `identity`: WireIdentity?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(`message`: [UInt8]?, `proposals`: [ProposalBundle], `isActive`: Bool, `commitDelay`: UInt64?, `senderClientId`: ClientId?, `hasEpochChanged`: Bool) {
+    public init(`message`: [UInt8]?, `proposals`: [ProposalBundle], `isActive`: Bool, `commitDelay`: UInt64?, `senderClientId`: ClientId?, `hasEpochChanged`: Bool, `identity`: WireIdentity?) {
         self.`message` = `message`
         self.`proposals` = `proposals`
         self.`isActive` = `isActive`
         self.`commitDelay` = `commitDelay`
         self.`senderClientId` = `senderClientId`
         self.`hasEpochChanged` = `hasEpochChanged`
+        self.`identity` = `identity`
     }
 }
 
@@ -1736,6 +1738,9 @@ extension DecryptedMessage: Equatable, Hashable {
         if lhs.`hasEpochChanged` != rhs.`hasEpochChanged` {
             return false
         }
+        if lhs.`identity` != rhs.`identity` {
+            return false
+        }
         return true
     }
 
@@ -1746,6 +1751,7 @@ extension DecryptedMessage: Equatable, Hashable {
         hasher.combine(`commitDelay`)
         hasher.combine(`senderClientId`)
         hasher.combine(`hasEpochChanged`)
+        hasher.combine(`identity`)
     }
 }
 
@@ -1758,7 +1764,8 @@ public struct FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer {
             `isActive`: FfiConverterBool.read(from: &buf), 
             `commitDelay`: FfiConverterOptionUInt64.read(from: &buf), 
             `senderClientId`: FfiConverterOptionTypeClientId.read(from: &buf), 
-            `hasEpochChanged`: FfiConverterBool.read(from: &buf)
+            `hasEpochChanged`: FfiConverterBool.read(from: &buf), 
+            `identity`: FfiConverterOptionTypeWireIdentity.read(from: &buf)
         )
     }
 
@@ -1769,6 +1776,7 @@ public struct FfiConverterTypeDecryptedMessage: FfiConverterRustBuffer {
         FfiConverterOptionUInt64.write(value.`commitDelay`, into: &buf)
         FfiConverterOptionTypeClientId.write(value.`senderClientId`, into: &buf)
         FfiConverterBool.write(value.`hasEpochChanged`, into: &buf)
+        FfiConverterOptionTypeWireIdentity.write(value.`identity`, into: &buf)
     }
 }
 
@@ -2190,6 +2198,77 @@ public func FfiConverterTypePublicGroupStateBundle_lower(_ value: PublicGroupSta
     return FfiConverterTypePublicGroupStateBundle.lower(value)
 }
 
+
+public struct WireIdentity {
+    public var `clientId`: String
+    public var `handle`: String
+    public var `displayName`: String
+    public var `domain`: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(`clientId`: String, `handle`: String, `displayName`: String, `domain`: String) {
+        self.`clientId` = `clientId`
+        self.`handle` = `handle`
+        self.`displayName` = `displayName`
+        self.`domain` = `domain`
+    }
+}
+
+
+extension WireIdentity: Equatable, Hashable {
+    public static func ==(lhs: WireIdentity, rhs: WireIdentity) -> Bool {
+        if lhs.`clientId` != rhs.`clientId` {
+            return false
+        }
+        if lhs.`handle` != rhs.`handle` {
+            return false
+        }
+        if lhs.`displayName` != rhs.`displayName` {
+            return false
+        }
+        if lhs.`domain` != rhs.`domain` {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(`clientId`)
+        hasher.combine(`handle`)
+        hasher.combine(`displayName`)
+        hasher.combine(`domain`)
+    }
+}
+
+
+public struct FfiConverterTypeWireIdentity: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WireIdentity {
+        return try WireIdentity(
+            `clientId`: FfiConverterString.read(from: &buf), 
+            `handle`: FfiConverterString.read(from: &buf), 
+            `displayName`: FfiConverterString.read(from: &buf), 
+            `domain`: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WireIdentity, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.`clientId`, into: &buf)
+        FfiConverterString.write(value.`handle`, into: &buf)
+        FfiConverterString.write(value.`displayName`, into: &buf)
+        FfiConverterString.write(value.`domain`, into: &buf)
+    }
+}
+
+
+public func FfiConverterTypeWireIdentity_lift(_ buf: RustBuffer) throws -> WireIdentity {
+    return try FfiConverterTypeWireIdentity.lift(buf)
+}
+
+public func FfiConverterTypeWireIdentity_lower(_ value: WireIdentity) -> RustBuffer {
+    return FfiConverterTypeWireIdentity.lower(value)
+}
+
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 public enum CiphersuiteName {
@@ -2555,6 +2634,9 @@ public enum CryptoError {
     // Simple error enums only carry a message
     case ParentGroupNotFound(message: String)
     
+    // Simple error enums only carry a message
+    case InvalidIdentity(message: String)
+    
 }
 
 public struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
@@ -2719,6 +2801,10 @@ public struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 39: return .InvalidIdentity(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -2843,6 +2929,9 @@ public struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             FfiConverterString.write(message, into: &buf)
         case let .ParentGroupNotFound(message):
             writeInt(&buf, Int32(38))
+            FfiConverterString.write(message, into: &buf)
+        case let .InvalidIdentity(message):
+            writeInt(&buf, Int32(39))
             FfiConverterString.write(message, into: &buf)
 
         
@@ -3175,7 +3264,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_552_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3301,6 +3390,27 @@ fileprivate struct FfiConverterOptionTypeCommitBundle: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeCommitBundle.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+fileprivate struct FfiConverterOptionTypeWireIdentity: FfiConverterRustBuffer {
+    typealias SwiftType = WireIdentity?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWireIdentity.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWireIdentity.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -3644,7 +3754,7 @@ public func `version`()  -> String {
     
     rustCall() {
     
-    CoreCrypto_552_version($0)
+    CoreCrypto_6af_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,335 +46,335 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_552_CoreCrypto_object_free(
+void ffi_CoreCrypto_6af_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_552_CoreCrypto_new(
+void*_Nonnull CoreCrypto_6af_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_552_CoreCrypto_deferred_init(
+void*_Nonnull CoreCrypto_6af_CoreCrypto_deferred_init(
       RustBuffer path,RustBuffer key,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_mls_init(
+void CoreCrypto_6af_CoreCrypto_mls_init(
       void*_Nonnull ptr,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_mls_generate_keypair(
+RustBuffer CoreCrypto_6af_CoreCrypto_mls_generate_keypair(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_mls_init_with_client_id(
+void CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer signature_public_key,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_restore_from_disk(
+void CoreCrypto_6af_CoreCrypto_restore_from_disk(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_set_callbacks(
+void CoreCrypto_6af_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_6af_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_6af_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_552_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_create_conversation(
+void CoreCrypto_6af_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_552_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_6af_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_552_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_6af_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_6af_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_mark_conversation_as_child_of(
+void CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(
       void*_Nonnull ptr,RustBuffer child_id,RustBuffer parent_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_6af_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_6af_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_wipe_conversation(
+void CoreCrypto_6af_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_6af_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_6af_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_6af_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_6af_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_6af_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_6af_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_6af_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_6af_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_6af_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_get_client_ids(
+RustBuffer CoreCrypto_6af_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_6af_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_reseed_rng(
+void CoreCrypto_6af_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_commit_accepted(
+void CoreCrypto_6af_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_6af_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_clear_pending_commit(
+void CoreCrypto_6af_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_proteus_init(
+void CoreCrypto_6af_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_proteus_session_save(
+void CoreCrypto_6af_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_proteus_session_delete(
+void CoreCrypto_6af_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_552_CoreCrypto_proteus_session_exists(
+int8_t CoreCrypto_6af_CoreCrypto_proteus_session_exists(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_new_prekey_auto(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-uint16_t CoreCrypto_552_CoreCrypto_proteus_last_resort_prekey_id(
+uint16_t CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_fingerprint_local(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_fingerprint_remote(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_CoreCrypto_proteus_fingerprint_prekeybundle(
+RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(
       void*_Nonnull ptr,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_552_CoreCrypto_new_acme_enrollment(
+void*_Nonnull CoreCrypto_6af_CoreCrypto_new_acme_enrollment(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer display_name,RustBuffer handle,uint32_t expiry_days,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_CoreCrypto_e2ei_mls_init(
+void CoreCrypto_6af_CoreCrypto_e2ei_mls_init(
       void*_Nonnull ptr,void*_Nonnull e2ei,RustBuffer certificate_chain,
     RustCallStatus *_Nonnull out_status
     );
-uint32_t CoreCrypto_552_CoreCrypto_proteus_last_error_code(
+uint32_t CoreCrypto_6af_CoreCrypto_proteus_last_error_code(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_552_WireE2eIdentity_object_free(
+void ffi_CoreCrypto_6af_WireE2eIdentity_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_directory_response(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_directory_response(
       void*_Nonnull ptr,RustBuffer directory,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_account_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_account_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_WireE2eIdentity_new_account_response(
+void CoreCrypto_6af_WireE2eIdentity_new_account_response(
       void*_Nonnull ptr,RustBuffer account,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_order_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_order_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_order_response(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_authz_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_authz_request(
       void*_Nonnull ptr,RustBuffer url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_authz_response(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_authz_response(
       void*_Nonnull ptr,RustBuffer authz,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_create_dpop_token(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_create_dpop_token(
       void*_Nonnull ptr,RustBuffer access_token_url,RustBuffer backend_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_dpop_challenge_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(
       void*_Nonnull ptr,RustBuffer access_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_new_oidc_challenge_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(
       void*_Nonnull ptr,RustBuffer id_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_WireE2eIdentity_new_challenge_response(
+void CoreCrypto_6af_WireE2eIdentity_new_challenge_response(
       void*_Nonnull ptr,RustBuffer challenge,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_check_order_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_check_order_request(
       void*_Nonnull ptr,RustBuffer order_url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_WireE2eIdentity_check_order_response(
+void CoreCrypto_6af_WireE2eIdentity_check_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_finalize_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_finalize_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_552_WireE2eIdentity_finalize_response(
+void CoreCrypto_6af_WireE2eIdentity_finalize_response(
       void*_Nonnull ptr,RustBuffer finalize,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_WireE2eIdentity_certificate_request(
+RustBuffer CoreCrypto_6af_WireE2eIdentity_certificate_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_552_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_552_version(
+RustBuffer CoreCrypto_6af_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_552_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_6af_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_552_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_6af_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_552_rustbuffer_free(
+void ffi_CoreCrypto_6af_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_552_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_6af_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -91,6 +91,7 @@ enum CryptoError {
     "NoProvisionalIdentityFound",
     "TooManyIdentitiesPresent",
     "ParentGroupNotFound",
+    "InvalidIdentity",
 };
 
 dictionary DecryptedMessage {
@@ -100,6 +101,14 @@ dictionary DecryptedMessage {
     u64? commit_delay;
     ClientId? sender_client_id;
     boolean has_epoch_changed;
+    WireIdentity? identity;
+};
+
+dictionary WireIdentity {
+    string client_id;
+    string handle;
+    string display_name;
+    string domain;
 };
 
 dictionary Invitee {

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -39,11 +39,8 @@ async-trait = "0.1"
 async-lock = "2.6"
 schnellru = "0.2"
 zeroize = "1.5"
-
-[dependencies.wire-e2e-identity]
-git = "https://github.com/wireapp/rusty-jwt-tools"
-package = "wire-e2e-identity"
-version = "0.3.5"
+wire-e2e-identity = "0.3.5"
+either = "1.8"
 
 [dependencies.proteus-wasm]
 version = "2.0"
@@ -86,12 +83,12 @@ wasm-bindgen-test = "0.3"
 js-sys = "0.3"
 rstest = "0.17"
 rstest_reuse = "0.5"
-rcgen = { version = "=0.9.2", features = ["x509-parser"] }
 async-std = { version = "1.12", features = ["attributes"] }
 futures-util = { version = "0.3", features = ["std", "alloc"] }
 futures-lite = "1.12"
 proteus-traits = "2.0"
 async-trait = "0.1"
+wire-e2e-identity = { version = "0.3.5", features = ["identity-builder"] }
 
 [dev-dependencies.core-crypto-keystore]
 version = "^0.7.0-rc.4"

--- a/crypto/src/e2e_identity/identity.rs
+++ b/crypto/src/e2e_identity/identity.rs
@@ -1,0 +1,47 @@
+use crate::{prelude::MlsConversation, CryptoError, CryptoResult};
+use openmls::{
+    credentials::MlsCredentialType,
+    prelude::{Credential, MlsCertificate},
+};
+
+/// Represents the identity claims identifying a client
+/// Those claims are verifiable by any member in the group
+#[derive(Debug, Clone)]
+pub struct WireIdentity {
+    /// Unique client identifier e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@whitehouse.gov`
+    pub client_id: String,
+    /// user handle e.g. `john_wire`
+    pub handle: String,
+    /// Name as displayed in the messaging application e.g. `John Fitzgerald Kennedy`
+    pub display_name: String,
+    /// DNS domain for which this identity proof was generated e.g. `whitehouse.gov`
+    pub domain: String,
+}
+
+impl From<wire_e2e_identity::prelude::WireIdentity> for WireIdentity {
+    fn from(i: wire_e2e_identity::prelude::WireIdentity) -> Self {
+        Self {
+            client_id: i.client_id,
+            handle: i.handle,
+            display_name: i.display_name,
+            domain: i.domain,
+        }
+    }
+}
+
+impl MlsConversation {
+    pub(crate) fn extract_identity(credential: &Credential) -> CryptoResult<Option<WireIdentity>> {
+        match &credential.credential {
+            MlsCredentialType::X509(MlsCertificate { cert_chain, .. }) => {
+                let cert = cert_chain.get(0).ok_or(CryptoError::InvalidIdentity)?;
+                use wire_e2e_identity::prelude::WireIdentityReader as _;
+                let identity = cert
+                    .as_slice()
+                    .extract_identity()
+                    .map_err(|_| CryptoError::InvalidIdentity)?;
+                Ok(Some(identity.into()))
+            }
+            MlsCredentialType::Basic(_) => Ok(None),
+        }
+    }
+}

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -143,6 +143,9 @@ pub enum CryptoError {
     /// Decrypted message uses an invalid KeyPackage (probably expired)
     #[error("Decrypted message uses an invalid KeyPackage")]
     InvalidKeyPackage,
+    /// Client presented an invalid identity
+    #[error("Client presented an invalid identity")]
+    InvalidIdentity,
     /// Parent group cannot be found
     #[error("The specified parent group has not been found in the keystore")]
     ParentGroupNotFound,

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -67,6 +67,7 @@ pub mod prelude {
     pub use crate::{
         e2e_identity::{
             error::{E2eIdentityError, E2eIdentityResult},
+            identity::WireIdentity,
             types::{E2eiAcmeChallenge, E2eiAcmeDirectory, E2eiNewAcmeAuthz, E2eiNewAcmeOrder},
             WireE2eIdentity,
         },

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -93,7 +93,10 @@ impl MlsConversation {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{mls::conversation::handshake::MlsConversationCreationMessage, test_utils::*};
+    use crate::{
+        mls::{conversation::handshake::MlsConversationCreationMessage, proposal::MlsProposal},
+        test_utils::*,
+    };
     use tls_codec::Serialize as _;
     use wasm_bindgen_test::*;
 
@@ -228,7 +231,7 @@ pub mod tests {
                     );
 
                     let proposal_bundle = alice_central
-                        .new_proposal(&id, crate::mls::proposal::MlsProposal::Remove("alice".into()))
+                        .new_proposal(&id, MlsProposal::Remove(alice_central.read_client_id()))
                         .await
                         .unwrap();
 

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -167,7 +167,7 @@ pub mod tests {
                             .unwrap();
                         assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                         alice_central
-                            .remove_members_from_conversation(&id, &["bob".into()])
+                            .remove_members_from_conversation(&id, &[bob_central.read_client_id()])
                             .await
                             .unwrap();
                         assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
@@ -239,7 +239,7 @@ pub mod tests {
                             .proposal_ref;
 
                         let remove_ref = alice_central
-                            .new_proposal(&id, MlsProposal::Remove(b"bob"[..].into()))
+                            .new_proposal(&id, MlsProposal::Remove(bob_central.read_client_id()))
                             .await
                             .unwrap()
                             .proposal_ref;

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -368,7 +368,7 @@ pub mod tests {
                         bob_central.get_conversation_unchecked(&id).await.id(),
                         alice_central.get_conversation_unchecked(&id).await.id()
                     );
-                    assert!(alice_central.talk_to(&id, &mut bob_central).await.is_ok());
+                    assert!(alice_central.try_talk_to(&id, &mut bob_central).await.is_ok());
                 })
             },
         )
@@ -438,7 +438,7 @@ pub mod tests {
                     c.process_welcome_message(welcome.clone(), case.custom_cfg())
                         .await
                         .unwrap();
-                    assert!(c.talk_to(&id, &mut alice_central).await.is_ok());
+                    assert!(c.try_talk_to(&id, &mut alice_central).await.is_ok());
                     bob_and_friends_groups.push(c);
                 }
 

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -640,13 +640,13 @@ pub mod tests {
 
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
-                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .new_proposal(&id, MlsProposal::Remove(charlie_central.read_client_id()))
                             .await
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         let commit = bob_central
-                            .remove_members_from_conversation(&id, &["charlie".into()])
+                            .remove_members_from_conversation(&id, &[charlie_central.read_client_id()])
                             .await
                             .unwrap()
                             .commit;
@@ -693,7 +693,7 @@ pub mod tests {
                             .unwrap();
 
                         let proposal = bob_central
-                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .new_proposal(&id, MlsProposal::Remove(charlie_central.read_client_id()))
                             .await
                             .unwrap()
                             .proposal;
@@ -760,14 +760,14 @@ pub mod tests {
                         // Alice wants to remove Charlie
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central
-                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .new_proposal(&id, MlsProposal::Remove(charlie_central.read_client_id()))
                             .await
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Whereas Bob wants to remove Debbie
                         let commit = bob_central
-                            .remove_members_from_conversation(&id, &["debbie".into()])
+                            .remove_members_from_conversation(&id, &[debbie_central.read_client_id()])
                             .await
                             .unwrap()
                             .commit;
@@ -825,14 +825,14 @@ pub mod tests {
 
                         // Alice wants to remove Charlie
                         alice_central
-                            .remove_members_from_conversation(&id, &["charlie".into()])
+                            .remove_members_from_conversation(&id, &[charlie_central.read_client_id()])
                             .await
                             .unwrap();
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // Whereas Bob wants to remove Debbie
                         let commit = bob_central
-                            .remove_members_from_conversation(&id, &["debbie".into()])
+                            .remove_members_from_conversation(&id, &[debbie_central.read_client_id()])
                             .await
                             .unwrap()
                             .commit;
@@ -890,7 +890,7 @@ pub mod tests {
 
                         // Alice wants to remove Charlie
                         alice_central
-                            .new_proposal(&id, MlsProposal::Remove(b"charlie"[..].into()))
+                            .new_proposal(&id, MlsProposal::Remove(charlie_central.read_client_id()))
                             .await
                             .unwrap();
                         alice_central.commit_pending_proposals(&id).await.unwrap();
@@ -899,7 +899,7 @@ pub mod tests {
 
                         // Whereas Bob wants to remove Debbie
                         let commit = bob_central
-                            .remove_members_from_conversation(&id, &["debbie".into()])
+                            .remove_members_from_conversation(&id, &[debbie_central.read_client_id()])
                             .await
                             .unwrap()
                             .commit;

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -141,7 +141,7 @@ pub mod proposal_tests {
                             .await
                             .unwrap();
                         assert_eq!(id, new_id);
-                        assert!(bob_central.talk_to(&id, &mut alice_central).await.is_ok());
+                        assert!(bob_central.try_talk_to(&id, &mut alice_central).await.is_ok());
                     })
                 },
             )
@@ -206,7 +206,7 @@ pub mod proposal_tests {
                     assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                     let remove_proposal = alice_central
-                        .new_proposal(&id, MlsProposal::Remove(b"bob"[..].into()))
+                        .new_proposal(&id, MlsProposal::Remove(bob_central.read_client_id()))
                         .await
                         .unwrap();
                     bob_central

--- a/crypto/src/test_utils/fixtures.rs
+++ b/crypto/src/test_utils/fixtures.rs
@@ -15,10 +15,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
 pub use crate::mls::credential::CredentialSupplier;
-use crate::prelude::{MlsConversationConfiguration, MlsCustomConfiguration};
+use crate::prelude::{MlsCiphersuite, MlsConversationConfiguration, MlsCustomConfiguration};
 use openmls_traits::types::SignatureScheme;
-
-use crate::mls::MlsCiphersuite;
 pub use rstest::*;
 pub use rstest_reuse::{self, *};
 
@@ -26,49 +24,49 @@ pub use rstest_reuse::{self, *};
 #[rstest(
     case,
     case::basic_cs1(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_basic(),
+        openmls::prelude::CredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
     )),
     case::cert_cs1(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_certificate_bundle(),
+        openmls::prelude::CredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
     )),
     #[cfg(feature = "test-all-cipher")]
     case::basic_cs2(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_basic(),
+        openmls::prelude::CredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
     )),
     /*
     #[cfg(feature = "test-all-cipher")]
     case::cert_cs2(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_certificate_bundle(),
+        openmls::prelude::CredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
     )),
     */
     #[cfg(feature = "test-all-cipher")]
     case::basic_cs3(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_basic(),
+        openmls::prelude::CredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
     )),
     #[cfg(feature = "test-all-cipher")]
     case::cert_cs3(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_certificate_bundle(),
+        openmls::prelude::CredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
     )),
     #[cfg(feature = "test-all-cipher")]
     case::basic_cs7(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_basic(),
+        openmls::prelude::CredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
     )),
     /*
     #[cfg(feature = "test-all-cipher")]
     case::cert_cs7(TestCase::new(
-        $crate::mls::credential::CertificateBundle::rand_certificate_bundle(),
+        openmls::prelude::CredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
     )),
     */
     case::pure_ciphertext(TestCase {
-        credential: $crate::mls::credential::CertificateBundle::rand_basic(),
+        credential_type: openmls::prelude::CredentialType::Basic,
         cfg: $crate::prelude::MlsConversationConfiguration {
             custom: $crate::prelude::MlsCustomConfiguration {
                 wire_policy: $crate::prelude::MlsWirePolicy::Ciphertext,
@@ -83,14 +81,14 @@ pub fn all_cred_cipher(case: TestCase) {}
 
 #[derive(Debug, Clone)]
 pub struct TestCase {
-    pub credential: CredentialSupplier,
+    pub credential_type: openmls::prelude::CredentialType,
     pub cfg: MlsConversationConfiguration,
 }
 
 impl TestCase {
-    pub fn new(credential: CredentialSupplier, cs: openmls::prelude::Ciphersuite) -> Self {
+    pub fn new(credential_type: openmls::prelude::CredentialType, cs: openmls::prelude::Ciphersuite) -> Self {
         Self {
-            credential,
+            credential_type,
             cfg: MlsConversationConfiguration {
                 ciphersuite: cs.into(),
                 ..Default::default()
@@ -109,16 +107,12 @@ impl TestCase {
     pub fn custom_cfg(&self) -> MlsCustomConfiguration {
         self.cfg.custom.clone()
     }
-
-    pub fn credential(&self) -> Option<crate::mls::credential::CertificateBundle> {
-        (self.credential)(self.cfg.ciphersuite)
-    }
 }
 
 impl Default for TestCase {
     fn default() -> Self {
         Self {
-            credential: |_| None,
+            credential_type: openmls::prelude::CredentialType::Basic,
             cfg: MlsConversationConfiguration::default(),
         }
     }

--- a/interop/src/clients/corecrypto/e2ei.js
+++ b/interop/src/clients/corecrypto/e2ei.js
@@ -3,9 +3,9 @@ const [callback] = arguments;
 const encoder = new TextEncoder();
 const jsonToByteArray = json => encoder.encode(JSON.stringify(json, null, 0));
 
-const clientId = "NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@example.com";
-const displayName = "Smith, Alice M (QA)";
-const handle = "alice.smith.qa@example.com";
+const clientId = "NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg:6c1866f567616f31@wire.com";
+const displayName = "Alice Smith";
+const handle = "alice_wire";
 const expiry = 90;
 
 const enrollment = await window.cc.newAcmeEnrollment(clientId, displayName, handle, expiry);
@@ -36,7 +36,7 @@ const newOrderResp = {
     "identifiers": [
         {
             "type": "wireapp-id",
-            "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+            "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
         }
     ],
     "authorizations": [
@@ -54,7 +54,7 @@ const authzResp = {
     "expires": "2016-01-02T14:09:30Z",
     "identifier": {
         "type": "wireapp-id",
-        "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+        "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
     },
     "challenges": [
         {
@@ -106,7 +106,7 @@ const checkOrderResp = {
     "identifiers": [
         {
             "type": "wireapp-id",
-            "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+            "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
         }
     ],
     "authorizations": [
@@ -126,7 +126,7 @@ const finalizeResp = {
     "identifiers": [
         {
             "type": "wireapp-id",
-            "value": "{\"name\":\"Smith, Alice M (QA)\",\"domain\":\"example.com\",\"client-id\":\"impp:wireapp=NjJiYTRjMTIyODJjNDY5YmE5NGZmMjhhNjFkODA0Njk/d2ba2c1a57588ee4@example.com\",\"handle\":\"impp:wireapp=alice.smith.qa@example.com\"}"
+            "value": "{\"name\":\"Alice Smith\",\"domain\":\"wire.com\",\"client-id\":\"im:wireapp=NjhlMzIxOWFjODRiNDAwYjk0ZGFhZDA2NzExNTEyNTg/6c1866f567616f31@wire.com\",\"handle\":\"im:wireapp=alice_wire\"}"
         }
     ],
     "authorizations": [


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Decrypting messages now returns identity in the CommitBundle
Also fixes an issue with URIs in x509 Subject Alternative Name converted to lowercase in acme server.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
