### PR TITLE
feat: persistable e2ei enrollment [CL-167]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tag = "v0.5.6-pre.core-crypto-0.7.0"
 [patch.crates-io.wire-e2e-identity]
 git = "https://github.com/wireapp/rusty-jwt-tools"
 package = "wire-e2e-identity"
-tag = "v0.4.1"
+tag = "v0.4.2"
 
 [patch.crates-io.hpke-rs]
 git = "https://github.com/wireapp/hpke-rs"

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.js
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.js
@@ -880,7 +880,7 @@ test("end-to-end-identity", async () => {
     const handle = "alice_wire";
     const expiryDays = 90;
 
-    const enrollment = await cc.newAcmeEnrollment(clientId, displayName, handle, expiryDays, ciphersuite);
+    let enrollment = await cc.e2eiNewEnrollment(clientId, displayName, handle, expiryDays, ciphersuite);
 
     const directoryResp = {
         "newNonce": "https://example.com/acme/new-nonce",
@@ -960,6 +960,10 @@ test("end-to-end-identity", async () => {
         "token": "LoqXcYV8q5ONbJQxbmR7SCTNo3tiAXDfowyjxAjEuX0"
     };
     enrollment.newChallengeResponse(jsonToByteArray(dpopChallengeResp));
+
+    // simulate the OAuth redirect
+    let storeHandle = await cc.e2eiEnrollmentStash(enrollment);
+    enrollment = await cc.e2eiEnrollmentStashPop(storeHandle);
 
     const idToken = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NzU5NjE3NTYsImV4cCI6MTY3NjA0ODE1NiwibmJmIjoxNjc1OTYxNzU2LCJpc3MiOiJodHRwOi8vaWRwLyIsInN1YiI6ImltcHA6d2lyZWFwcD1OREV5WkdZd05qYzJNekZrTkRCaU5UbGxZbVZtTWpReVpUSXpOVGM0TldRLzY1YzNhYzFhMTYzMWMxMzZAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwOi8vaWRwLyIsIm5hbWUiOiJTbWl0aCwgQWxpY2UgTSAoUUEpIiwiaGFuZGxlIjoiaW1wcDp3aXJlYXBwPWFsaWNlLnNtaXRoLnFhQGV4YW1wbGUuY29tIiwia2V5YXV0aCI6IlNZNzR0Sm1BSUloZHpSdEp2cHgzODlmNkVLSGJYdXhRLi15V29ZVDlIQlYwb0ZMVElSRGw3cjhPclZGNFJCVjhOVlFObEw3cUxjbWcifQ.0iiq3p5Bmmp8ekoFqv4jQu_GrnPbEfxJ36SCuw-UvV6hCi6GlxOwU7gwwtguajhsd1sednGWZpN8QssKI5_CDQ";
     const oidcChallengeReq = enrollment.newOidcChallengeRequest(idToken, previousNonce);

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2a1f_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2a1f_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,335 +264,343 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_2a1f_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_c853_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_2a1f_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_2a1f_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_mls_generate_keypairs(`ptr`: Pointer,`ciphersuites`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(`ptr`: Pointer,`ciphersuites`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKeys`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKeys`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_restore_from_disk(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_restore_from_disk(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_c853_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_client_public_key(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_client_public_key(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_client_keypackages(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,`amountRequested`: Int,
+    fun CoreCrypto_c853_CoreCrypto_client_keypackages(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_2a1f_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_2a1f_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_2a1f_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`ciphersuite`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`ciphersuite`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_c853_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_c853_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_c853_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Short
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_CoreCrypto_new_acme_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): Pointer
-
-    fun CoreCrypto_2a1f_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`e2ei`: Pointer,`certificateChain`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): Unit
-
-    fun CoreCrypto_2a1f_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Int
 
-    fun ffi_CoreCrypto_2a1f_WireE2eIdentity_object_free(`ptr`: Pointer,
+    fun CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Pointer
+
+    fun CoreCrypto_c853_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`enrollment`: Pointer,`certificateChain`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(`ptr`: Pointer,`enrollment`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(`ptr`: Pointer,`handle`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
+    ): Pointer
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_c853_WireE2eIdentity_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_2a1f_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`expirySecs`: Int,`backendNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
-    _uniffi_out_err: RustCallStatus
-    ): RustBuffer.ByValue
-
-    fun CoreCrypto_2a1f_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_2a1f_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`expirySecs`: Int,`backendNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_2a1f_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_c853_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_2a1f_version(
+    fun CoreCrypto_c853_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_2a1f_rustbuffer_alloc(`size`: Int,
+    fun CoreCrypto_c853_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_2a1f_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_2a1f_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun CoreCrypto_c853_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun CoreCrypto_c853_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_2a1f_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun CoreCrypto_c853_version(
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_c853_rustbuffer_alloc(`size`: Int,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_c853_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): RustBuffer.ByValue
+
+    fun ffi_CoreCrypto_c853_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    _uniffi_out_err: RustCallStatus
+    ): Unit
+
+    fun ffi_CoreCrypto_c853_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -1112,13 +1120,19 @@ public interface CoreCryptoInterface {
     @Throws(CryptoException::class)
     fun `proteusCryptoboxMigrate`(`path`: String)
     
-    @Throws(CryptoException::class)
-    fun `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity
-    
-    @Throws(CryptoException::class)
-    fun `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String)
-    
     fun `proteusLastErrorCode`(): UInt
+    
+    @Throws(CryptoException::class)
+    fun `e2eiNewEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity
+    
+    @Throws(CryptoException::class)
+    fun `e2eiMlsInit`(`enrollment`: WireE2eIdentity, `certificateChain`: String)
+    
+    @Throws(CryptoException::class)
+    fun `e2eiEnrollmentStash`(`enrollment`: WireE2eIdentity): List<UByte>
+    
+    @Throws(CryptoException::class)
+    fun `e2eiEnrollmentStashPop`(`handle`: List<UByte>): WireE2eIdentity
     
 }
 
@@ -1128,7 +1142,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: ClientId, `ciphersuites`: List<CiphersuiteName>, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1141,7 +1155,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2a1f_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1149,7 +1163,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInit`(`clientId`: ClientId, `ciphersuites`: List<CiphersuiteName>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
 }
         }
     
@@ -1157,7 +1171,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsGenerateKeypairs`(`ciphersuites`: List<CiphersuiteName>): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_mls_generate_keypairs(it, FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(it, FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1166,7 +1180,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKeys`: List<List<UByte>>, `ciphersuites`: List<CiphersuiteName>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceSequenceUByte.lower(`signaturePublicKeys`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceSequenceUByte.lower(`signaturePublicKeys`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
 }
         }
     
@@ -1174,7 +1188,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `restoreFromDisk`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_restore_from_disk(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_restore_from_disk(it,  _status)
 }
         }
     
@@ -1182,7 +1196,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1190,7 +1204,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(`ciphersuite`: CiphersuiteName): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_client_public_key(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_client_public_key(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1199,7 +1213,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`ciphersuite`: CiphersuiteName, `amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_client_keypackages(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_client_keypackages(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1208,7 +1222,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(`ciphersuite`: CiphersuiteName): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_client_valid_keypackages_count(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1217,7 +1231,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1225,7 +1239,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1233,7 +1247,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1242,7 +1256,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1251,7 +1265,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1260,7 +1274,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1269,7 +1283,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
 }
         }
     
@@ -1277,7 +1291,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1286,7 +1300,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1295,7 +1309,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1303,7 +1317,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1312,7 +1326,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1321,7 +1335,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1330,7 +1344,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1339,7 +1353,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1348,7 +1362,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong, `ciphersuite`: CiphersuiteName, `credentialType`: MlsCredentialType): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1357,7 +1371,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1366,7 +1380,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>, `customConfiguration`: CustomConfiguration, `credentialType`: MlsCredentialType): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1375,7 +1389,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1383,7 +1397,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1391,7 +1405,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1400,7 +1414,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1409,7 +1423,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1418,7 +1432,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1427,7 +1441,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1435,7 +1449,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1443,7 +1457,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1451,7 +1465,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1459,7 +1473,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1467,7 +1481,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1475,7 +1489,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1484,7 +1498,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1492,7 +1506,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1500,7 +1514,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionExists`(`sessionId`: String): Boolean =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1509,7 +1523,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1518,7 +1532,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1527,7 +1541,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1536,7 +1550,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1545,7 +1559,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekeyAuto`(): ProteusAutoPrekeyBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey_auto(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(it,  _status)
 }
         }.let {
             FfiConverterTypeProteusAutoPrekeyBundle.lift(it)
@@ -1554,7 +1568,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1563,7 +1577,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekeyId`(): UShort =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
 }
         }.let {
             FfiConverterUShort.lift(it)
@@ -1572,7 +1586,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1581,7 +1595,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintLocal`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1590,7 +1604,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintRemote`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1599,7 +1613,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintPrekeybundle`(`prekey`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1608,34 +1622,52 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
-}
-        }
-    
-    
-    @Throws(CryptoException::class)override fun `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity =
-        callWithPointer {
-    rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_new_acme_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
-}
-        }.let {
-            FfiConverterTypeWireE2eIdentity.lift(it)
-        }
-    
-    @Throws(CryptoException::class)override fun `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) =
-        callWithPointer {
-    rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`e2ei`), FfiConverterString.lower(`certificateChain`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
     override fun `proteusLastErrorCode`(): UInt =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_proteus_last_error_code(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_last_error_code(it,  _status)
 }
         }.let {
             FfiConverterUInt.lift(it)
+        }
+    
+    @Throws(CryptoException::class)override fun `e2eiNewEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+}
+        }.let {
+            FfiConverterTypeWireE2eIdentity.lift(it)
+        }
+    
+    @Throws(CryptoException::class)override fun `e2eiMlsInit`(`enrollment`: WireE2eIdentity, `certificateChain`: String) =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`enrollment`), FfiConverterString.lower(`certificateChain`),  _status)
+}
+        }
+    
+    
+    @Throws(CryptoException::class)override fun `e2eiEnrollmentStash`(`enrollment`: WireE2eIdentity): List<UByte> =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(it, FfiConverterTypeWireE2eIdentity.lower(`enrollment`),  _status)
+}
+        }.let {
+            FfiConverterSequenceUByte.lift(it)
+        }
+    
+    @Throws(CryptoException::class)override fun `e2eiEnrollmentStashPop`(`handle`: List<UByte>): WireE2eIdentity =
+        callWithPointer {
+    rustCallWithError(CryptoException) { _status ->
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(it, FfiConverterSequenceUByte.lower(`handle`),  _status)
+}
+        }.let {
+            FfiConverterTypeWireE2eIdentity.lift(it)
         }
     
 
@@ -1643,7 +1675,7 @@ class CoreCrypto(
         fun `deferredInit`(`path`: String, `key`: String, `ciphersuites`: List<CiphersuiteName>, `entropySeed`: List<UByte>?): CoreCrypto =
             CoreCrypto(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
         
     }
@@ -1741,7 +1773,7 @@ class WireE2eIdentity(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_2a1f_WireE2eIdentity_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_WireE2eIdentity_object_free(this.pointer, status)
         }
     }
 
@@ -1749,7 +1781,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: List<UByte>): AcmeDirectory =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
 }
         }.let {
             FfiConverterTypeAcmeDirectory.lift(it)
@@ -1758,7 +1790,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1767,7 +1799,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
 }
         }
     
@@ -1775,7 +1807,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1784,7 +1816,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: List<UByte>): NewAcmeOrder =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeOrder.lift(it)
@@ -1793,7 +1825,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1802,7 +1834,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeAuthz.lift(it)
@@ -1811,7 +1843,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `createDpopToken`(`expirySecs`: UInt, `backendNonce`: String): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_create_dpop_token(it, FfiConverterUInt.lower(`expirySecs`), FfiConverterString.lower(`backendNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_create_dpop_token(it, FfiConverterUInt.lower(`expirySecs`), FfiConverterString.lower(`backendNonce`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1820,7 +1852,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1829,7 +1861,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1838,7 +1870,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
 }
         }
     
@@ -1846,7 +1878,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1855,7 +1887,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1864,7 +1896,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1873,7 +1905,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1882,7 +1914,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `certificateRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -3117,7 +3149,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_2a1f_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -3656,7 +3688,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_2a1f_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_c853_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -980,16 +980,33 @@ public class CoreCryptoWrapper {
     /// - parameter expiryDays: generated x509 certificate expiry
     /// - parameter ciphersuite: For generating signing key material.
     /// - returns: The new ``CoreCryptoSwift.WireE2eIdentity`` object
-    public func newAcmeEnrollment(clientId: String, displayName: String, handle: String, expiryDays: UInt32, ciphersuite: CoreCryptoSwift.CiphersuiteName) throws -> CoreCryptoSwift.WireE2eIdentity {
-        return try self.coreCrypto.newAcmeEnrollment(clientId: clientId, displayName: displayName, handle: handle, expiryDays: expiryDays, ciphersuite: ciphersuite)
+    public func e2eiNewEnrollment(clientId: String, displayName: String, handle: String, expiryDays: UInt32, ciphersuite: CoreCryptoSwift.CiphersuiteName) throws -> CoreCryptoSwift.WireE2eIdentity {
+        return try self.coreCrypto.e2eiNewEnrollment(clientId: clientId, displayName: displayName, handle: handle, expiryDays: expiryDays, ciphersuite: ciphersuite)
     }
 
     /// Parses the ACME server response from the endpoint fetching x509 certificates and uses it to initialize the MLS client with a certificate
     ///
     /// - parameter e2ei: the enrollment instance used to fetch the certificates
     /// - parameter certificateChain: the raw response from ACME server
-    public func e2eiMlsInit(e2ei: CoreCryptoSwift.WireE2eIdentity, certificateChain: String) throws {
-        return try self.coreCrypto.e2eiMlsInit(e2ei: e2ei, certificateChain: certificateChain)
+    public func e2eiMlsInit(enrollment: CoreCryptoSwift.WireE2eIdentity, certificateChain: String) throws {
+        return try self.coreCrypto.e2eiMlsInit(enrollment: enrollment, certificateChain: certificateChain)
+    }
+
+    /// Allows persisting an active enrollment (for example while redirecting the user during OAuth) in order to resume
+    /// it later with [MlsCentral::e2eiEnrollmentStashPop]
+    ///
+    /// - parameter e2ei: the enrollment instance to persist
+    /// - returns: a handle to fetch the enrollment later with [MlsCentral::e2eiEnrollmentStashPop]
+    public func e2eiEnrollmentStash(enrollment: CoreCryptoSwift.WireE2eIdentity) throws -> [UInt8] {
+        return try self.coreCrypto.e2eiEnrollmentStash(enrollment: enrollment)
+    }
+
+    /// Fetches the persisted enrollment and deletes it from the keystore
+    ///
+    /// - parameter handle: returned by [MlsCentral::e2eiEnrollmentStash]
+    /// - returns: the persisted enrollment instance
+    public func e2eiEnrollmentStashPop(handle: [UInt8]) throws -> CoreCryptoSwift.WireE2eIdentity {
+        return try self.coreCrypto.e2eiEnrollmentStashPop(handle: handle)
     }
 
     /// - returns: The CoreCrypto version

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_2a1f_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_c853_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_2a1f_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_c853_rustbuffer_free(self, $0) }
     }
 }
 
@@ -472,9 +472,11 @@ public protocol CoreCryptoProtocol {
     func `proteusFingerprintRemote`(`sessionId`: String) throws -> String
     func `proteusFingerprintPrekeybundle`(`prekey`: [UInt8]) throws -> String
     func `proteusCryptoboxMigrate`(`path`: String) throws
-    func `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt32, `ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity
-    func `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) throws
     func `proteusLastErrorCode`()  -> UInt32
+    func `e2eiNewEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt32, `ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity
+    func `e2eiMlsInit`(`enrollment`: WireE2eIdentity, `certificateChain`: String) throws
+    func `e2eiEnrollmentStash`(`enrollment`: WireE2eIdentity) throws -> [UInt8]
+    func `e2eiEnrollmentStashPop`(`handle`: [UInt8]) throws -> WireE2eIdentity
     
 }
 
@@ -492,7 +494,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_2a1f_CoreCrypto_new(
+    CoreCrypto_c853_CoreCrypto_new(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterTypeClientId.lower(`clientId`), 
@@ -502,7 +504,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_2a1f_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_c853_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -511,7 +513,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_2a1f_CoreCrypto_deferred_init(
+    CoreCrypto_c853_CoreCrypto_deferred_init(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), 
@@ -524,7 +526,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInit`(`clientId`: ClientId, `ciphersuites`: [CiphersuiteName]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_mls_init(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_mls_init(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), $0
     )
@@ -534,7 +536,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_mls_generate_keypairs(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(self.pointer, 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), $0
     )
 }
@@ -543,7 +545,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKeys`: [[UInt8]], `ciphersuites`: [CiphersuiteName]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_mls_init_with_client_id(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceSequenceUInt8.lower(`signaturePublicKeys`), 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), $0
@@ -553,14 +555,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `restoreFromDisk`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_restore_from_disk(self.pointer, $0
+    CoreCrypto_c853_CoreCrypto_restore_from_disk(self.pointer, $0
     )
 }
     }
     public func `setCallbacks`(`callbacks`: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(`callbacks`), $0
     )
 }
@@ -569,7 +571,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_client_public_key(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_client_public_key(self.pointer, 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), $0
     )
 }
@@ -579,7 +581,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), 
         FfiConverterUInt32.lower(`amountRequested`), $0
     )
@@ -590,7 +592,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_client_valid_keypackages_count(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(self.pointer, 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), $0
     )
 }
@@ -599,7 +601,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeConversationConfiguration.lower(`config`), $0
     )
@@ -609,7 +611,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -620,7 +622,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_2a1f_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -630,7 +632,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(`welcomeMessage`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -641,7 +643,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeInvitee.lower(`clients`), $0
     )
@@ -652,7 +654,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeClientId.lower(`clients`), $0
     )
@@ -662,7 +664,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
         FfiConverterTypeConversationId.lower(`childId`), 
         FfiConverterTypeConversationId.lower(`parentId`), $0
     )
@@ -672,7 +674,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -682,7 +684,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -691,7 +693,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `wipeConversation`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -700,7 +702,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`payload`), $0
     )
@@ -711,7 +713,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`message`), $0
     )
@@ -722,7 +724,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`keyPackage`), $0
     )
@@ -733,7 +735,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -743,7 +745,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
@@ -754,7 +756,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), 
@@ -767,7 +769,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterSequenceUInt8.lower(`keyPackageRef`), $0
@@ -779,7 +781,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(`publicGroupState`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), 
         FfiConverterTypeMlsCredentialType.lower(`credentialType`), $0
@@ -790,7 +792,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -798,7 +800,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -807,7 +809,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -817,7 +819,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt32.lower(`keyLength`), $0
     )
@@ -828,7 +830,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_get_client_ids(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -838,7 +840,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(`length`), $0
     )
 }
@@ -847,7 +849,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `reseedRng`(`seed`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(`seed`), $0
     )
 }
@@ -855,7 +857,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `commitAccepted`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -863,7 +865,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`proposalRef`), $0
     )
@@ -872,7 +874,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -880,14 +882,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusInit`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_c853_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
@@ -897,7 +899,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`envelope`), $0
     )
@@ -907,7 +909,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionSave`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -915,7 +917,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionDelete`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -924,7 +926,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterBool.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_session_exists(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_session_exists(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -934,7 +936,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`ciphertext`), $0
     )
@@ -945,7 +947,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -956,7 +958,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -967,7 +969,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(`prekeyId`), $0
     )
 }
@@ -977,7 +979,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProteusAutoPrekeyBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
+    CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
     )
 }
         )
@@ -986,7 +988,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
+    CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
     )
 }
         )
@@ -995,7 +997,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt16.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
+    CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
     )
 }
         )
@@ -1004,7 +1006,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_c853_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -1013,7 +1015,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_local(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1023,7 +1025,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1033,7 +1035,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
 }
@@ -1042,16 +1044,26 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusCryptoboxMigrate`(`path`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(`path`), $0
     )
 }
     }
-    public func `newAcmeEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt32, `ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity {
+    public func `proteusLastErrorCode`()  -> UInt32 {
+        return try! FfiConverterUInt32.lift(
+            try!
+    rustCall() {
+    
+    CoreCrypto_c853_CoreCrypto_proteus_last_error_code(self.pointer, $0
+    )
+}
+        )
+    }
+    public func `e2eiNewEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt32, `ciphersuite`: CiphersuiteName) throws -> WireE2eIdentity {
         return try FfiConverterTypeWireE2eIdentity.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_new_acme_enrollment(self.pointer, 
+    CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(self.pointer, 
         FfiConverterString.lower(`clientId`), 
         FfiConverterString.lower(`displayName`), 
         FfiConverterString.lower(`handle`), 
@@ -1061,21 +1073,31 @@ public class CoreCrypto: CoreCryptoProtocol {
 }
         )
     }
-    public func `e2eiMlsInit`(`e2ei`: WireE2eIdentity, `certificateChain`: String) throws {
+    public func `e2eiMlsInit`(`enrollment`: WireE2eIdentity, `certificateChain`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_2a1f_CoreCrypto_e2ei_mls_init(self.pointer, 
-        FfiConverterTypeWireE2eIdentity.lower(`e2ei`), 
+    CoreCrypto_c853_CoreCrypto_e2ei_mls_init(self.pointer, 
+        FfiConverterTypeWireE2eIdentity.lower(`enrollment`), 
         FfiConverterString.lower(`certificateChain`), $0
     )
 }
     }
-    public func `proteusLastErrorCode`()  -> UInt32 {
-        return try! FfiConverterUInt32.lift(
-            try!
-    rustCall() {
-    
-    CoreCrypto_2a1f_CoreCrypto_proteus_last_error_code(self.pointer, $0
+    public func `e2eiEnrollmentStash`(`enrollment`: WireE2eIdentity) throws -> [UInt8] {
+        return try FfiConverterSequenceUInt8.lift(
+            try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(self.pointer, 
+        FfiConverterTypeWireE2eIdentity.lower(`enrollment`), $0
+    )
+}
+        )
+    }
+    public func `e2eiEnrollmentStashPop`(`handle`: [UInt8]) throws -> WireE2eIdentity {
+        return try FfiConverterTypeWireE2eIdentity.lift(
+            try
+    rustCallWithError(FfiConverterTypeCryptoError.self) {
+    CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(self.pointer, 
+        FfiConverterSequenceUInt8.lower(`handle`), $0
     )
 }
         )
@@ -1146,7 +1168,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_2a1f_WireE2eIdentity_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_c853_WireE2eIdentity_object_free(pointer, $0) }
     }
 
     
@@ -1156,7 +1178,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeAcmeDirectory.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_directory_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_directory_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`directory`), $0
     )
 }
@@ -1166,7 +1188,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_account_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_account_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1175,7 +1197,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newAccountResponse`(`account`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_account_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_account_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`account`), $0
     )
 }
@@ -1184,7 +1206,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_order_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_order_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1194,7 +1216,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeOrder.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_order_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1204,7 +1226,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_authz_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_authz_request(self.pointer, 
         FfiConverterString.lower(`url`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1215,7 +1237,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeAuthz.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_authz_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_authz_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`authz`), $0
     )
 }
@@ -1225,7 +1247,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_create_dpop_token(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_create_dpop_token(self.pointer, 
         FfiConverterUInt32.lower(`expirySecs`), 
         FfiConverterString.lower(`backendNonce`), $0
     )
@@ -1236,7 +1258,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
         FfiConverterString.lower(`accessToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1247,7 +1269,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
         FfiConverterString.lower(`idToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1257,7 +1279,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newChallengeResponse`(`challenge`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_new_challenge_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_new_challenge_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`challenge`), $0
     )
 }
@@ -1266,7 +1288,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_check_order_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_check_order_request(self.pointer, 
         FfiConverterString.lower(`orderUrl`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1277,7 +1299,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_check_order_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_check_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1287,7 +1309,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_finalize_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_finalize_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1297,7 +1319,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_finalize_response(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_finalize_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`finalize`), $0
     )
 }
@@ -1307,7 +1329,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_2a1f_WireE2eIdentity_certificate_request(self.pointer, 
+    CoreCrypto_c853_WireE2eIdentity_certificate_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -3338,7 +3360,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_2a1f_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3850,7 +3872,7 @@ public func `version`()  -> String {
     
     rustCall() {
     
-    CoreCrypto_2a1f_version($0)
+    CoreCrypto_c853_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,335 +46,343 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_2a1f_CoreCrypto_object_free(
+void ffi_CoreCrypto_c853_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_2a1f_CoreCrypto_new(
+void*_Nonnull CoreCrypto_c853_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer ciphersuites,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_2a1f_CoreCrypto_deferred_init(
+void*_Nonnull CoreCrypto_c853_CoreCrypto_deferred_init(
       RustBuffer path,RustBuffer key,RustBuffer ciphersuites,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_mls_init(
+void CoreCrypto_c853_CoreCrypto_mls_init(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer ciphersuites,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_mls_generate_keypairs(
+RustBuffer CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(
       void*_Nonnull ptr,RustBuffer ciphersuites,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_mls_init_with_client_id(
+void CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer signature_public_keys,RustBuffer ciphersuites,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_restore_from_disk(
+void CoreCrypto_c853_CoreCrypto_restore_from_disk(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_set_callbacks(
+void CoreCrypto_c853_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_c853_CoreCrypto_client_public_key(
       void*_Nonnull ptr,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_c853_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,RustBuffer ciphersuite,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_2a1f_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_create_conversation(
+void CoreCrypto_c853_CoreCrypto_create_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_2a1f_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_c853_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_2a1f_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_c853_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_c853_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_mark_conversation_as_child_of(
+void CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(
       void*_Nonnull ptr,RustBuffer child_id,RustBuffer parent_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_c853_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_c853_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_wipe_conversation(
+void CoreCrypto_c853_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_c853_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_c853_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_c853_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_c853_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_c853_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_c853_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer ciphersuite,RustBuffer credential_type,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_c853_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,RustBuffer custom_configuration,RustBuffer credential_type,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_c853_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_c853_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_get_client_ids(
+RustBuffer CoreCrypto_c853_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_c853_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_reseed_rng(
+void CoreCrypto_c853_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_commit_accepted(
+void CoreCrypto_c853_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_c853_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_clear_pending_commit(
+void CoreCrypto_c853_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_proteus_init(
+void CoreCrypto_c853_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_proteus_session_save(
+void CoreCrypto_c853_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_proteus_session_delete(
+void CoreCrypto_c853_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_2a1f_CoreCrypto_proteus_session_exists(
+int8_t CoreCrypto_c853_CoreCrypto_proteus_session_exists(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_new_prekey_auto(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-uint16_t CoreCrypto_2a1f_CoreCrypto_proteus_last_resort_prekey_id(
+uint16_t CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_local(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_remote(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_CoreCrypto_proteus_fingerprint_prekeybundle(
+RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(
       void*_Nonnull ptr,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_2a1f_CoreCrypto_new_acme_enrollment(
+uint32_t CoreCrypto_c853_CoreCrypto_proteus_last_error_code(
+      void*_Nonnull ptr,
+    RustCallStatus *_Nonnull out_status
+    );
+void*_Nonnull CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer display_name,RustBuffer handle,uint32_t expiry_days,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_CoreCrypto_e2ei_mls_init(
-      void*_Nonnull ptr,void*_Nonnull e2ei,RustBuffer certificate_chain,
+void CoreCrypto_c853_CoreCrypto_e2ei_mls_init(
+      void*_Nonnull ptr,void*_Nonnull enrollment,RustBuffer certificate_chain,
     RustCallStatus *_Nonnull out_status
     );
-uint32_t CoreCrypto_2a1f_CoreCrypto_proteus_last_error_code(
+RustBuffer CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(
+      void*_Nonnull ptr,void*_Nonnull enrollment,
+    RustCallStatus *_Nonnull out_status
+    );
+void*_Nonnull CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(
+      void*_Nonnull ptr,RustBuffer handle,
+    RustCallStatus *_Nonnull out_status
+    );
+void ffi_CoreCrypto_c853_WireE2eIdentity_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_2a1f_WireE2eIdentity_object_free(
-      void*_Nonnull ptr,
-    RustCallStatus *_Nonnull out_status
-    );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_directory_response(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_directory_response(
       void*_Nonnull ptr,RustBuffer directory,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_account_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_account_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_WireE2eIdentity_new_account_response(
+void CoreCrypto_c853_WireE2eIdentity_new_account_response(
       void*_Nonnull ptr,RustBuffer account,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_order_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_order_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_order_response(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_authz_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_authz_request(
       void*_Nonnull ptr,RustBuffer url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_authz_response(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_authz_response(
       void*_Nonnull ptr,RustBuffer authz,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_create_dpop_token(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_create_dpop_token(
       void*_Nonnull ptr,uint32_t expiry_secs,RustBuffer backend_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_dpop_challenge_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(
       void*_Nonnull ptr,RustBuffer access_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_new_oidc_challenge_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(
       void*_Nonnull ptr,RustBuffer id_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_2a1f_WireE2eIdentity_new_challenge_response(
+void CoreCrypto_c853_WireE2eIdentity_new_challenge_response(
       void*_Nonnull ptr,RustBuffer challenge,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_check_order_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_check_order_request(
       void*_Nonnull ptr,RustBuffer order_url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_check_order_response(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_check_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_finalize_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_finalize_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_finalize_response(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_finalize_response(
       void*_Nonnull ptr,RustBuffer finalize,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_WireE2eIdentity_certificate_request(
+RustBuffer CoreCrypto_c853_WireE2eIdentity_certificate_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_2a1f_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_2a1f_version(
+RustBuffer CoreCrypto_c853_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_2a1f_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_c853_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_2a1f_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_c853_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_2a1f_rustbuffer_free(
+void ffi_CoreCrypto_c853_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_2a1f_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_c853_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -322,13 +322,19 @@ interface CoreCrypto {
     [Throws=CryptoError]
     void proteus_cryptobox_migrate([ByRef] string path);
 
-    [Throws=CryptoError]
-    WireE2eIdentity new_acme_enrollment(string client_id, string display_name, string handle, u32 expiry_days, CiphersuiteName ciphersuite);
-
-    [Throws=CryptoError]
-    void e2ei_mls_init(WireE2eIdentity e2ei, string certificate_chain);
-
     u32 proteus_last_error_code();
+
+    [Throws=CryptoError]
+    WireE2eIdentity e2ei_new_enrollment(string client_id, string display_name, string handle, u32 expiry_days, CiphersuiteName ciphersuite);
+
+    [Throws=CryptoError]
+    void e2ei_mls_init(WireE2eIdentity enrollment, string certificate_chain);
+
+    [Throws=CryptoError]
+    sequence<u8> e2ei_enrollment_stash(WireE2eIdentity enrollment);
+
+    [Throws=CryptoError]
+    WireE2eIdentity e2ei_enrollment_stash_pop(sequence<u8> handle);
 };
 
 [Error]

--- a/crypto/src/e2e_identity/stash.rs
+++ b/crypto/src/e2e_identity/stash.rs
@@ -1,0 +1,109 @@
+use crate::prelude::{CryptoError, E2eIdentityResult, MlsCentral, WireE2eIdentity};
+use core_crypto_keystore::CryptoKeystoreMls;
+use mls_crypto_provider::MlsCryptoProvider;
+use openmls_traits::{crypto::OpenMlsCrypto, types::HashType, OpenMlsCryptoProvider};
+
+/// A unique identifier for an enrollment a consumer can use to fetch it from the keystore when he
+/// wants to resume the process
+pub(crate) type EnrollmentHandle = Vec<u8>;
+
+impl WireE2eIdentity {
+    pub(crate) async fn stash(self, backend: &MlsCryptoProvider) -> E2eIdentityResult<EnrollmentHandle> {
+        let content = serde_json::to_vec(&self)?;
+        let handle = backend.crypto().hash(HashType::Sha2_256, &content)?;
+        backend
+            .key_store()
+            .save_e2ei_enrollment(&handle, &content)
+            .await
+            .map_err(CryptoError::from)?;
+        Ok(handle)
+    }
+
+    pub(crate) async fn stash_pop(backend: &MlsCryptoProvider, handle: EnrollmentHandle) -> E2eIdentityResult<Self> {
+        let content = backend
+            .key_store()
+            .pop_e2ei_enrollment(&handle)
+            .await
+            .map_err(CryptoError::from)?;
+        Ok(serde_json::from_slice(&content)?)
+    }
+}
+
+impl MlsCentral {
+    /// Allows persisting an active enrollment (for example while redirecting the user during OAuth)
+    /// in order to resume it later with [MlsCentral::e2ei_enrollment_stash_pop]
+    ///
+    /// # Arguments
+    /// * `enrollment` - the enrollment instance to persist
+    ///
+    /// # Returns
+    /// A handle for retrieving the enrollment later on
+    pub async fn e2ei_enrollment_stash(&self, enrollment: WireE2eIdentity) -> E2eIdentityResult<EnrollmentHandle> {
+        enrollment.stash(&self.mls_backend).await
+    }
+
+    /// Fetches the persisted enrollment and deletes it from the keystore
+    ///
+    /// # Arguments
+    /// * `handle` - returned by [MlsCentral::e2ei_enrollment_stash]
+    pub async fn e2ei_enrollment_stash_pop(&self, handle: EnrollmentHandle) -> E2eIdentityResult<WireE2eIdentity> {
+        WireE2eIdentity::stash_pop(&self.mls_backend, handle).await
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::{e2e_identity::tests::e2ei_enrollment, prelude::WireE2eIdentity, test_utils::*};
+    use mls_crypto_provider::MlsCryptoProvider;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn e2e_identity_should_work(case: TestCase) {
+        run_test_wo_clients(case.clone(), move |cc| {
+            Box::pin(async move {
+                let result = e2ei_enrollment(case, cc, |e, cc| {
+                    Box::pin(async move {
+                        let handle = cc.e2ei_enrollment_stash(e).await.unwrap();
+                        let enrollment = cc.e2ei_enrollment_stash_pop(handle).await.unwrap();
+                        (enrollment, cc)
+                    })
+                })
+                .await;
+                assert!(result.is_ok());
+            })
+        })
+        .await
+    }
+
+    // this ensures the nominal test does its job
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn should_fail_when_restoring_invalid(case: TestCase) {
+        run_test_wo_clients(case.clone(), move |cc| {
+            Box::pin(async move {
+                let result = e2ei_enrollment(case, cc, move |e, cc| {
+                    Box::pin(async move {
+                        // this restore recreates a partial enrollment
+                        let backend = MlsCryptoProvider::try_new_in_memory("new").await.unwrap();
+                        let enrollment = WireE2eIdentity::try_new(
+                            e.client_id.as_str().into(),
+                            e.display_name,
+                            e.handle,
+                            1,
+                            &backend,
+                            e.ciphersuite,
+                        )
+                        .unwrap();
+                        (enrollment, cc)
+                    })
+                })
+                .await;
+                assert!(result.is_err());
+            })
+        })
+        .await
+    }
+}

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -19,7 +19,8 @@ pub(crate) mod external_proposal;
 pub(crate) mod member;
 pub(crate) mod proposal;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, derive_more::Deref)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, derive_more::Deref, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 #[repr(transparent)]
 /// A wrapper for the OpenMLS Ciphersuite, so that we are able to provide a default value.
 pub struct MlsCiphersuite(Ciphersuite);

--- a/interop/src/clients/corecrypto/e2ei.js
+++ b/interop/src/clients/corecrypto/e2ei.js
@@ -9,7 +9,7 @@ const handle = "alice_wire";
 const expiryDays = 90;
 const ciphersuite = window.ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
-const enrollment = await window.cc.newAcmeEnrollment(clientId, displayName, handle, expiryDays, ciphersuite);
+const enrollment = await window.cc.e2eiNewEnrollment(clientId, displayName, handle, expiryDays, ciphersuite);
 
 const directoryResp = {
     "newNonce": "https://example.com/acme/new-nonce",

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -167,7 +167,7 @@ impl crate::clients::EmulatedProteusClient for CoreCryptoNativeClient {
 
 #[async_trait::async_trait(?Send)]
 impl crate::clients::EmulatedE2eIdentityClient for CoreCryptoNativeClient {
-    async fn new_acme_enrollment(&mut self, ciphersuite: MlsCiphersuite) -> Result<()> {
+    async fn e2ei_new_enrollment(&mut self, ciphersuite: MlsCiphersuite) -> Result<()> {
         let display_name = "Smith, Alice M (QA)".to_string();
         let domain = "example.com";
         let client_id: ClientId = format!("NDEyZGYwNjc2MzFkNDBiNTllYmVmMjQyZTIzNTc4NWQ:65c3ac1a1631c136@{domain}")
@@ -178,7 +178,7 @@ impl crate::clients::EmulatedE2eIdentityClient for CoreCryptoNativeClient {
 
         let mut enrollment = self
             .cc
-            .new_acme_enrollment(client_id, display_name, handle, expiry, ciphersuite)?;
+            .e2ei_new_enrollment(client_id, display_name, handle, expiry, ciphersuite)?;
         let directory = serde_json::json!({
             "newNonce": "https://example.com/acme/new-nonce",
             "newAccount": "https://example.com/acme/new-account",

--- a/interop/src/clients/corecrypto/web.rs
+++ b/interop/src/clients/corecrypto/web.rs
@@ -338,7 +338,7 @@ window.cc.proteusDecrypt(sessionId, ciphertextBuffer).then(callback);"#,
 
 #[async_trait::async_trait(?Send)]
 impl crate::clients::EmulatedE2eIdentityClient for CoreCryptoWebClient {
-    async fn new_acme_enrollment(&mut self, _ciphersuite: MlsCiphersuite) -> Result<()> {
+    async fn e2ei_new_enrollment(&mut self, _ciphersuite: MlsCiphersuite) -> Result<()> {
         let script = include_str!("e2ei.js");
         Ok(self.browser.execute_async(script, vec![]).await.map(|_| ())?)
     }

--- a/interop/src/clients/mod.rs
+++ b/interop/src/clients/mod.rs
@@ -88,5 +88,5 @@ pub trait EmulatedProteusClient: EmulatedClient {
 
 #[async_trait::async_trait(?Send)]
 pub trait EmulatedE2eIdentityClient: EmulatedClient {
-    async fn new_acme_enrollment(&mut self, ciphersuite: MlsCiphersuite) -> Result<()>;
+    async fn e2ei_new_enrollment(&mut self, ciphersuite: MlsCiphersuite) -> Result<()>;
 }

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -384,7 +384,7 @@ async fn run_e2e_identity_test(chrome_driver_addr: &std::net::SocketAddr) -> Res
     ));
 
     for c in clients.iter_mut() {
-        c.new_acme_enrollment(MlsCiphersuite::default()).await?;
+        c.e2ei_new_enrollment(MlsCiphersuite::default()).await?;
     }
     spinner.success("[E2EI] Step 0: Perform ACME enrollment [OK]");
 

--- a/keystore/src/connection/platform/generic/migrations/V1__schema.sql
+++ b/keystore/src/connection/platform/generic/migrations/V1__schema.sql
@@ -24,3 +24,8 @@ CREATE TABLE mls_pending_groups (
     state BLOB,
     cfg BLOB
 );
+
+CREATE TABLE e2ei_enrollment (
+    id VARCHAR(255) UNIQUE,
+    content BLOB
+);

--- a/keystore/src/connection/platform/wasm/mod.rs
+++ b/keystore/src/connection/platform/wasm/mod.rs
@@ -58,6 +58,7 @@ impl DatabaseConnection for WasmConnection {
                     .add_index(Index::new("signature", "signature").unique(true)),
             )
             .add_object_store(ObjectStore::new("mls_groups").auto_increment(false))
+            .add_object_store(ObjectStore::new("e2ei_enrollment").auto_increment(false))
             .add_object_store(ObjectStore::new("mls_pending_groups").auto_increment(false))
             .add_object_store(ObjectStore::new("proteus_prekeys").auto_increment(false))
             .add_object_store(ObjectStore::new("proteus_identities").auto_increment(false))

--- a/keystore/src/entities/mls.rs
+++ b/keystore/src/entities/mls.rs
@@ -95,3 +95,13 @@ pub struct MlsKeypackage {
     pub id: String,
     pub key: Vec<u8>,
 }
+
+/// Entity representing an enrollment instance used to fetch a x509 certificate and persisted when
+/// context switches and the memory it lives in is about to be erased
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
+#[zeroize(drop)]
+#[cfg_attr(target_family = "wasm", derive(serde::Serialize, serde::Deserialize))]
+pub struct E2eiEnrollment {
+    pub id: Vec<u8>,
+    pub content: Vec<u8>,
+}

--- a/keystore/src/entities/mod.rs
+++ b/keystore/src/entities/mod.rs
@@ -59,8 +59,16 @@ impl<'a> StringEntityId<'a> {
         hex::encode(self.0)
     }
 
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn into_bytes(&self) -> Vec<u8> {
         self.0.into()
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0
+    }
+
+    pub fn try_as_str(&self) -> Result<&str, ::core::str::Utf8Error> {
+        std::str::from_utf8(self.0)
     }
 }
 

--- a/keystore/src/entities/platform/generic/mls/enrollment.rs
+++ b/keystore/src/entities/platform/generic/mls/enrollment.rs
@@ -1,0 +1,134 @@
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+
+use crate::{
+    connection::{DatabaseConnection, KeystoreDatabaseConnection},
+    entities::{E2eiEnrollment, Entity, EntityBase, EntityFindParams, StringEntityId},
+    CryptoKeystoreError, MissingKeyErrorKind,
+};
+
+impl Entity for E2eiEnrollment {
+    fn id_raw(&self) -> &[u8] {
+        &self.id[..]
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl EntityBase for E2eiEnrollment {
+    type ConnectionType = KeystoreDatabaseConnection;
+
+    fn to_missing_key_err_kind() -> MissingKeyErrorKind {
+        MissingKeyErrorKind::E2eiEnrollment
+    }
+
+    async fn find_all(
+        _conn: &mut Self::ConnectionType,
+        _params: EntityFindParams,
+    ) -> crate::CryptoKeystoreResult<Vec<Self>> {
+        Err(CryptoKeystoreError::ImplementationError)
+    }
+
+    async fn save(&self, conn: &mut Self::ConnectionType) -> crate::CryptoKeystoreResult<()> {
+        use rusqlite::OptionalExtension as _;
+        use rusqlite::ToSql as _;
+
+        Self::ConnectionType::check_buffer_size(self.content.len())?;
+
+        let transaction = conn.transaction()?;
+        let existing_rowid = transaction
+            .query_row("SELECT rowid FROM e2ei_enrollment WHERE id = ?", [&self.id], |r| {
+                r.get::<_, i64>(0)
+            })
+            .optional()?;
+
+        let row_id = if existing_rowid.is_some() {
+            return Err(CryptoKeystoreError::AlreadyExists);
+        } else {
+            let zb = rusqlite::blob::ZeroBlob(self.content.len() as i32);
+            let params: [rusqlite::types::ToSqlOutput; 2] = [self.id.to_sql()?, zb.to_sql()?];
+            transaction.execute("INSERT INTO e2ei_enrollment (id, content) VALUES (?, ?)", params)?;
+            transaction.last_insert_rowid()
+        };
+
+        let mut blob = transaction.blob_open(
+            rusqlite::DatabaseName::Main,
+            "e2ei_enrollment",
+            "content",
+            row_id,
+            false,
+        )?;
+
+        use std::io::Write as _;
+        blob.write_all(&self.content)?;
+        blob.close()?;
+
+        transaction.commit()?;
+
+        Ok(())
+    }
+
+    async fn find_one(
+        conn: &mut Self::ConnectionType,
+        id: &StringEntityId,
+    ) -> crate::CryptoKeystoreResult<Option<Self>> {
+        let transaction = conn.transaction()?;
+        use rusqlite::OptionalExtension as _;
+        let mut row_id = transaction
+            .query_row("SELECT rowid FROM e2ei_enrollment WHERE id = ?", [id.as_bytes()], |r| {
+                r.get::<_, i64>(0)
+            })
+            .optional()?;
+
+        if let Some(rowid) = row_id.take() {
+            let mut blob =
+                transaction.blob_open(rusqlite::DatabaseName::Main, "e2ei_enrollment", "content", rowid, true)?;
+            use std::io::Read as _;
+            let mut buf = Vec::with_capacity(blob.len());
+            blob.read_to_end(&mut buf)?;
+            blob.close()?;
+
+            transaction.commit()?;
+
+            Ok(Some(Self {
+                id: id.into_bytes(),
+                content: buf,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn count(_conn: &mut Self::ConnectionType) -> crate::CryptoKeystoreResult<usize> {
+        Err(CryptoKeystoreError::ImplementationError)
+    }
+
+    async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
+        let transaction = conn.transaction()?;
+        let len = ids.len();
+        let mut updated = 0;
+        for id in ids {
+            updated += transaction.execute("DELETE FROM e2ei_enrollment WHERE id = ?", [id.as_bytes()])?;
+        }
+
+        if updated == len {
+            transaction.commit()?;
+            Ok(())
+        } else {
+            transaction.rollback()?;
+            Err(Self::to_missing_key_err_kind().into())
+        }
+    }
+}

--- a/keystore/src/entities/platform/generic/mls/group.rs
+++ b/keystore/src/entities/platform/generic/mls/group.rs
@@ -145,7 +145,7 @@ impl EntityBase for PersistedMlsGroup {
         use rusqlite::OptionalExtension as _;
         let transaction = conn.transaction()?;
         let mut rowid: Option<i64> = transaction
-            .query_row("SELECT rowid FROM mls_groups WHERE id = ?", [id.as_bytes()], |r| {
+            .query_row("SELECT rowid FROM mls_groups WHERE id = ?", [id.into_bytes()], |r| {
                 r.get::<_, i64>(0)
             })
             .optional()?;
@@ -243,7 +243,7 @@ impl EntityBase for PersistedMlsGroup {
         let len = ids.len();
         let mut updated = 0;
         for id in ids {
-            updated += transaction.execute("DELETE FROM mls_groups WHERE id = ?", [id.as_bytes()])?;
+            updated += transaction.execute("DELETE FROM mls_groups WHERE id = ?", [id.into_bytes()])?;
         }
 
         if updated == len {

--- a/keystore/src/entities/platform/generic/mls/keypackage.rs
+++ b/keystore/src/entities/platform/generic/mls/keypackage.rs
@@ -107,7 +107,7 @@ impl EntityBase for MlsKeypackage {
         conn: &mut Self::ConnectionType,
         id: &StringEntityId,
     ) -> crate::CryptoKeystoreResult<Option<Self>> {
-        let id = String::from_utf8(id.as_bytes())?;
+        let id = String::from_utf8(id.into_bytes())?;
 
         let transaction = conn.transaction()?;
         use rusqlite::OptionalExtension as _;
@@ -140,7 +140,7 @@ impl EntityBase for MlsKeypackage {
         let len = ids.len();
         let mut updated = 0;
         for id in ids {
-            let id = String::from_utf8(id.as_bytes())?;
+            let id = String::from_utf8(id.into_bytes())?;
             updated += transaction.execute("DELETE FROM mls_keys WHERE id = ?", [id])?;
         }
 

--- a/keystore/src/entities/platform/generic/mls/mod.rs
+++ b/keystore/src/entities/platform/generic/mls/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+pub mod enrollment;
 pub mod group;
 pub mod identity;
 pub mod keypackage;

--- a/keystore/src/entities/platform/generic/mls/pending_group.rs
+++ b/keystore/src/entities/platform/generic/mls/pending_group.rs
@@ -130,7 +130,7 @@ impl EntityBase for PersistedMlsPendingGroup {
         let rowid: Option<i64> = transaction
             .query_row(
                 "SELECT rowid FROM mls_pending_groups WHERE id = ?",
-                [&id.as_bytes()],
+                [&id.into_bytes()],
                 |r| r.get(0),
             )
             .optional()?;
@@ -316,7 +316,7 @@ impl EntityBase for PersistedMlsPendingGroup {
         let len = ids.len();
         let mut updated = 0;
         for id in ids {
-            updated += transaction.execute("DELETE FROM mls_pending_groups WHERE id = ?", [id.as_bytes()])?;
+            updated += transaction.execute("DELETE FROM mls_pending_groups WHERE id = ?", [id.into_bytes()])?;
         }
 
         if updated == len {

--- a/keystore/src/entities/platform/generic/proteus/prekey.rs
+++ b/keystore/src/entities/platform/generic/proteus/prekey.rs
@@ -67,7 +67,7 @@ impl EntityBase for ProteusPrekey {
         conn: &mut Self::ConnectionType,
         id: &StringEntityId,
     ) -> crate::CryptoKeystoreResult<Option<Self>> {
-        let id = ProteusPrekey::id_from_slice(&id.as_bytes());
+        let id = ProteusPrekey::id_from_slice(&id.into_bytes());
 
         let transaction = conn.transaction()?;
 
@@ -146,7 +146,7 @@ impl EntityBase for ProteusPrekey {
 
         let mut updated = 0;
         for id in ids {
-            let id = ProteusPrekey::id_from_slice(&id.as_bytes());
+            let id = ProteusPrekey::id_from_slice(&id.into_bytes());
             updated += transaction.execute("DELETE FROM proteus_prekeys WHERE id = ?", [id])?;
         }
 

--- a/keystore/src/entities/platform/wasm/mls/group.rs
+++ b/keystore/src/entities/platform/wasm/mls/group.rs
@@ -65,7 +65,7 @@ impl EntityBase for PersistedMlsGroup {
 
     async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
         let storage = conn.storage_mut();
-        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+        let ids = ids.iter().map(StringEntityId::as_bytes).collect::<Vec<_>>();
         let _ = storage.delete("mls_groups", &ids).await?;
         Ok(())
     }
@@ -144,8 +144,8 @@ impl EntityBase for PersistedMlsPendingGroup {
         conn.storage().count("mls_pending_groups").await
     }
 
-    async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
-        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+    async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> CryptoKeystoreResult<()> {
+        let ids = ids.iter().map(StringEntityId::as_bytes).collect::<Vec<_>>();
         let _ = conn.storage_mut().delete("mls_pending_groups", &ids).await?;
         Ok(())
     }

--- a/keystore/src/entities/platform/wasm/mls/identity.rs
+++ b/keystore/src/entities/platform/wasm/mls/identity.rs
@@ -53,7 +53,7 @@ impl EntityBase for MlsIdentity {
 
     async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
         let storage = conn.storage_mut();
-        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+        let ids = ids.iter().map(StringEntityId::as_bytes).collect::<Vec<_>>();
         storage.delete("mls_identities", &ids).await
     }
 }

--- a/keystore/src/entities/platform/wasm/mls/mod.rs
+++ b/keystore/src/entities/platform/wasm/mls/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+pub mod enrollment;
 pub mod group;
 pub mod identity;
 pub mod keypackage;

--- a/keystore/src/entities/platform/wasm/proteus/identity.rs
+++ b/keystore/src/entities/platform/wasm/proteus/identity.rs
@@ -57,7 +57,7 @@ impl EntityBase for ProteusIdentity {
 
     async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
         let storage = conn.storage_mut();
-        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+        let ids = ids.iter().map(StringEntityId::as_bytes).collect::<Vec<_>>();
         storage.delete("proteus_identities", &ids).await
     }
 }

--- a/keystore/src/entities/platform/wasm/proteus/prekey.rs
+++ b/keystore/src/entities/platform/wasm/proteus/prekey.rs
@@ -53,7 +53,7 @@ impl EntityBase for ProteusPrekey {
 
     async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
         let storage = conn.storage_mut();
-        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+        let ids = ids.iter().map(StringEntityId::as_bytes).collect::<Vec<_>>();
         storage.delete("proteus_prekeys", &ids).await
     }
 }

--- a/keystore/src/entities/platform/wasm/proteus/session.rs
+++ b/keystore/src/entities/platform/wasm/proteus/session.rs
@@ -53,7 +53,7 @@ impl EntityBase for ProteusSession {
 
     async fn delete(conn: &mut Self::ConnectionType, ids: &[StringEntityId]) -> crate::CryptoKeystoreResult<()> {
         let storage = conn.storage_mut();
-        let ids: Vec<Vec<u8>> = ids.iter().map(StringEntityId::as_bytes).collect();
+        let ids = ids.iter().map(StringEntityId::as_bytes).collect::<Vec<_>>();
         storage.delete("proteus_sessions", &ids).await
     }
 }

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -25,6 +25,8 @@ pub enum MissingKeyErrorKind {
     MlsGroup,
     #[error("MLS Persisted Pending Group")]
     MlsPendingGroup,
+    #[error("End-to-end identity enrollment")]
+    E2eiEnrollment,
     #[cfg(feature = "proteus-keystore")]
     #[error("Proteus PreKey")]
     ProteusPrekey,
@@ -47,8 +49,12 @@ pub enum CryptoKeystoreError {
     TryFromSliceError(#[from] std::array::TryFromSliceError),
     #[error("One of the Keystore locks has been poisoned")]
     LockPoisonError,
+    #[error("We have done something terribly wrong and it needs to be fixed")]
+    ImplementationError,
     #[error("The keystore has run out of keypackage bundles!")]
     OutOfKeyPackageBundles,
+    #[error("A uniqueness constraint has been violated")]
+    AlreadyExists,
     #[error("The provided buffer is too big to be persisted in the store")]
     BlobTooBig,
     #[cfg(feature = "mls-keystore")]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Web needs to redirect the user during the OAuth challenge. Hence, the enrollment instance has to be persisted. We reuse the keystore from CoreCrypto to do so

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
