### PR TITLE
fix: native libraries not included in android package

### DIFF
--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.tasks.MergeResources
-
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -56,8 +54,10 @@ val copyBinariesTasks = listOf(
     registerCopyJvmBinaryTask("x86_64-linux-android", "x86_64")
 )
 
-tasks.withType<MergeResources> {
-    dependsOn(copyBinariesTasks)
+project.afterEvaluate {
+    tasks.getByName("mergeReleaseJniLibFolders") {
+        dependsOn(copyBinariesTasks)
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The published android package didn't include the necessary native libraries.

### Causes

Gradle misconfiguration 

### Solutions

Add dependency on copying native libraries before processing the JNI resources.
 
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
