### PR TITLE
feat: add methods to renew/switch to a x509 credential

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,10 @@ git = "https://github.com/wireapp/openmls"
 tag = "v0.5.6-pre.core-crypto-0.7.0"
 
 [patch.crates-io.wire-e2e-identity]
-git = "https://github.com/wireapp/rusty-jwt-tools"
-package = "wire-e2e-identity"
-tag = "v0.3.6"
+#git = "https://github.com/wireapp/rusty-jwt-tools"
+#package = "wire-e2e-identity"
+#tag = "v0.3.6"
+path = "../rusty-jwt-tools/e2e-identity"
 
 [patch.crates-io.hpke-rs]
 git = "https://github.com/wireapp/hpke-rs"

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_3d4a_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_3d4a_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,335 +264,335 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_6af_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_3d4a_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_6af_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_6af_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_mls_generate_keypair(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_mls_generate_keypair(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKey`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_restore_from_disk(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_restore_from_disk(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_3d4a_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_client_public_key(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_client_public_key(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
+    fun CoreCrypto_3d4a_CoreCrypto_client_keypackages(`ptr`: Pointer,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_6af_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_6af_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_6af_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
+    fun CoreCrypto_3d4a_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_3d4a_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_3d4a_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Short
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_6af_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`e2ei`: Pointer,`certificateChain`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`e2ei`: Pointer,`certificateChain`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
+    fun CoreCrypto_3d4a_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Int
 
-    fun ffi_CoreCrypto_6af_WireE2eIdentity_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_3d4a_WireE2eIdentity_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`backendNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`accessTokenUrl`: RustBuffer.ByValue,`expirySecs`: Int,`backendNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_6af_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_3d4a_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_3d4a_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_6af_version(
+    fun CoreCrypto_3d4a_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6af_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_3d4a_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6af_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_3d4a_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_6af_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_3d4a_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_6af_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_3d4a_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -1128,7 +1128,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: ClientId, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1141,7 +1141,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_3d4a_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1149,7 +1149,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInit`(`clientId`: ClientId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }
     
@@ -1157,7 +1157,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsGenerateKeypair`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mls_generate_keypair(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_mls_generate_keypair(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1166,7 +1166,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceUByte.lower(`signaturePublicKey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceUByte.lower(`signaturePublicKey`),  _status)
 }
         }
     
@@ -1174,7 +1174,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `restoreFromDisk`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_restore_from_disk(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_restore_from_disk(it,  _status)
 }
         }
     
@@ -1182,7 +1182,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1190,7 +1190,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_client_public_key(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_client_public_key(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1199,7 +1199,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_client_keypackages(it, FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1208,7 +1208,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_client_valid_keypackages_count(it,  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1217,7 +1217,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1225,7 +1225,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1233,7 +1233,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1242,7 +1242,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1251,7 +1251,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1260,7 +1260,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1269,7 +1269,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
 }
         }
     
@@ -1277,7 +1277,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1286,7 +1286,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1295,7 +1295,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1303,7 +1303,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1312,7 +1312,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1321,7 +1321,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1330,7 +1330,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1339,7 +1339,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1348,7 +1348,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1357,7 +1357,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1366,7 +1366,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1375,7 +1375,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1383,7 +1383,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1391,7 +1391,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1400,7 +1400,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1409,7 +1409,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1418,7 +1418,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1427,7 +1427,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1435,7 +1435,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1443,7 +1443,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1451,7 +1451,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1459,7 +1459,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1467,7 +1467,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1475,7 +1475,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1484,7 +1484,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1492,7 +1492,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1500,7 +1500,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionExists`(`sessionId`: String): Boolean =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1509,7 +1509,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1518,7 +1518,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1527,7 +1527,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1536,7 +1536,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1545,7 +1545,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekeyAuto`(): ProteusAutoPrekeyBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey_auto(it,  _status)
 }
         }.let {
             FfiConverterTypeProteusAutoPrekeyBundle.lift(it)
@@ -1554,7 +1554,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1563,7 +1563,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekeyId`(): UShort =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
 }
         }.let {
             FfiConverterUShort.lift(it)
@@ -1572,7 +1572,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1581,7 +1581,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintLocal`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1590,7 +1590,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintRemote`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1599,7 +1599,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintPrekeybundle`(`prekey`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1608,7 +1608,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
@@ -1616,7 +1616,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_new_acme_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_new_acme_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterTypeWireE2eIdentity.lift(it)
@@ -1625,14 +1625,14 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`e2ei`), FfiConverterString.lower(`certificateChain`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`e2ei`), FfiConverterString.lower(`certificateChain`),  _status)
 }
         }
     
     override fun `proteusLastErrorCode`(): UInt =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_proteus_last_error_code(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_proteus_last_error_code(it,  _status)
 }
         }.let {
             FfiConverterUInt.lift(it)
@@ -1643,7 +1643,7 @@ class CoreCrypto(
         fun `deferredInit`(`path`: String, `key`: String, `entropySeed`: List<UByte>?): CoreCrypto =
             CoreCrypto(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
         
     }
@@ -1699,7 +1699,7 @@ public interface WireE2eIdentityInterface {
     fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz
     
     @Throws(E2eIdentityException::class)
-    fun `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String): String
+    fun `createDpopToken`(`accessTokenUrl`: String, `expirySecs`: UInt, `backendNonce`: String): String
     
     @Throws(E2eIdentityException::class)
     fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte>
@@ -1741,7 +1741,7 @@ class WireE2eIdentity(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_6af_WireE2eIdentity_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_3d4a_WireE2eIdentity_object_free(this.pointer, status)
         }
     }
 
@@ -1749,7 +1749,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: List<UByte>): AcmeDirectory =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
 }
         }.let {
             FfiConverterTypeAcmeDirectory.lift(it)
@@ -1758,7 +1758,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1767,7 +1767,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
 }
         }
     
@@ -1775,7 +1775,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1784,7 +1784,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: List<UByte>): NewAcmeOrder =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeOrder.lift(it)
@@ -1793,7 +1793,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1802,16 +1802,16 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeAuthz.lift(it)
         }
     
-    @Throws(E2eIdentityException::class)override fun `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String): String =
+    @Throws(E2eIdentityException::class)override fun `createDpopToken`(`accessTokenUrl`: String, `expirySecs`: UInt, `backendNonce`: String): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterString.lower(`backendNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_create_dpop_token(it, FfiConverterString.lower(`accessTokenUrl`), FfiConverterUInt.lower(`expirySecs`), FfiConverterString.lower(`backendNonce`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1820,7 +1820,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1829,7 +1829,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1838,7 +1838,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
 }
         }
     
@@ -1846,7 +1846,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1855,7 +1855,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }
     
@@ -1863,7 +1863,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1872,7 +1872,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
 }
         }
     
@@ -1880,7 +1880,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `certificateRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -3088,7 +3088,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_3d4a_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -3602,7 +3602,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_6af_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_3d4a_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_6af_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_3d4a_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_6af_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_3d4a_rustbuffer_free(self, $0) }
     }
 }
 
@@ -492,7 +492,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_6af_CoreCrypto_new(
+    CoreCrypto_3d4a_CoreCrypto_new(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterTypeClientId.lower(`clientId`), 
@@ -501,7 +501,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_6af_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_3d4a_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -510,7 +510,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_6af_CoreCrypto_deferred_init(
+    CoreCrypto_3d4a_CoreCrypto_deferred_init(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterOptionSequenceUInt8.lower(`entropySeed`), $0)
@@ -522,7 +522,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInit`(`clientId`: ClientId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_mls_init(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_mls_init(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
 }
@@ -531,7 +531,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_mls_generate_keypair(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_mls_generate_keypair(self.pointer, $0
     )
 }
         )
@@ -539,7 +539,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_mls_init_with_client_id(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceUInt8.lower(`signaturePublicKey`), $0
     )
@@ -548,14 +548,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `restoreFromDisk`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_restore_from_disk(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_restore_from_disk(self.pointer, $0
     )
 }
     }
     public func `setCallbacks`(`callbacks`: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(`callbacks`), $0
     )
 }
@@ -564,7 +564,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_client_public_key(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_client_public_key(self.pointer, $0
     )
 }
         )
@@ -573,7 +573,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterUInt32.lower(`amountRequested`), $0
     )
 }
@@ -583,7 +583,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_client_valid_keypackages_count(self.pointer, $0
     )
 }
         )
@@ -591,7 +591,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeConversationConfiguration.lower(`config`), $0
     )
@@ -601,7 +601,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -612,7 +612,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_6af_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -622,7 +622,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(`welcomeMessage`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -633,7 +633,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeInvitee.lower(`clients`), $0
     )
@@ -644,7 +644,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeClientId.lower(`clients`), $0
     )
@@ -654,7 +654,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
         FfiConverterTypeConversationId.lower(`childId`), 
         FfiConverterTypeConversationId.lower(`parentId`), $0
     )
@@ -664,7 +664,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -674,7 +674,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -683,7 +683,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `wipeConversation`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -692,7 +692,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`payload`), $0
     )
@@ -703,7 +703,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`message`), $0
     )
@@ -714,7 +714,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`keyPackage`), $0
     )
@@ -725,7 +725,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -735,7 +735,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
@@ -746,7 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), $0
     )
@@ -757,7 +757,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterSequenceUInt8.lower(`keyPackageRef`), $0
@@ -769,7 +769,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(`publicGroupState`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -779,7 +779,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -787,7 +787,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -796,7 +796,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -806,7 +806,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt32.lower(`keyLength`), $0
     )
@@ -817,7 +817,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_get_client_ids(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -827,7 +827,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(`length`), $0
     )
 }
@@ -836,7 +836,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `reseedRng`(`seed`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(`seed`), $0
     )
 }
@@ -844,7 +844,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `commitAccepted`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -852,7 +852,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`proposalRef`), $0
     )
@@ -861,7 +861,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -869,14 +869,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusInit`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
@@ -886,7 +886,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`envelope`), $0
     )
@@ -896,7 +896,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionSave`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -904,7 +904,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionDelete`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -913,7 +913,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterBool.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_session_exists(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_session_exists(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -923,7 +923,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`ciphertext`), $0
     )
@@ -934,7 +934,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -945,7 +945,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -956,7 +956,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(`prekeyId`), $0
     )
 }
@@ -966,7 +966,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProteusAutoPrekeyBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
     )
 }
         )
@@ -975,7 +975,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
     )
 }
         )
@@ -984,7 +984,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt16.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
     )
 }
         )
@@ -993,7 +993,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -1002,7 +1002,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_local(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1012,7 +1012,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1022,7 +1022,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
 }
@@ -1031,7 +1031,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusCryptoboxMigrate`(`path`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(`path`), $0
     )
 }
@@ -1040,7 +1040,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeWireE2eIdentity.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_new_acme_enrollment(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_new_acme_enrollment(self.pointer, 
         FfiConverterString.lower(`clientId`), 
         FfiConverterString.lower(`displayName`), 
         FfiConverterString.lower(`handle`), 
@@ -1053,7 +1053,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_6af_CoreCrypto_e2ei_mls_init(self.pointer, 
+    CoreCrypto_3d4a_CoreCrypto_e2ei_mls_init(self.pointer, 
         FfiConverterTypeWireE2eIdentity.lower(`e2ei`), 
         FfiConverterString.lower(`certificateChain`), $0
     )
@@ -1064,7 +1064,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_6af_CoreCrypto_proteus_last_error_code(self.pointer, $0
+    CoreCrypto_3d4a_CoreCrypto_proteus_last_error_code(self.pointer, $0
     )
 }
         )
@@ -1112,7 +1112,7 @@ public protocol WireE2eIdentityProtocol {
     func `newOrderResponse`(`order`: [UInt8]) throws -> NewAcmeOrder
     func `newAuthzRequest`(`url`: String, `previousNonce`: String) throws -> [UInt8]
     func `newAuthzResponse`(`authz`: [UInt8]) throws -> NewAcmeAuthz
-    func `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String) throws -> String
+    func `createDpopToken`(`accessTokenUrl`: String, `expirySecs`: UInt32, `backendNonce`: String) throws -> String
     func `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String) throws -> [UInt8]
     func `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String) throws -> [UInt8]
     func `newChallengeResponse`(`challenge`: [UInt8]) throws
@@ -1135,7 +1135,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_6af_WireE2eIdentity_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_3d4a_WireE2eIdentity_object_free(pointer, $0) }
     }
 
     
@@ -1145,7 +1145,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeAcmeDirectory.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_directory_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_directory_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`directory`), $0
     )
 }
@@ -1155,7 +1155,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_account_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_account_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1164,7 +1164,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newAccountResponse`(`account`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_account_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_account_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`account`), $0
     )
 }
@@ -1173,7 +1173,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_order_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_order_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1183,7 +1183,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeOrder.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_order_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1193,7 +1193,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_authz_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_authz_request(self.pointer, 
         FfiConverterString.lower(`url`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1204,18 +1204,19 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeAuthz.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_authz_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_authz_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`authz`), $0
     )
 }
         )
     }
-    public func `createDpopToken`(`accessTokenUrl`: String, `backendNonce`: String) throws -> String {
+    public func `createDpopToken`(`accessTokenUrl`: String, `expirySecs`: UInt32, `backendNonce`: String) throws -> String {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_create_dpop_token(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_create_dpop_token(self.pointer, 
         FfiConverterString.lower(`accessTokenUrl`), 
+        FfiConverterUInt32.lower(`expirySecs`), 
         FfiConverterString.lower(`backendNonce`), $0
     )
 }
@@ -1225,7 +1226,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
         FfiConverterString.lower(`accessToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1236,7 +1237,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
         FfiConverterString.lower(`idToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1246,7 +1247,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newChallengeResponse`(`challenge`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_new_challenge_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_new_challenge_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`challenge`), $0
     )
 }
@@ -1255,7 +1256,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_check_order_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_check_order_request(self.pointer, 
         FfiConverterString.lower(`orderUrl`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1265,7 +1266,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `checkOrderResponse`(`order`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_check_order_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_check_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1274,7 +1275,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_finalize_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_finalize_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1283,7 +1284,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `finalizeResponse`(`finalize`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_finalize_response(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_finalize_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`finalize`), $0
     )
 }
@@ -1292,7 +1293,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_6af_WireE2eIdentity_certificate_request(self.pointer, 
+    CoreCrypto_3d4a_WireE2eIdentity_certificate_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -3264,7 +3265,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_3d4a_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3754,7 +3755,7 @@ public func `version`()  -> String {
     
     rustCall() {
     
-    CoreCrypto_6af_version($0)
+    CoreCrypto_3d4a_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,335 +46,335 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_6af_CoreCrypto_object_free(
+void ffi_CoreCrypto_3d4a_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_6af_CoreCrypto_new(
+void*_Nonnull CoreCrypto_3d4a_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_6af_CoreCrypto_deferred_init(
+void*_Nonnull CoreCrypto_3d4a_CoreCrypto_deferred_init(
       RustBuffer path,RustBuffer key,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_mls_init(
+void CoreCrypto_3d4a_CoreCrypto_mls_init(
       void*_Nonnull ptr,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_mls_generate_keypair(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_mls_generate_keypair(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_mls_init_with_client_id(
+void CoreCrypto_3d4a_CoreCrypto_mls_init_with_client_id(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer signature_public_key,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_restore_from_disk(
+void CoreCrypto_3d4a_CoreCrypto_restore_from_disk(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_set_callbacks(
+void CoreCrypto_3d4a_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_client_public_key(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_6af_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_3d4a_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_create_conversation(
+void CoreCrypto_3d4a_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_6af_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_3d4a_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_6af_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_3d4a_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_mark_conversation_as_child_of(
+void CoreCrypto_3d4a_CoreCrypto_mark_conversation_as_child_of(
       void*_Nonnull ptr,RustBuffer child_id,RustBuffer parent_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_wipe_conversation(
+void CoreCrypto_3d4a_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_3d4a_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_3d4a_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_get_client_ids(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_reseed_rng(
+void CoreCrypto_3d4a_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_commit_accepted(
+void CoreCrypto_3d4a_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_3d4a_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_clear_pending_commit(
+void CoreCrypto_3d4a_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_proteus_init(
+void CoreCrypto_3d4a_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_3d4a_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_proteus_session_save(
+void CoreCrypto_3d4a_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_proteus_session_delete(
+void CoreCrypto_3d4a_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_6af_CoreCrypto_proteus_session_exists(
+int8_t CoreCrypto_3d4a_CoreCrypto_proteus_session_exists(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_new_prekey_auto(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_new_prekey_auto(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-uint16_t CoreCrypto_6af_CoreCrypto_proteus_last_resort_prekey_id(
+uint16_t CoreCrypto_3d4a_CoreCrypto_proteus_last_resort_prekey_id(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint_local(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_local(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint_remote(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_remote(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_CoreCrypto_proteus_fingerprint_prekeybundle(
+RustBuffer CoreCrypto_3d4a_CoreCrypto_proteus_fingerprint_prekeybundle(
       void*_Nonnull ptr,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_3d4a_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_6af_CoreCrypto_new_acme_enrollment(
+void*_Nonnull CoreCrypto_3d4a_CoreCrypto_new_acme_enrollment(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer display_name,RustBuffer handle,uint32_t expiry_days,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_CoreCrypto_e2ei_mls_init(
+void CoreCrypto_3d4a_CoreCrypto_e2ei_mls_init(
       void*_Nonnull ptr,void*_Nonnull e2ei,RustBuffer certificate_chain,
     RustCallStatus *_Nonnull out_status
     );
-uint32_t CoreCrypto_6af_CoreCrypto_proteus_last_error_code(
+uint32_t CoreCrypto_3d4a_CoreCrypto_proteus_last_error_code(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_6af_WireE2eIdentity_object_free(
+void ffi_CoreCrypto_3d4a_WireE2eIdentity_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_directory_response(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_directory_response(
       void*_Nonnull ptr,RustBuffer directory,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_account_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_account_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_WireE2eIdentity_new_account_response(
+void CoreCrypto_3d4a_WireE2eIdentity_new_account_response(
       void*_Nonnull ptr,RustBuffer account,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_order_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_order_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_order_response(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_authz_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_authz_request(
       void*_Nonnull ptr,RustBuffer url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_authz_response(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_authz_response(
       void*_Nonnull ptr,RustBuffer authz,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_create_dpop_token(
-      void*_Nonnull ptr,RustBuffer access_token_url,RustBuffer backend_nonce,
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_create_dpop_token(
+      void*_Nonnull ptr,RustBuffer access_token_url,uint32_t expiry_secs,RustBuffer backend_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_dpop_challenge_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_dpop_challenge_request(
       void*_Nonnull ptr,RustBuffer access_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_new_oidc_challenge_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_new_oidc_challenge_request(
       void*_Nonnull ptr,RustBuffer id_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_WireE2eIdentity_new_challenge_response(
+void CoreCrypto_3d4a_WireE2eIdentity_new_challenge_response(
       void*_Nonnull ptr,RustBuffer challenge,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_check_order_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_check_order_request(
       void*_Nonnull ptr,RustBuffer order_url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_WireE2eIdentity_check_order_response(
+void CoreCrypto_3d4a_WireE2eIdentity_check_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_finalize_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_finalize_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_6af_WireE2eIdentity_finalize_response(
+void CoreCrypto_3d4a_WireE2eIdentity_finalize_response(
       void*_Nonnull ptr,RustBuffer finalize,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_WireE2eIdentity_certificate_request(
+RustBuffer CoreCrypto_3d4a_WireE2eIdentity_certificate_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_6af_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_3d4a_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_6af_version(
+RustBuffer CoreCrypto_3d4a_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_6af_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_3d4a_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_6af_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_3d4a_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_6af_rustbuffer_free(
+void ffi_CoreCrypto_3d4a_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_6af_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_3d4a_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -373,14 +373,13 @@ impl CoreCrypto<'_> {
     /// See [core_crypto::MlsCentral::mls_init]
     pub fn mls_init(&self, client_id: &ClientId) -> CryptoResult<()> {
         let ciphersuites = vec![MlsCiphersuite::default()];
-        future::block_on(
-            self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
-                self.central
-                    .lock()
-                    .map_err(|_| CryptoError::LockPoisonError)?
-                    .mls_init(either::Left(client_id.clone()), ciphersuites),
+        future::block_on(self.executor.lock().map_err(|_| CryptoError::LockPoisonError)?.run(
+            self.central.lock().map_err(|_| CryptoError::LockPoisonError)?.mls_init(
+                either::Left(client_id.clone()),
+                ciphersuites,
+                false,
             ),
-        )
+        ))
     }
 
     /// See [core_crypto::mls::MlsCentral::mls_generate_keypair]

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -907,7 +907,7 @@ impl CoreCrypto {
                 let ciphersuites = vec![MlsCiphersuite::default()];
                 let mut central = this.write().await;
                 central
-                    .mls_init(either::Left(client_id.clone().into()), ciphersuites)
+                    .mls_init(either::Left(client_id.clone().into()), ciphersuites, false)
                     .await
                     .map_err(CoreCryptoError::from)?;
                 WasmCryptoResult::Ok(JsValue::UNDEFINED)

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -41,6 +41,7 @@ schnellru = "0.2"
 zeroize = "1.5"
 wire-e2e-identity = "0.3"
 either = "1.8"
+futures-util = { version = "0.3", features = ["std", "alloc"] }
 
 [dependencies.proteus-wasm]
 version = "2.0"
@@ -84,7 +85,6 @@ js-sys = "0.3"
 rstest = "0.17"
 rstest_reuse = "0.5"
 async-std = { version = "1.12", features = ["attributes"] }
-futures-util = { version = "0.3", features = ["std", "alloc"] }
 futures-lite = "1.12"
 proteus-traits = "2.0"
 async-trait = "0.1"

--- a/crypto/src/e2e_identity/identity.rs
+++ b/crypto/src/e2e_identity/identity.rs
@@ -6,7 +6,7 @@ use openmls::{
 
 /// Represents the identity claims identifying a client
 /// Those claims are verifiable by any member in the group
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct WireIdentity {
     /// Unique client identifier e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@whitehouse.gov`
     pub client_id: String,

--- a/crypto/src/e2e_identity/renew.rs
+++ b/crypto/src/e2e_identity/renew.rs
@@ -1,0 +1,156 @@
+//! Allows getting a new certificate either because
+//! * display_name or handle changed
+//! * the previous certificate is expired.
+
+use crate::group_store::GroupStoreValue;
+use crate::prelude::{E2eIdentityResult, MlsCentral, MlsCommitBundle, MlsConversation, WireE2eIdentity};
+use crate::{CryptoError, CryptoResult};
+use openmls::prelude::{GroupId, KeyPackage};
+use std::collections::HashMap;
+
+pub struct MlsRenewBundle {
+    pub commits: HashMap<GroupId, MlsCommitBundle>,
+    pub key_packages: Vec<KeyPackage>,
+}
+
+impl MlsCentral {
+    /// TODO
+    ///
+    /// # Arguments
+    /// * `display_name` - human readable name displayed in the application e.g. `Smith, Alice M (QA)`
+    /// * `handle` - user handle e.g. `alice.smith.qa@example.com`
+    /// * `expiry_days` - generated x509 certificate expiry in days
+    pub fn new_acme_renew(
+        &self,
+        display_name: String,
+        handle: String,
+        expiry_days: u32,
+    ) -> E2eIdentityResult<WireE2eIdentity> {
+        let client = self.mls_client.as_ref().ok_or(CryptoError::MlsNotInitialized)?;
+        WireE2eIdentity::try_new(
+            client.id().clone(),
+            display_name,
+            handle,
+            expiry_days,
+            &self.mls_backend,
+            *client.ciphersuite(),
+        )
+    }
+
+    /// TODO
+    pub async fn e2ei_mls_renew(
+        &mut self,
+        e2ei: WireE2eIdentity,
+        certificate_chain: String,
+        amount_requested: usize,
+    ) -> E2eIdentityResult<MlsRenewBundle> {
+        e2ei.certificate_response(self, certificate_chain, true).await?;
+        let commits = self.update_all_conversations().await?;
+        let kpbs = self.client_keypackages(amount_requested).await?;
+        let key_packages = kpbs.into_iter().map(|kpb| kpb.into_parts().0).collect::<Vec<_>>();
+        Ok(MlsRenewBundle { commits, key_packages })
+    }
+
+    async fn update_all_conversations(&mut self) -> CryptoResult<HashMap<GroupId, MlsCommitBundle>> {
+        let conversations = self.get_all_conversations().await?;
+
+        let backend = &self.mls_backend;
+
+        use futures_util::{StreamExt as _, TryStreamExt as _};
+        futures_util::stream::iter(conversations)
+            .map(|c| Ok::<GroupStoreValue<MlsConversation>, CryptoError>(c))
+            .try_fold(HashMap::new(), |mut acc, c| async move {
+                let mut c = c.write().await;
+                let id = GroupId::from_slice(c.id().as_slice());
+                let commit_bundle = c.update_keying_material(backend).await?;
+                acc.insert(id, commit_bundle);
+                Ok(acc)
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::test_utils::*;
+    use wasm_bindgen_test::*;
+    use wire_e2e_identity::prelude::*;
+
+    use crate::e2e_identity::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn e2e_identity_renew_should_work(case: TestCase) {
+        let is_x509 = matches!(case.credential_type, openmls::prelude::CredentialType::X509);
+        if is_x509 && utils::SUPPORTED_ALG.contains(&case.signature_scheme()) {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        // MLS clients should already be initialized in this test
+                        assert!(alice_central.mls_client.is_some());
+                        assert!(bob_central.mls_client.is_some());
+
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), case.cfg.clone())
+                            .await
+                            .unwrap();
+                        alice_central
+                            .invite(&id, [&mut bob_central], case.custom_cfg())
+                            .await
+                            .unwrap();
+
+                        // Alice
+                        let mut alice_identity = WireIdentityBuilder {
+                            display_name: "Alice Smith".to_string(),
+                            handle: "alice_wire".to_string(),
+                            ..Default::default()
+                        };
+                        let WireIdentityBuilder {
+                            client_id: alice_client_id,
+                            display_name: alice_display_name,
+                            handle: alice_handle,
+                            domain: alice_domain,
+                            ..
+                        } = alice_identity.clone();
+
+                        let enrollment = alice_central
+                            .new_acme_renew(alice_display_name.clone(), alice_handle.clone(), 90)
+                            .unwrap();
+                        // since creating an enrollment creates a new keypair, we have to get it back in order to sign our fake certificate
+                        let alice_kp = enrollment.get_key_pair();
+                        alice_identity.options = Some(WireIdentityBuilderOptions::X509(WireIdentityBuilderX509 {
+                            cert_kp: Some(alice_kp),
+                            ..Default::default()
+                        }));
+                        // Alice refreshes her x509 credential
+                        let (certificates, ..) = alice_identity.build_x509_pem();
+                        let MlsRenewBundle { commits, .. } = alice_central
+                            .e2ei_mls_renew(enrollment, certificates, 10)
+                            .await
+                            .unwrap();
+
+                        assert_eq!(commits.len(), 1);
+                        let MlsCommitBundle { commit, .. } = commits.get(&GroupId::from_slice(id.as_slice())).unwrap();
+                        alice_central.commit_accepted(&id).await.unwrap();
+
+                        // Bob processes Alice's update of credential
+                        bob_central
+                            .decrypt_message(&id, commit.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+
+                        // Alice's credential is updated and both can communicate
+                        alice_central.try_talk_to(&id, &mut bob_central).await.unwrap();
+                    })
+                },
+            )
+            .await
+        }
+    }
+}

--- a/crypto/src/e2e_identity/renew.rs
+++ b/crypto/src/e2e_identity/renew.rs
@@ -2,8 +2,7 @@
 //! * display_name or handle changed
 //! * the previous certificate is expired.
 
-use crate::group_store::GroupStoreValue;
-use crate::prelude::{E2eIdentityResult, MlsCentral, MlsCommitBundle, MlsConversation, WireE2eIdentity};
+use crate::prelude::{E2eIdentityResult, MlsCentral, MlsCommitBundle, WireE2eIdentity};
 use crate::{CryptoError, CryptoResult};
 use openmls::prelude::{GroupId, KeyPackage};
 use std::collections::HashMap;
@@ -58,7 +57,7 @@ impl MlsCentral {
 
         use futures_util::{StreamExt as _, TryStreamExt as _};
         futures_util::stream::iter(conversations)
-            .map(|c| Ok::<GroupStoreValue<MlsConversation>, CryptoError>(c))
+            .map(|c| Ok::<_, CryptoError>(c))
             .try_fold(HashMap::new(), |mut acc, c| async move {
                 let mut c = c.write().await;
                 let id = GroupId::from_slice(c.id().as_slice());

--- a/crypto/src/mls/client.rs
+++ b/crypto/src/mls/client.rs
@@ -349,8 +349,6 @@ impl Client {
         ciphersuites: &[MlsCiphersuite],
         backend: &MlsCryptoProvider,
     ) -> CryptoResult<Self> {
-        use core_crypto_keystore::CryptoKeystoreMls as _;
-
         // TODO: support multi-ciphersuite
         let ciphersuite = *ciphersuites.get(0).ok_or(CryptoError::ImplementationError)?;
 

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -187,7 +187,7 @@ pub mod tests {
                     let MlsConversationCreationMessage {
                         welcome: bob_welcome, ..
                     } = alice_central
-                        .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                        .add_members_to_conversation(&id, &mut [bob_central.rand_member().await])
                         .await
                         .unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
@@ -204,7 +204,7 @@ pub mod tests {
                         commit,
                         ..
                     } = alice_central
-                        .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                        .add_members_to_conversation(&id, &mut [charlie_central.rand_member().await])
                         .await
                         .unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -223,7 +223,7 @@ impl MlsCentral {
             .await?;
 
         if !decrypt_message.is_active {
-            // ? Do we wipe conversations or do we just prune the group from the cache - subsequent accesses will make it look like the group doesn't exist
+            // TODO: Do we wipe conversations or do we just prune the group from the cache - subsequent accesses will make it look like the group doesn't exist
             self.wipe_conversation(conversation_id).await?;
             // self.mls_groups
             //     .remove(conversation_id)
@@ -267,10 +267,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let MlsCommitBundle { commit, .. } = bob_central.update_keying_material(&id).await.unwrap();
                         let MlsConversationDecryptMessage { is_active, .. } = alice_central
@@ -297,10 +295,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let MlsCommitBundle { commit, .. } = bob_central
                             .remove_members_from_conversation(&id, &[alice_central.read_client_id()])
@@ -335,10 +331,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let epoch_before = alice_central.conversation_epoch(&id).await.unwrap();
 
@@ -375,14 +369,12 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Alice creates a commit which will be superseded by Bob's one
-                        let charlie = charlie_central.rnd_member().await;
-                        let debbie = debbie_central.rnd_member().await;
+                        let charlie = charlie_central.rand_member().await;
+                        let debbie = debbie_central.rand_member().await;
                         alice_central
                             .add_members_to_conversation(&id, &mut [charlie.clone()])
                             .await
@@ -433,15 +425,13 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Alice will create a commit to add Charlie
                         // Bob will create a commit which will be accepted first by DS so Alice will decrypt it
                         // Then Alice will renew the proposal in her pending commit
-                        let charlie = charlie_central.rnd_member().await;
+                        let charlie = charlie_central.rand_member().await;
 
                         let bob_commit = bob_central.update_keying_material(&id).await.unwrap().commit;
                         bob_central.commit_accepted(&id).await.unwrap();
@@ -536,10 +526,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Bob will create a proposal to add Charlie
                         // Alice will decrypt this proposal
@@ -590,10 +578,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Alice will create a proposal to add Charlie
                         // Bob will create a commit which Alice will decrypt
@@ -679,10 +665,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // DS will create an external proposal to add Charlie
                         // But meanwhile Bob, before receiving the external proposal,
@@ -729,10 +713,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let commit = alice_central.update_keying_material(&id).await.unwrap().commit;
 
@@ -767,10 +749,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let epoch = alice_central.get_conversation_unchecked(&id).await.group.epoch();
                         let ext_proposal = alice2_central
@@ -812,10 +792,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let epoch = alice_central.get_conversation_unchecked(&id).await.group.epoch();
                         let message = alice2_central
@@ -862,10 +840,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let epoch = alice_central.get_conversation_unchecked(&id).await.group.epoch();
                         let external_proposal = alice2_central
@@ -911,10 +887,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let charlie_kp = charlie_central.get_one_key_package().await;
                         let proposal = alice_central
@@ -955,10 +929,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let proposal = alice_central
                             .new_proposal(&id, MlsProposal::Update)
@@ -995,10 +967,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let msg = b"Hello bob";
                         let encrypted = alice_central.encrypt_message(&id, msg).await.unwrap();
@@ -1053,10 +1023,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let msg = b"Hello bob";
                         let encrypted = alice_central.encrypt_message(&id, msg).await.unwrap();
@@ -1084,10 +1052,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // encrypt a message in epoch 1
                         let msg = b"Hello bob";
@@ -1124,10 +1090,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // encrypt a message in epoch 1
                         let msg = b"Hello bob";
@@ -1164,10 +1128,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // only Alice which change epoch without notifying Bob
                         let commit = alice_central.update_keying_material(&id).await.unwrap().commit;
@@ -1210,10 +1172,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let out_of_order_tolerance = case.custom_cfg().out_of_order_tolerance;
                         let nb_messages = out_of_order_tolerance * 2;
@@ -1256,10 +1216,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let msg = b"Hello bob";
                         let encrypted = alice_central.encrypt_message(&id, msg).await.unwrap();
@@ -1296,10 +1254,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Alice generates a bunch of soon to be outdated messages
                         let msg = b"Hello bob";
@@ -1385,10 +1341,8 @@ pub mod tests {
                         bob_client.keypackage_lifetime(Duration::from_secs(2));
 
                         // Now Bob will have shorter KeyPackages. Let's add Bob to the group before those expire
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Now Bob will generate AND SIGN some messages with a signature key
                         // in his soon to expire KeyPackage

--- a/crypto/src/mls/conversation/encrypt.rs
+++ b/crypto/src/mls/conversation/encrypt.rs
@@ -82,10 +82,8 @@ pub mod tests {
                         .new_conversation(id.clone(), case.cfg.clone())
                         .await
                         .unwrap();
-                    alice_central
-                        .invite(&id, &mut bob_central, case.custom_cfg())
-                        .await
-                        .unwrap();
+                    let custom_cfg = case.custom_cfg();
+                    alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                     let msg = b"Hello bob";
                     let encrypted = alice_central.encrypt_message(&id, msg).await.unwrap();
@@ -117,10 +115,8 @@ pub mod tests {
                         .new_conversation(id.clone(), case.cfg.clone())
                         .await
                         .unwrap();
-                    alice_central
-                        .invite(&id, &mut bob_central, case.custom_cfg())
-                        .await
-                        .unwrap();
+                    let custom_cfg = case.custom_cfg();
+                    alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                     let msg = b"Hello bob";
                     let encrypted = alice_central.encrypt_message(&id, msg).await.unwrap();

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -178,10 +178,8 @@ pub mod tests {
 
                         assert_eq!(alice_central.get_client_ids(&id).await.unwrap().len(), 1);
 
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                         assert_eq!(alice_central.get_client_ids(&id).await.unwrap().len(), 2);
                     })
                 },

--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -420,7 +420,7 @@ pub mod tests {
                             .await
                             .unwrap();
                         let MlsConversationCreationMessage { welcome, .. } = alice_central
-                            .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [bob_central.rand_member().await])
                             .await
                             .unwrap();
 
@@ -471,7 +471,7 @@ pub mod tests {
                             .unwrap();
 
                         let welcome = alice_central
-                            .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [bob_central.rand_member().await])
                             .await
                             .unwrap()
                             .welcome;
@@ -503,7 +503,7 @@ pub mod tests {
                             .unwrap();
 
                         let public_group_state = alice_central
-                            .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [bob_central.rand_member().await])
                             .await
                             .unwrap()
                             .public_group_state;
@@ -541,10 +541,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                         let charlie_kp = charlie_central.get_one_key_package().await;
 
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
@@ -605,10 +603,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let MlsCommitBundle { commit, welcome, .. } = alice_central
                             .remove_members_from_conversation(&id, &[bob_central.read_client_id()])
@@ -652,10 +648,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let proposal = alice_central
                             .new_proposal(&id, MlsProposal::Add(guest_central.get_one_key_package().await))
@@ -699,10 +693,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let public_group_state = alice_central
                             .remove_members_from_conversation(&id, &[bob_central.read_client_id()])
@@ -745,10 +737,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                         let pgs = alice_central.verifiable_public_group_state(&id).await;
                         charlie_central
                             .try_join_from_public_group_state(
@@ -805,10 +795,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let bob_keys: Vec<KeyPackage> = bob_central
                             .get_conversation_unchecked(&id)
@@ -890,10 +878,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let bob_keys: Vec<KeyPackage> = bob_central
                             .get_conversation_unchecked(&id)
@@ -1009,10 +995,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let proposal = alice_central
                             .new_proposal(&id, MlsProposal::Add(guest_central.get_one_key_package().await))
@@ -1061,10 +1045,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let public_group_state = alice_central
                             .update_keying_material(&id)
@@ -1105,10 +1087,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let bob_keys: Vec<KeyPackage> = bob_central
                             .get_conversation_unchecked(&id)
@@ -1251,10 +1231,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                         let proposal = bob_central
                             .new_proposal(&id, MlsProposal::Add(charlie_central.get_one_key_package().await))
                             .await
@@ -1369,10 +1347,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let commit = alice_central.update_keying_material(&id).await.unwrap().commit;
 
@@ -1402,10 +1378,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let commit1 = alice_central.update_keying_material(&id).await.unwrap().commit;
                         alice_central.commit_accepted(&id).await.unwrap();
@@ -1447,10 +1421,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let _alice_commit = alice_central.update_keying_material(&id).await.unwrap().commit;
                         let bob_commit = bob_central.update_keying_material(&id).await.unwrap().commit;
@@ -1480,10 +1452,8 @@ pub mod tests {
                                 .new_conversation(id.clone(), case.cfg.clone())
                                 .await
                                 .unwrap();
-                            alice_central
-                                .invite(&id, &mut bob_central, case.custom_cfg())
-                                .await
-                                .unwrap();
+                            let custom_cfg = case.custom_cfg();
+                            alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                             let proposal1 = alice_central
                                 .new_proposal(&id, MlsProposal::Update)
@@ -1550,10 +1520,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let proposal = alice_central
                             .new_proposal(&id, MlsProposal::Update)

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -161,10 +161,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                         assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                         alice_central
                             .remove_members_from_conversation(&id, &[bob_central.read_client_id()])
@@ -194,7 +192,7 @@ pub mod tests {
                             .unwrap();
                         alice_central.new_proposal(&id, MlsProposal::Update).await.unwrap();
                         alice_central
-                            .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [bob_central.rand_member().await])
                             .await
                             .unwrap();
                         assert!(!alice_central.pending_proposals(&id).await.is_empty());
@@ -225,10 +223,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
 
                         let charlie_kp = charlie_central.get_one_key_package().await;

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -37,6 +37,7 @@ use mls_crypto_provider::MlsCryptoProvider;
 
 use config::MlsConversationConfiguration;
 
+use crate::group_store::GroupStoreValue;
 use crate::{
     mls::{client::Client, member::MemberId, ClientId, MlsCentral},
     CryptoError, CryptoResult, MlsError,
@@ -224,7 +225,7 @@ impl MlsCentral {
     pub(crate) async fn get_conversation(
         &mut self,
         id: &ConversationId,
-    ) -> CryptoResult<crate::group_store::GroupStoreValue<MlsConversation>> {
+    ) -> CryptoResult<GroupStoreValue<MlsConversation>> {
         let keystore = self.mls_backend.borrow_keystore_mut();
         self.mls_groups
             .get_fetch(id, keystore, None)
@@ -235,7 +236,7 @@ impl MlsCentral {
     pub(crate) async fn get_parent_conversation(
         &mut self,
         id: &ConversationId,
-    ) -> CryptoResult<Option<crate::group_store::GroupStoreValue<MlsConversation>>> {
+    ) -> CryptoResult<Option<GroupStoreValue<MlsConversation>>> {
         let conversation = self.get_conversation(id).await?;
         let conversation_lock = conversation.read().await;
         if let Some(parent_id) = conversation_lock.parent_id.as_ref() {
@@ -251,13 +252,9 @@ impl MlsCentral {
 
     pub(crate) async fn get_all_conversations(
         &mut self,
-    ) -> CryptoResult<Vec<crate::group_store::GroupStoreValue<MlsConversation>>> {
+    ) -> CryptoResult<Vec<either::Either<GroupStoreValue<MlsConversation>, MlsConversation>>> {
         let keystore = self.mls_backend.borrow_keystore_mut();
-        /*self.mls_groups
-        .get_fetch(id, keystore, None)
-        .await?
-        .ok_or_else(|| CryptoError::ConversationNotFound(id.clone()))*/
-        todo!()
+        self.mls_groups.get_all(keystore).await
     }
 
     /// Mark a conversation as child of another one

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -249,6 +249,17 @@ impl MlsCentral {
         }
     }
 
+    pub(crate) async fn get_all_conversations(
+        &mut self,
+    ) -> CryptoResult<Vec<crate::group_store::GroupStoreValue<MlsConversation>>> {
+        let keystore = self.mls_backend.borrow_keystore_mut();
+        /*self.mls_groups
+        .get_fetch(id, keystore, None)
+        .await?
+        .ok_or_else(|| CryptoError::ConversationNotFound(id.clone()))*/
+        todo!()
+    }
+
     /// Mark a conversation as child of another one
     /// This will affect the behavior of callbacks in particular
     pub async fn mark_conversation_as_child_of(
@@ -340,7 +351,7 @@ pub mod tests {
                         .unwrap();
 
                     let MlsConversationCreationMessage { welcome, .. } = alice_central
-                        .add_members_to_conversation(&id, &mut [bob_central.rnd_member().await])
+                        .add_members_to_conversation(&id, &mut [bob_central.rand_member().await])
                         .await
                         .unwrap();
                     // before merging, commit is not applied
@@ -405,9 +416,10 @@ pub mod tests {
 
                 let number_of_friends = bob_and_friends.len();
 
-                let mut bob_and_friends_members: Vec<ConversationMember> =
-                    futures_util::future::join_all(bob_and_friends.iter().map(|c| async move { c.rnd_member().await }))
-                        .await;
+                let mut bob_and_friends_members: Vec<ConversationMember> = futures_util::future::join_all(
+                    bob_and_friends.iter().map(|c| async move { c.rand_member().await }),
+                )
+                .await;
 
                 let MlsConversationCreationMessage { welcome, .. } = alice_central
                     .add_members_to_conversation(&id, &mut bob_and_friends_members)
@@ -460,7 +472,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     // has to be before the original key_package count because it creates one
-                    let bob = bob_central.rnd_member().await;
+                    let bob = bob_central.rand_member().await;
                     // Keep track of the whatever amount was initially generated
                     let original_kpb_count = bob_central
                         .mls_backend

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -144,10 +144,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
                         alice_central.new_proposal(&id, MlsProposal::Update).await.unwrap();
@@ -198,10 +196,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         alice_central.update_keying_material(&id).await.unwrap();
                         assert!(alice_central.pending_commit(&id).await.is_some());
@@ -236,10 +232,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
                         let proposal = alice_central
@@ -309,18 +303,9 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
+                            .invite(&id, [&mut bob_central, &mut charlie_central], custom_cfg)
                             .await
                             .unwrap();
 
@@ -369,10 +354,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let charlie_kp = charlie_central.get_one_key_package().await;
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
@@ -383,7 +366,7 @@ pub mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         let commit = bob_central
-                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [charlie_central.rand_member().await])
                             .await
                             .unwrap()
                             .commit;
@@ -414,10 +397,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         let charlie_kp = charlie_central.get_one_key_package().await;
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
@@ -432,7 +413,7 @@ pub mod tests {
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         let commit = bob_central
-                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [charlie_central.rand_member().await])
                             .await
                             .unwrap()
                             .commit;
@@ -463,18 +444,9 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
+                            .invite(&id, [&mut bob_central, &mut charlie_central], custom_cfg)
                             .await
                             .unwrap();
 
@@ -520,10 +492,8 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Alice proposes adding Charlie
                         let charlie_kp = charlie_central.get_one_key_package().await;
@@ -578,14 +548,12 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
-                        alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
+                        let custom_cfg = case.custom_cfg();
+                        alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
 
                         // Alice commits adding Charlie
                         alice_central
-                            .add_members_to_conversation(&id, &mut [charlie_central.rnd_member().await])
+                            .add_members_to_conversation(&id, &mut [charlie_central.rand_member().await])
                             .await
                             .unwrap();
                         assert!(alice_central.pending_commit(&id).await.is_some());
@@ -623,18 +591,9 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
+                            .invite(&id, [&mut bob_central, &mut charlie_central], custom_cfg)
                             .await
                             .unwrap();
 
@@ -677,18 +636,9 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
+                            .invite(&id, [&mut bob_central, &mut charlie_central], custom_cfg)
                             .await
                             .unwrap();
 
@@ -732,27 +682,12 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
+                            .invite(
                                 &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        debbie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central, &mut charlie_central],
+                                [&mut bob_central, &mut charlie_central, &mut debbie_central],
+                                custom_cfg,
                             )
                             .await
                             .unwrap();
@@ -798,27 +733,12 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
+                            .invite(
                                 &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        debbie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central, &mut charlie_central],
+                                [&mut bob_central, &mut charlie_central, &mut debbie_central],
+                                custom_cfg,
                             )
                             .await
                             .unwrap();
@@ -863,27 +783,12 @@ pub mod tests {
                             .new_conversation(id.clone(), case.cfg.clone())
                             .await
                             .unwrap();
+                        let custom_cfg = case.custom_cfg();
                         alice_central
-                            .invite(&id, &mut bob_central, case.custom_cfg())
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        charlie_central
-                            .try_join_from_public_group_state(
+                            .invite(
                                 &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central],
-                            )
-                            .await
-                            .unwrap();
-                        let pgs = alice_central.verifiable_public_group_state(&id).await;
-                        debbie_central
-                            .try_join_from_public_group_state(
-                                &id,
-                                pgs,
-                                case.custom_cfg(),
-                                vec![&mut alice_central, &mut bob_central, &mut charlie_central],
+                                [&mut bob_central, &mut charlie_central, &mut debbie_central],
+                                custom_cfg,
                             )
                             .await
                             .unwrap();

--- a/crypto/src/mls/credential.rs
+++ b/crypto/src/mls/credential.rs
@@ -293,16 +293,19 @@ pub mod tests {
             MlsCentralConfiguration::try_new(alice_path.0, "alice".into(), None, ciphersuites.clone(), None)?;
 
         let mut alice_central = MlsCentral::try_new(alice_cfg).await?;
-        alice_central.mls_init(alice_identity, ciphersuites.clone()).await?;
+        alice_central
+            .mls_init(alice_identity, ciphersuites.clone(), false)
+            .await?;
 
         let bob_path = tmp_db_file();
         let bob_cfg = MlsCentralConfiguration::try_new(bob_path.0, "bob".into(), None, ciphersuites.clone(), None)?;
 
         let mut bob_central = MlsCentral::try_new(bob_cfg).await?;
-        bob_central.mls_init(bob_identity, ciphersuites.clone()).await?;
+        bob_central.mls_init(bob_identity, ciphersuites.clone(), false).await?;
 
         alice_central.new_conversation(id.clone(), cfg.clone()).await?;
-        alice_central.invite(&id, &mut bob_central, cfg.custom).await?;
+        let custom_cfg = cfg.custom;
+        alice_central.invite(&id, [&mut bob_central], custom_cfg).await?;
         alice_central.try_talk_to(&id, &mut bob_central).await
     }
 }

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -402,10 +402,8 @@ mod tests {
                         .new_conversation(id.clone(), case.cfg.clone())
                         .await
                         .unwrap();
-                    alice_central
-                        .invite(&id, &mut bob_central, case.custom_cfg())
-                        .await
-                        .unwrap();
+                    let custom_cfg = case.custom_cfg();
+                    alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                     let public_group_state = alice_central.verifiable_public_group_state(&id).await;
                     // Alice can rejoin by external commit
                     let alice_join = alice_central

--- a/crypto/src/mls/external_proposal.rs
+++ b/crypto/src/mls/external_proposal.rs
@@ -258,8 +258,9 @@ mod tests {
                             cfg.set_raw_external_senders(vec![remove_key]);
                             owner_central.new_conversation(id.clone(), cfg).await.unwrap();
 
+                            let custom_cfg = case.custom_cfg();
                             owner_central
-                                .invite(&id, &mut guest_central, case.custom_cfg())
+                                .invite(&id, [&mut guest_central], custom_cfg)
                                 .await
                                 .unwrap();
                             assert_eq!(owner_central.get_conversation_unchecked(&id).await.members().len(), 2);
@@ -321,8 +322,9 @@ mod tests {
                         cfg.set_raw_external_senders(vec![remove_key]);
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
 
+                        let custom_cfg = case.custom_cfg();
                         owner_central
-                            .invite(&id, &mut guest_central, case.custom_cfg())
+                            .invite(&id, [&mut guest_central], custom_cfg)
                             .await
                             .unwrap();
                         assert_eq!(owner_central.get_conversation_unchecked(&id).await.members().len(), 2);
@@ -383,8 +385,9 @@ mod tests {
                         cfg.set_raw_external_senders(vec![short_remove_key.as_slice().to_vec()]);
                         owner_central.new_conversation(id.clone(), cfg).await.unwrap();
 
+                        let custom_cfg = case.custom_cfg();
                         owner_central
-                            .invite(&id, &mut guest_central, case.custom_cfg())
+                            .invite(&id, [&mut guest_central], custom_cfg)
                             .await
                             .unwrap();
                         assert_eq!(owner_central.get_conversation_unchecked(&id).await.members().len(), 2);
@@ -444,15 +447,13 @@ mod tests {
                             cfg.set_raw_external_senders(vec![remove_key]);
                             alice_central.new_conversation(id.clone(), cfg).await.unwrap();
 
-                            alice_central
-                                .invite(&id, &mut bob_central, case.custom_cfg())
-                                .await
-                                .unwrap();
+                            let custom_cfg = case.custom_cfg();
+                            alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                             assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                             // Charlie joins through a Welcome and should get external_senders from Welcome
                             // message and not from configuration
-                            let charlie = charlie_central.rnd_member().await;
+                            let charlie = charlie_central.rand_member().await;
                             let MlsConversationCreationMessage { welcome, commit, .. } = alice_central
                                 .add_members_to_conversation(&id, &mut [charlie])
                                 .await
@@ -544,10 +545,8 @@ mod tests {
                             cfg.set_raw_external_senders(vec![remove_key]);
                             alice_central.new_conversation(id.clone(), cfg).await.unwrap();
 
-                            alice_central
-                                .invite(&id, &mut bob_central, case.custom_cfg())
-                                .await
-                                .unwrap();
+                            let custom_cfg = case.custom_cfg();
+                            alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                             assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                             // Charlie joins through an external commit and should get external_senders

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -198,10 +198,8 @@ pub mod proposal_tests {
                         .new_conversation(id.clone(), case.cfg.clone())
                         .await
                         .unwrap();
-                    alice_central
-                        .invite(&id, &mut bob_central, case.custom_cfg())
-                        .await
-                        .unwrap();
+                    let custom_cfg = case.custom_cfg();
+                    alice_central.invite(&id, [&mut bob_central], custom_cfg).await.unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 

--- a/crypto/src/proteus.rs
+++ b/crypto/src/proteus.rs
@@ -983,7 +983,7 @@ mod tests {
             CredentialType::Basic => either::Left(client_id),
             CredentialType::X509 => either::Right(CertificateBundle::rand(case.ciphersuite(), client_id)),
         };
-        cc.mls_init(identity, vec![case.ciphersuite()]).await.unwrap();
+        cc.mls_init(identity, vec![case.ciphersuite()], false).await.unwrap();
         // expect MLS to work
         assert_eq!(cc.client_keypackages(2).await.unwrap().len(), 2);
         drop(db_file);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Allows 
* renewing an expired x509 certificate
* Switch from a basic credential to a x509 one
* Manages basic & x509 credentials locally as they have to live alongside

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
