### PR TITLE
fix!: creating a MLS group does not consume an existing KeyPackage

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -841,6 +841,7 @@ export class CoreCrypto {
      * You will want to use {@link CoreCrypto.addClientsToConversation} afterwards to add clients to this conversation
      *
      * @param conversationId - The conversation ID; You can either make them random or let the backend attribute MLS group IDs
+     * @param creatorCredentialType - kind of credential the creator wants to create the group with
      * @param configuration - configuration of the MLS group
      * @param configuration.ciphersuite - The {@link Ciphersuite} that is chosen to be the group's
      * @param configuration.externalSenders - Array of Client IDs that are qualified as external senders within the group
@@ -848,6 +849,7 @@ export class CoreCrypto {
      */
     async createConversation(
         conversationId: ConversationId,
+        creatorCredentialType: CredentialType,
         configuration: ConversationConfiguration = {}
     ) {
         try {
@@ -857,7 +859,7 @@ export class CoreCrypto {
                 externalSenders,
                 custom?.keyRotationSpan,
             );
-            const ret = await CoreCryptoError.asyncMapErr(this.#cc.create_conversation(conversationId, config));
+            const ret = await CoreCryptoError.asyncMapErr(this.#cc.create_conversation(conversationId, creatorCredentialType, config));
             return ret;
         } catch(e) {
             throw CoreCryptoError.fromStdError(e as Error);

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.js
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.js
@@ -80,12 +80,13 @@ test("can use pgs enums", async () => {
   const [ctx, page] = await initBrowser();
 
   const [PublicGroupStateEncryptionType, RatchetTreeType] = await page.evaluate(async () => {
-    const { CoreCrypto, Ciphersuite, PublicGroupStateEncryptionType, RatchetTreeType } = await import ("./corecrypto.js");
+    const { CoreCrypto, Ciphersuite, CredentialType, PublicGroupStateEncryptionType, RatchetTreeType } = await import ("./corecrypto.js");
 
     window.PublicGroupStateEncryptionType = PublicGroupStateEncryptionType;
     window.RatchetTreeType = RatchetTreeType;
     window.CoreCrypto = CoreCrypto;
     window.Ciphersuite = Ciphersuite;
+    window.CredentialType = CredentialType.Basic;
 
     return [PublicGroupStateEncryptionType, RatchetTreeType];
   });
@@ -125,7 +126,7 @@ test("can use pgs enums", async () => {
     const encoder = new TextEncoder();
     const conversationId = encoder.encode("testConversation");
 
-    await cc.createConversation(conversationId);
+    await cc.createConversation(conversationId, window.CredentialType);
 
     const { publicGroupState } = await cc.addClientsToConversation(conversationId, [
       { id: encoder.encode(client2Config.clientId), kp },
@@ -230,9 +231,10 @@ test("externally generated clients", async () => {
   const [ctx, page] = await initBrowser();
 
   await page.evaluate(async () => {
-    const { CoreCrypto, Ciphersuite } = await import("./corecrypto.js");
+    const { CoreCrypto, Ciphersuite, CredentialType } = await import("./corecrypto.js");
 
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    const credentialType = CredentialType.Basic;
     const alice = await CoreCrypto.deferredInit({
       databaseName: "extgen alice test",
       key: "test",
@@ -258,7 +260,7 @@ test("externally generated clients", async () => {
 
     const conversationId = encoder.encode("testConversation");
 
-    await alice.createConversation(conversationId);
+    await alice.createConversation(conversationId, credentialType);
 
     const memberAdded = await alice.addClientsToConversation(conversationId, [
       { id: encoder.encode("bob"), kp: bobKp },
@@ -374,9 +376,10 @@ test("encrypt message", async () => {
   const [ctx, page] = await initBrowser();
 
   const msgLen = await page.evaluate(async () => {
-    const { CoreCrypto, Ciphersuite } = await import("./corecrypto.js");
+    const { CoreCrypto, Ciphersuite, CredentialType } = await import("./corecrypto.js");
 
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    const credentialType = CredentialType.Basic;
     const cc = await CoreCrypto.init({
       databaseName: "encrypt message",
       key: "test",
@@ -388,7 +391,7 @@ test("encrypt message", async () => {
 
     const conversationId = encoder.encode("testConversation");
 
-    await cc.createConversation(conversationId);
+    await cc.createConversation(conversationId, credentialType);
 
     const encryptedMessage = await cc.encryptMessage(
       conversationId,
@@ -437,9 +440,10 @@ test("roundtrip message", async () => {
   kp = Uint8Array.from(Object.values(kp));
 
   let [welcome, message] = await page.evaluate(async (kp, messageText, conversationId, clientId2) => {
-    const { CoreCrypto, Ciphersuite } = await import("./corecrypto.js");
+    const { CoreCrypto, Ciphersuite, CredentialType } = await import("./corecrypto.js");
 
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    const credentialType = CredentialType.Basic;
     const config = {
         databaseName: "roundtrip message test 1",
         key: "test",
@@ -453,7 +457,7 @@ test("roundtrip message", async () => {
 
     const conversationIdBuffer = encoder.encode(conversationId);
 
-    await cc.createConversation(conversationIdBuffer);
+    await cc.createConversation(conversationIdBuffer, credentialType);
 
     const memberAdded = await cc.addClientsToConversation(conversationIdBuffer, [
       { id: encoder.encode(clientId2), kp: Uint8Array.from(Object.values(kp)) },
@@ -525,9 +529,10 @@ test("callbacks default to false when not async", async () => {
   const [ctx, page] = await initBrowser({ captureLogs: false });
 
   const result = await page.evaluate(async () => {
-    const { CoreCrypto, Ciphersuite, ExternalProposalType } = await import("./corecrypto.js");
+    const { CoreCrypto, Ciphersuite, CredentialType, ExternalProposalType } = await import("./corecrypto.js");
 
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    const credentialType = CredentialType.Basic;
     const client1Config = {
       databaseName: "test cb",
       key: "test",
@@ -565,7 +570,7 @@ test("callbacks default to false when not async", async () => {
 
     const conversationId = encoder.encode("Test conversation");
 
-    await cc.createConversation(conversationId);
+    await cc.createConversation(conversationId, credentialType);
 
     try {
       const creationMessage = await cc.addClientsToConversation(conversationId, [
@@ -661,7 +666,7 @@ test("ext commits|proposals & callbacks", async () => {
 
     const conversationId = encoder.encode("Test conversation");
 
-    await cc.createConversation(conversationId);
+    await cc.createConversation(conversationId, credentialType);
 
     // ! This should trigger the authorize callback
     const creationMessage = await cc.addClientsToConversation(conversationId, [

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/CoreCrypto.kt
@@ -44,7 +44,7 @@ open class RustBuffer : Structure() {
 
     companion object {
         internal fun alloc(size: Int = 0) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_rustbuffer_alloc(size, status).also {
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1fef_rustbuffer_alloc(size, status).also {
                 if(it.data == null) {
                    throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=${size})")
                }
@@ -52,7 +52,7 @@ open class RustBuffer : Structure() {
         }
 
         internal fun free(buf: RustBuffer.ByValue) = rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_rustbuffer_free(buf, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1fef_rustbuffer_free(buf, status)
         }
     }
 
@@ -264,343 +264,343 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_CoreCrypto_c853_CoreCrypto_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_1fef_CoreCrypto_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_new(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_c853_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_deferred_init(`path`: RustBuffer.ByValue,`key`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,`entropySeed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_c853_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_mls_init(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(`ptr`: Pointer,`ciphersuites`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_mls_generate_keypairs(`ptr`: Pointer,`ciphersuites`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKeys`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_mls_init_with_client_id(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`signaturePublicKeys`: RustBuffer.ByValue,`ciphersuites`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_restore_from_disk(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_restore_from_disk(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
+    fun CoreCrypto_1fef_CoreCrypto_set_callbacks(`ptr`: Pointer,`callbacks`: Long,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_client_public_key(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_client_public_key(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_client_keypackages(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,`amountRequested`: Int,
+    fun CoreCrypto_1fef_CoreCrypto_client_keypackages(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,`amountRequested`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_client_valid_keypackages_count(`ptr`: Pointer,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_c853_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_create_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`creatorCredentialType`: RustBuffer.ByValue,`config`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_conversation_epoch(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Long
 
-    fun CoreCrypto_c853_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_conversation_exists(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_c853_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_process_welcome_message(`ptr`: Pointer,`welcomeMessage`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_add_clients_to_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_remove_clients_from_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clients`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_mark_conversation_as_child_of(`ptr`: Pointer,`childId`: RustBuffer.ByValue,`parentId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_update_keying_material(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_commit_pending_proposals(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_wipe_conversation(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_decrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`payload`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_encrypt_message(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`message`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_new_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyPackage`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_new_update_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_new_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`clientId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`ciphersuite`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_new_external_add_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`ciphersuite`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_new_external_remove_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`epoch`: Long,`keyPackageRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_join_by_external_commit(`ptr`: Pointer,`publicGroupState`: RustBuffer.ByValue,`customConfiguration`: RustBuffer.ByValue,`credentialType`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_merge_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_clear_pending_group_from_external_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_export_group_state(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
+    fun CoreCrypto_1fef_CoreCrypto_export_secret_key(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`keyLength`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_get_client_ids(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
+    fun CoreCrypto_1fef_CoreCrypto_random_bytes(`ptr`: Pointer,`length`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_reseed_rng(`ptr`: Pointer,`seed`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_commit_accepted(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_clear_pending_proposal(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,`proposalRef`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_clear_pending_commit(`ptr`: Pointer,`conversationId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_init(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_init(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_session_from_prekey(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_session_from_message(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`envelope`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_session_save(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_session_delete(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_session_exists(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Byte
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_decrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`ciphertext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_encrypt(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_encrypt_batched(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,`plaintext`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_new_prekey(`ptr`: Pointer,`prekeyId`: Short,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_new_prekey_auto(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey_id(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Short
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_fingerprint(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_local(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_remote(`ptr`: Pointer,`sessionId`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_prekeybundle(`ptr`: Pointer,`prekey`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_cryptobox_migrate(`ptr`: Pointer,`path`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_proteus_last_error_code(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Int
 
-    fun CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_e2ei_new_enrollment(`ptr`: Pointer,`clientId`: RustBuffer.ByValue,`displayName`: RustBuffer.ByValue,`handle`: RustBuffer.ByValue,`expiryDays`: Int,`ciphersuite`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun CoreCrypto_c853_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`enrollment`: Pointer,`certificateChain`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_e2ei_mls_init(`ptr`: Pointer,`enrollment`: Pointer,`certificateChain`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(`ptr`: Pointer,`enrollment`: Pointer,
+    fun CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash(`ptr`: Pointer,`enrollment`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(`ptr`: Pointer,`handle`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash_pop(`ptr`: Pointer,`handle`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Pointer
 
-    fun ffi_CoreCrypto_c853_WireE2eIdentity_object_free(`ptr`: Pointer,
+    fun ffi_CoreCrypto_1fef_WireE2eIdentity_object_free(`ptr`: Pointer,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_directory_response(`ptr`: Pointer,`directory`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_account_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_account_response(`ptr`: Pointer,`account`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_order_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_authz_request(`ptr`: Pointer,`url`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_authz_response(`ptr`: Pointer,`authz`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`expirySecs`: Int,`backendNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_create_dpop_token(`ptr`: Pointer,`expirySecs`: Int,`backendNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_dpop_challenge_request(`ptr`: Pointer,`accessToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_oidc_challenge_request(`ptr`: Pointer,`idToken`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_new_challenge_response(`ptr`: Pointer,`challenge`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_check_order_request(`ptr`: Pointer,`orderUrl`: RustBuffer.ByValue,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_check_order_response(`ptr`: Pointer,`order`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_finalize_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_finalize_response(`ptr`: Pointer,`finalize`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun CoreCrypto_c853_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
+    fun CoreCrypto_1fef_WireE2eIdentity_certificate_request(`ptr`: Pointer,`previousNonce`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
+    fun ffi_CoreCrypto_1fef_CoreCryptoCallbacks_init_callback(`callbackStub`: ForeignCallback,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun CoreCrypto_c853_version(
+    fun CoreCrypto_1fef_version(
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_c853_rustbuffer_alloc(`size`: Int,
+    fun ffi_CoreCrypto_1fef_rustbuffer_alloc(`size`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_c853_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
+    fun ffi_CoreCrypto_1fef_rustbuffer_from_bytes(`bytes`: ForeignBytes.ByValue,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
-    fun ffi_CoreCrypto_c853_rustbuffer_free(`buf`: RustBuffer.ByValue,
+    fun ffi_CoreCrypto_1fef_rustbuffer_free(`buf`: RustBuffer.ByValue,
     _uniffi_out_err: RustCallStatus
     ): Unit
 
-    fun ffi_CoreCrypto_c853_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
+    fun ffi_CoreCrypto_1fef_rustbuffer_reserve(`buf`: RustBuffer.ByValue,`additional`: Int,
     _uniffi_out_err: RustCallStatus
     ): RustBuffer.ByValue
 
@@ -984,7 +984,7 @@ public interface CoreCryptoInterface {
     fun `clientValidKeypackagesCount`(`ciphersuite`: CiphersuiteName): ULong
     
     @Throws(CryptoException::class)
-    fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration)
+    fun `createConversation`(`conversationId`: ConversationId, `creatorCredentialType`: MlsCredentialType, `config`: ConversationConfiguration)
     
     @Throws(CryptoException::class)
     fun `conversationEpoch`(`conversationId`: ConversationId): ULong
@@ -1142,7 +1142,7 @@ class CoreCrypto(
     constructor(`path`: String, `key`: String, `clientId`: ClientId, `ciphersuites`: List<CiphersuiteName>, `entropySeed`: List<UByte>?) :
         this(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_new(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
 
     /**
@@ -1155,7 +1155,7 @@ class CoreCrypto(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_CoreCrypto_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1fef_CoreCrypto_object_free(this.pointer, status)
         }
     }
 
@@ -1163,7 +1163,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInit`(`clientId`: ClientId, `ciphersuites`: List<CiphersuiteName>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_mls_init(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
 }
         }
     
@@ -1171,7 +1171,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsGenerateKeypairs`(`ciphersuites`: List<CiphersuiteName>): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(it, FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_mls_generate_keypairs(it, FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1180,7 +1180,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKeys`: List<List<UByte>>, `ciphersuites`: List<CiphersuiteName>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceSequenceUByte.lower(`signaturePublicKeys`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_mls_init_with_client_id(it, FfiConverterTypeClientId.lower(`clientId`), FfiConverterSequenceSequenceUByte.lower(`signaturePublicKeys`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`),  _status)
 }
         }
     
@@ -1188,7 +1188,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `restoreFromDisk`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_restore_from_disk(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_restore_from_disk(it,  _status)
 }
         }
     
@@ -1196,7 +1196,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `setCallbacks`(`callbacks`: CoreCryptoCallbacks) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_set_callbacks(it, FfiConverterTypeCoreCryptoCallbacks.lower(`callbacks`),  _status)
 }
         }
     
@@ -1204,7 +1204,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientPublicKey`(`ciphersuite`: CiphersuiteName): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_client_public_key(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_client_public_key(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1213,7 +1213,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientKeypackages`(`ciphersuite`: CiphersuiteName, `amountRequested`: UInt): List<List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_client_keypackages(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterUInt.lower(`amountRequested`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_client_keypackages(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterUInt.lower(`amountRequested`),  _status)
 }
         }.let {
             FfiConverterSequenceSequenceUByte.lift(it)
@@ -1222,16 +1222,16 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clientValidKeypackagesCount`(`ciphersuite`: CiphersuiteName): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_client_valid_keypackages_count(it, FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
         }
     
-    @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) =
+    @Throws(CryptoException::class)override fun `createConversation`(`conversationId`: ConversationId, `creatorCredentialType`: MlsCredentialType, `config`: ConversationConfiguration) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_create_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeMlsCredentialType.lower(`creatorCredentialType`), FfiConverterTypeConversationConfiguration.lower(`config`),  _status)
 }
         }
     
@@ -1239,7 +1239,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `conversationEpoch`(`conversationId`: ConversationId): ULong =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_conversation_epoch(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterULong.lift(it)
@@ -1247,7 +1247,7 @@ class CoreCrypto(
     override fun `conversationExists`(`conversationId`: ConversationId): Boolean =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_conversation_exists(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1256,7 +1256,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `processWelcomeMessage`(`welcomeMessage`: List<UByte>, `customConfiguration`: CustomConfiguration): ConversationId =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_process_welcome_message(it, FfiConverterSequenceUByte.lower(`welcomeMessage`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`),  _status)
 }
         }.let {
             FfiConverterTypeConversationId.lift(it)
@@ -1265,7 +1265,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `addClientsToConversation`(`conversationId`: ConversationId, `clients`: List<Invitee>): MemberAddedMessages =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_add_clients_to_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeInvitee.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeMemberAddedMessages.lift(it)
@@ -1274,7 +1274,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `removeClientsFromConversation`(`conversationId`: ConversationId, `clients`: List<ClientId>): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_remove_clients_from_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceTypeClientId.lower(`clients`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1283,7 +1283,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_mark_conversation_as_child_of(it, FfiConverterTypeConversationId.lower(`childId`), FfiConverterTypeConversationId.lower(`parentId`),  _status)
 }
         }
     
@@ -1291,7 +1291,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `updateKeyingMaterial`(`conversationId`: ConversationId): CommitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_update_keying_material(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeCommitBundle.lift(it)
@@ -1300,7 +1300,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitPendingProposals`(`conversationId`: ConversationId): CommitBundle? =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_commit_pending_proposals(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterOptionalTypeCommitBundle.lift(it)
@@ -1309,7 +1309,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `wipeConversation`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_wipe_conversation(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1317,7 +1317,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `decryptMessage`(`conversationId`: ConversationId, `payload`: List<UByte>): DecryptedMessage =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_decrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`payload`),  _status)
 }
         }.let {
             FfiConverterTypeDecryptedMessage.lift(it)
@@ -1326,7 +1326,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `encryptMessage`(`conversationId`: ConversationId, `message`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_encrypt_message(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`message`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1335,7 +1335,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newAddProposal`(`conversationId`: ConversationId, `keyPackage`: List<UByte>): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_new_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`keyPackage`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1344,7 +1344,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newUpdateProposal`(`conversationId`: ConversationId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_new_update_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1353,7 +1353,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newRemoveProposal`(`conversationId`: ConversationId, `clientId`: ClientId): ProposalBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_new_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterTypeClientId.lower(`clientId`),  _status)
 }
         }.let {
             FfiConverterTypeProposalBundle.lift(it)
@@ -1362,7 +1362,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalAddProposal`(`conversationId`: ConversationId, `epoch`: ULong, `ciphersuite`: CiphersuiteName, `credentialType`: MlsCredentialType): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_new_external_add_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1371,7 +1371,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `newExternalRemoveProposal`(`conversationId`: ConversationId, `epoch`: ULong, `keyPackageRef`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_new_external_remove_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterULong.lower(`epoch`), FfiConverterSequenceUByte.lower(`keyPackageRef`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1380,7 +1380,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `joinByExternalCommit`(`publicGroupState`: List<UByte>, `customConfiguration`: CustomConfiguration, `credentialType`: MlsCredentialType): ConversationInitBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_join_by_external_commit(it, FfiConverterSequenceUByte.lower(`publicGroupState`), FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), FfiConverterTypeMlsCredentialType.lower(`credentialType`),  _status)
 }
         }.let {
             FfiConverterTypeConversationInitBundle.lift(it)
@@ -1389,7 +1389,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_merge_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1397,7 +1397,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_clear_pending_group_from_external_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1405,7 +1405,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportGroupState`(`conversationId`: ConversationId): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_export_group_state(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1414,7 +1414,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `exportSecretKey`(`conversationId`: ConversationId, `keyLength`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_export_secret_key(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterUInt.lower(`keyLength`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1423,7 +1423,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `getClientIds`(`conversationId`: ConversationId): List<ClientId> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_get_client_ids(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }.let {
             FfiConverterSequenceTypeClientId.lift(it)
@@ -1432,7 +1432,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `randomBytes`(`length`: UInt): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_random_bytes(it, FfiConverterUInt.lower(`length`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1441,7 +1441,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `reseedRng`(`seed`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_reseed_rng(it, FfiConverterSequenceUByte.lower(`seed`),  _status)
 }
         }
     
@@ -1449,7 +1449,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `commitAccepted`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_commit_accepted(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1457,7 +1457,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_clear_pending_proposal(it, FfiConverterTypeConversationId.lower(`conversationId`), FfiConverterSequenceUByte.lower(`proposalRef`),  _status)
 }
         }
     
@@ -1465,7 +1465,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `clearPendingCommit`(`conversationId`: ConversationId) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_clear_pending_commit(it, FfiConverterTypeConversationId.lower(`conversationId`),  _status)
 }
         }
     
@@ -1473,7 +1473,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusInit`() =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_init(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_init(it,  _status)
 }
         }
     
@@ -1481,7 +1481,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: List<UByte>) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_session_from_prekey(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }
     
@@ -1489,7 +1489,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionFromMessage`(`sessionId`: String, `envelope`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_session_from_message(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`envelope`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1498,7 +1498,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionSave`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_session_save(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1506,7 +1506,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionDelete`(`sessionId`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_session_delete(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }
     
@@ -1514,7 +1514,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusSessionExists`(`sessionId`: String): Boolean =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_session_exists(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterBoolean.lift(it)
@@ -1523,7 +1523,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusDecrypt`(`sessionId`: String, `ciphertext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_decrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`ciphertext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1532,7 +1532,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncrypt`(`sessionId`: String, `plaintext`: List<UByte>): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_encrypt(it, FfiConverterString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1541,7 +1541,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusEncryptBatched`(`sessionId`: List<String>, `plaintext`: List<UByte>): Map<String, List<UByte>> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_encrypt_batched(it, FfiConverterSequenceString.lower(`sessionId`), FfiConverterSequenceUByte.lower(`plaintext`),  _status)
 }
         }.let {
             FfiConverterMapStringListUByte.lift(it)
@@ -1550,7 +1550,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekey`(`prekeyId`: UShort): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_new_prekey(it, FfiConverterUShort.lower(`prekeyId`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1559,7 +1559,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusNewPrekeyAuto`(): ProteusAutoPrekeyBundle =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_new_prekey_auto(it,  _status)
 }
         }.let {
             FfiConverterTypeProteusAutoPrekeyBundle.lift(it)
@@ -1568,7 +1568,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekey`(): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey(it,  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1577,7 +1577,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusLastResortPrekeyId`(): UShort =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey_id(it,  _status)
 }
         }.let {
             FfiConverterUShort.lift(it)
@@ -1586,7 +1586,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprint`(): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_fingerprint(it,  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1595,7 +1595,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintLocal`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_local(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1604,7 +1604,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintRemote`(`sessionId`: String): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_remote(it, FfiConverterString.lower(`sessionId`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1613,7 +1613,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusFingerprintPrekeybundle`(`prekey`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_prekeybundle(it, FfiConverterSequenceUByte.lower(`prekey`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1622,14 +1622,14 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `proteusCryptoboxMigrate`(`path`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_cryptobox_migrate(it, FfiConverterString.lower(`path`),  _status)
 }
         }
     
     override fun `proteusLastErrorCode`(): UInt =
         callWithPointer {
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_proteus_last_error_code(it,  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_proteus_last_error_code(it,  _status)
 }
         }.let {
             FfiConverterUInt.lift(it)
@@ -1638,7 +1638,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `e2eiNewEnrollment`(`clientId`: String, `displayName`: String, `handle`: String, `expiryDays`: UInt, `ciphersuite`: CiphersuiteName): WireE2eIdentity =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_e2ei_new_enrollment(it, FfiConverterString.lower(`clientId`), FfiConverterString.lower(`displayName`), FfiConverterString.lower(`handle`), FfiConverterUInt.lower(`expiryDays`), FfiConverterTypeCiphersuiteName.lower(`ciphersuite`),  _status)
 }
         }.let {
             FfiConverterTypeWireE2eIdentity.lift(it)
@@ -1647,7 +1647,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `e2eiMlsInit`(`enrollment`: WireE2eIdentity, `certificateChain`: String) =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`enrollment`), FfiConverterString.lower(`certificateChain`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_e2ei_mls_init(it, FfiConverterTypeWireE2eIdentity.lower(`enrollment`), FfiConverterString.lower(`certificateChain`),  _status)
 }
         }
     
@@ -1655,7 +1655,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `e2eiEnrollmentStash`(`enrollment`: WireE2eIdentity): List<UByte> =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(it, FfiConverterTypeWireE2eIdentity.lower(`enrollment`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash(it, FfiConverterTypeWireE2eIdentity.lower(`enrollment`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1664,7 +1664,7 @@ class CoreCrypto(
     @Throws(CryptoException::class)override fun `e2eiEnrollmentStashPop`(`handle`: List<UByte>): WireE2eIdentity =
         callWithPointer {
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(it, FfiConverterSequenceUByte.lower(`handle`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash_pop(it, FfiConverterSequenceUByte.lower(`handle`),  _status)
 }
         }.let {
             FfiConverterTypeWireE2eIdentity.lift(it)
@@ -1675,7 +1675,7 @@ class CoreCrypto(
         fun `deferredInit`(`path`: String, `key`: String, `ciphersuites`: List<CiphersuiteName>, `entropySeed`: List<UByte>?): CoreCrypto =
             CoreCrypto(
     rustCallWithError(CryptoException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_CoreCrypto_deferred_init(FfiConverterString.lower(`path`), FfiConverterString.lower(`key`), FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), FfiConverterOptionalSequenceUByte.lower(`entropySeed`), _status)
 })
         
     }
@@ -1773,7 +1773,7 @@ class WireE2eIdentity(
      */
     override protected fun freeRustArcPtr() {
         rustCall() { status ->
-            _UniFFILib.INSTANCE.ffi_CoreCrypto_c853_WireE2eIdentity_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_CoreCrypto_1fef_WireE2eIdentity_object_free(this.pointer, status)
         }
     }
 
@@ -1781,7 +1781,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `directoryResponse`(`directory`: List<UByte>): AcmeDirectory =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_directory_response(it, FfiConverterSequenceUByte.lower(`directory`),  _status)
 }
         }.let {
             FfiConverterTypeAcmeDirectory.lift(it)
@@ -1790,7 +1790,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_account_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1799,7 +1799,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAccountResponse`(`account`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_account_response(it, FfiConverterSequenceUByte.lower(`account`),  _status)
 }
         }
     
@@ -1807,7 +1807,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_order_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1816,7 +1816,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOrderResponse`(`order`: List<UByte>): NewAcmeOrder =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeOrder.lift(it)
@@ -1825,7 +1825,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzRequest`(`url`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_authz_request(it, FfiConverterString.lower(`url`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1834,7 +1834,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newAuthzResponse`(`authz`: List<UByte>): NewAcmeAuthz =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_authz_response(it, FfiConverterSequenceUByte.lower(`authz`),  _status)
 }
         }.let {
             FfiConverterTypeNewAcmeAuthz.lift(it)
@@ -1843,7 +1843,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `createDpopToken`(`expirySecs`: UInt, `backendNonce`: String): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_create_dpop_token(it, FfiConverterUInt.lower(`expirySecs`), FfiConverterString.lower(`backendNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_create_dpop_token(it, FfiConverterUInt.lower(`expirySecs`), FfiConverterString.lower(`backendNonce`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1852,7 +1852,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newDpopChallengeRequest`(`accessToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_dpop_challenge_request(it, FfiConverterString.lower(`accessToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1861,7 +1861,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newOidcChallengeRequest`(`idToken`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_oidc_challenge_request(it, FfiConverterString.lower(`idToken`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1870,7 +1870,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `newChallengeResponse`(`challenge`: List<UByte>) =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_new_challenge_response(it, FfiConverterSequenceUByte.lower(`challenge`),  _status)
 }
         }
     
@@ -1878,7 +1878,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderRequest`(`orderUrl`: String, `previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_check_order_request(it, FfiConverterString.lower(`orderUrl`), FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1887,7 +1887,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `checkOrderResponse`(`order`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_check_order_response(it, FfiConverterSequenceUByte.lower(`order`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1896,7 +1896,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_finalize_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1905,7 +1905,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `finalizeResponse`(`finalize`: List<UByte>): String =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_finalize_response(it, FfiConverterSequenceUByte.lower(`finalize`),  _status)
 }
         }.let {
             FfiConverterString.lift(it)
@@ -1914,7 +1914,7 @@ class WireE2eIdentity(
     @Throws(E2eIdentityException::class)override fun `certificateRequest`(`previousNonce`: String): List<UByte> =
         callWithPointer {
     rustCallWithError(E2eIdentityException) { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_WireE2eIdentity_certificate_request(it, FfiConverterString.lower(`previousNonce`),  _status)
 }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -2602,6 +2602,7 @@ sealed class CryptoException(message: String): Exception(message) {
         class TooManyIdentitiesPresent(message: String) : CryptoException(message)
         class ParentGroupNotFound(message: String) : CryptoException(message)
         class InvalidIdentity(message: String) : CryptoException(message)
+        class IdentityInitializationException(message: String) : CryptoException(message)
         
 
     companion object ErrorHandler : CallStatusErrorHandler<CryptoException> {
@@ -2652,6 +2653,7 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
             37 -> CryptoException.TooManyIdentitiesPresent(FfiConverterString.read(buf))
             38 -> CryptoException.ParentGroupNotFound(FfiConverterString.read(buf))
             39 -> CryptoException.InvalidIdentity(FfiConverterString.read(buf))
+            40 -> CryptoException.IdentityInitializationException(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
         
@@ -2817,6 +2819,10 @@ public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoExcepti
             }
             is CryptoException.InvalidIdentity -> {
                 buf.putInt(39)
+                Unit
+            }
+            is CryptoException.IdentityInitializationException -> {
+                buf.putInt(40)
                 Unit
             }
         }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
@@ -3149,7 +3155,7 @@ public object FfiConverterTypeCoreCryptoCallbacks: FfiConverterCallbackInterface
 ) {
     override fun register(lib: _UniFFILib) {
         rustCall() { status ->
-            lib.ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
+            lib.ffi_CoreCrypto_1fef_CoreCryptoCallbacks_init_callback(this.foreignCallback, status)
         }
     }
 }
@@ -3688,7 +3694,7 @@ public typealias FfiConverterTypeMemberId = FfiConverterSequenceUByte
 fun `version`(): String {
     return FfiConverterString.lift(
     rustCall() { _status ->
-    _UniFFILib.INSTANCE.CoreCrypto_c853_version( _status)
+    _UniFFILib.INSTANCE.CoreCrypto_1fef_version( _status)
 })
 }
 

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/client/MLSClient.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/client/MLSClient.kt
@@ -87,6 +87,7 @@ interface MLSClient {
 
     fun createConversation(
         groupId: MLSGroupId,
+        creatorCredentialType: MlsCredentialType,
         externalSenders: List<Ed22519Key> = emptyList()
     )
 
@@ -184,7 +185,7 @@ class MLSClientImpl(
         cc.clearPendingGroupFromExternalCommit(groupId.toUByteList())
     }
 
-    override fun createConversation(groupId: MLSGroupId, externalSenders: List<Ed22519Key>) {
+    override fun createConversation(groupId: MLSGroupId, creatorCredentialType: MlsCredentialType, externalSenders: List<Ed22519Key>) {
         val conf = ConversationConfiguration(
             MLSClient.defaultCiphersuite,
             externalSenders.map { it.toUByteList() },
@@ -192,7 +193,7 @@ class MLSClientImpl(
         )
 
         val groupIdAsBytes = groupId.toUByteList()
-        cc.createConversation(groupIdAsBytes, conf)
+        cc.createConversation(groupIdAsBytes, creatorCredentialType, conf)
     }
 
     override fun wipeConversation(groupId: MLSGroupId) {

--- a/crypto-ffi/bindings/kt/test/com/wire/crypto/client/MLSClientTest.kt
+++ b/crypto-ffi/bindings/kt/test/com/wire/crypto/client/MLSClientTest.kt
@@ -47,7 +47,7 @@ class MLSClientTest {
     @Test
     fun givenNewConversation_whenCallingConversationEpoch_ReturnZeroEpoch() {
         val mlsClient = createClient(ALICE1)
-        mlsClient.createConversation(MLS_CONVERSATION_ID)
+        mlsClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         assertEquals(0UL, mlsClient.conversationEpoch(MLS_CONVERSATION_ID))
     }
 
@@ -58,7 +58,7 @@ class MLSClientTest {
 
         val aliceKeyPackage = aliceClient.generateKeyPackages(CIPHERSUITE, 1).first()
         val clientKeyPackageList = listOf(Pair(ALICE1, aliceKeyPackage))
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val conversationId = aliceClient.processWelcomeMessage(welcome)
@@ -76,7 +76,7 @@ class MLSClientTest {
 
         val aliceKeyPackage = aliceClient.generateKeyPackages(CIPHERSUITE, 1).first()
         val clientKeyPackageList = listOf(Pair(ALICE1, aliceKeyPackage))
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)!!.welcome!!
         val conversationId = aliceClient.processWelcomeMessage(welcome)
 
@@ -92,7 +92,7 @@ class MLSClientTest {
         val alice1KeyPackage = alice1Client.generateKeyPackages(CIPHERSUITE, 1).first()
         val clientKeyPackageList = listOf(Pair(ALICE1, alice1KeyPackage))
 
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val proposal = alice2Client.joinConversation(MLS_CONVERSATION_ID, 1UL, CIPHERSUITE, CREDENTIAL_TYPE)
@@ -112,7 +112,7 @@ class MLSClientTest {
         val clientKeyPackageList = listOf(
             Pair(ALICE1, aliceClient.generateKeyPackages(CIPHERSUITE, 1).first())
         )
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val conversationId = aliceClient.processWelcomeMessage(welcome)
@@ -131,7 +131,7 @@ class MLSClientTest {
         val clientKeyPackageList = listOf(
             Pair(ALICE1, aliceClient.generateKeyPackages(CIPHERSUITE, 1).first())
         )
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted((MLS_CONVERSATION_ID))
         val conversationId = aliceClient.processWelcomeMessage(welcome)
@@ -145,7 +145,7 @@ class MLSClientTest {
         val bobClient = createClient(BOB1)
         val carolClient = createClient(CAROL1)
 
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         val welcome = bobClient.addMember(
             MLS_CONVERSATION_ID,
             listOf(Pair(ALICE1, aliceClient.generateKeyPackages(CIPHERSUITE, 1).first()))
@@ -172,7 +172,7 @@ class MLSClientTest {
             ALICE1 to aliceClient.generateKeyPackages(CIPHERSUITE, 1).first(),
             CAROL1 to carolClient.generateKeyPackages(CIPHERSUITE, 1).first()
         )
-        bobClient.createConversation(MLS_CONVERSATION_ID)
+        bobClient.createConversation(MLS_CONVERSATION_ID, MlsCredentialType.BASIC)
         val welcome = bobClient.addMember(MLS_CONVERSATION_ID, clientKeyPackageList)?.welcome!!
         bobClient.commitAccepted(MLS_CONVERSATION_ID)
         val conversationId = aliceClient.processWelcomeMessage(welcome)
@@ -338,7 +338,7 @@ gBQY+1rDw64QLm/weFQC1mo9y29ddTAKBggqhkjOPQQDAgNHADBEAiARvd7RBuuv
 OhUy7ncjd/nzoN5Qs0p6D+ujdSLDqLlNIAIgfkwAAgsQMDF3ClqVM/p9cmS95B0g
 CAdIObqPoNL5MJo=
 -----END CERTIFICATE-----""".trimIndent()
-         cc.e2eiMlsClient(enrollment, certificateChain)
+        cc.e2eiMlsClient(enrollment, certificateChain)
     }
 
     companion object {

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -549,9 +549,10 @@ public class CoreCryptoWrapper {
     /// Creates a new conversation with the current client being the sole member
     /// You will want to use ``addClientsToConversation(conversationId:clients:)`` afterwards to add clients to this conversation
     /// - parameter conversationId: conversation identifier
+    /// - parameter creatorCredentialType: kind of credential the creator wants to create the group with
     /// - parameter config: the configuration for the conversation to be created
-    public func createConversation(conversationId: ConversationId, config: ConversationConfiguration) throws {
-        try self.coreCrypto.createConversation(conversationId: conversationId, config: config.convert())
+    public func createConversation(conversationId: ConversationId, creatorCredentialType: MlsCredentialType, config: ConversationConfiguration) throws {
+        try self.coreCrypto.createConversation(conversationId: conversationId, creatorCredentialType: creatorCredentialType.convert(), config: config.convert())
     }
 
     /// Checks if the Client is member of a given conversation and if the MLS Group is loaded up

--- a/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCryptoSwift/CoreCryptoSwift.swift
@@ -19,13 +19,13 @@ fileprivate extension RustBuffer {
     }
 
     static func from(_ ptr: UnsafeBufferPointer<UInt8>) -> RustBuffer {
-        try! rustCall { ffi_CoreCrypto_c853_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
+        try! rustCall { ffi_CoreCrypto_1fef_rustbuffer_from_bytes(ForeignBytes(bufferPointer: ptr), $0) }
     }
 
     // Frees the buffer in place.
     // The buffer must not be used after this is called.
     func deallocate() {
-        try! rustCall { ffi_CoreCrypto_c853_rustbuffer_free(self, $0) }
+        try! rustCall { ffi_CoreCrypto_1fef_rustbuffer_free(self, $0) }
     }
 }
 
@@ -426,7 +426,7 @@ public protocol CoreCryptoProtocol {
     func `clientPublicKey`(`ciphersuite`: CiphersuiteName) throws -> [UInt8]
     func `clientKeypackages`(`ciphersuite`: CiphersuiteName, `amountRequested`: UInt32) throws -> [[UInt8]]
     func `clientValidKeypackagesCount`(`ciphersuite`: CiphersuiteName) throws -> UInt64
-    func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws
+    func `createConversation`(`conversationId`: ConversationId, `creatorCredentialType`: MlsCredentialType, `config`: ConversationConfiguration) throws
     func `conversationEpoch`(`conversationId`: ConversationId) throws -> UInt64
     func `conversationExists`(`conversationId`: ConversationId)  -> Bool
     func `processWelcomeMessage`(`welcomeMessage`: [UInt8], `customConfiguration`: CustomConfiguration) throws -> ConversationId
@@ -494,7 +494,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_c853_CoreCrypto_new(
+    CoreCrypto_1fef_CoreCrypto_new(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterTypeClientId.lower(`clientId`), 
@@ -504,7 +504,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_c853_CoreCrypto_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_1fef_CoreCrypto_object_free(pointer, $0) }
     }
 
     
@@ -513,7 +513,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     
     rustCallWithError(FfiConverterTypeCryptoError.self) {
     
-    CoreCrypto_c853_CoreCrypto_deferred_init(
+    CoreCrypto_1fef_CoreCrypto_deferred_init(
         FfiConverterString.lower(`path`), 
         FfiConverterString.lower(`key`), 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), 
@@ -526,7 +526,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInit`(`clientId`: ClientId, `ciphersuites`: [CiphersuiteName]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_mls_init(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_mls_init(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), $0
     )
@@ -536,7 +536,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_mls_generate_keypairs(self.pointer, 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), $0
     )
 }
@@ -545,7 +545,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mlsInitWithClientId`(`clientId`: ClientId, `signaturePublicKeys`: [[UInt8]], `ciphersuites`: [CiphersuiteName]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_mls_init_with_client_id(self.pointer, 
         FfiConverterTypeClientId.lower(`clientId`), 
         FfiConverterSequenceSequenceUInt8.lower(`signaturePublicKeys`), 
         FfiConverterSequenceTypeCiphersuiteName.lower(`ciphersuites`), $0
@@ -555,14 +555,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `restoreFromDisk`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_restore_from_disk(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_restore_from_disk(self.pointer, $0
     )
 }
     }
     public func `setCallbacks`(`callbacks`: CoreCryptoCallbacks) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_set_callbacks(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_set_callbacks(self.pointer, 
         FfiConverterCallbackInterfaceCoreCryptoCallbacks.lower(`callbacks`), $0
     )
 }
@@ -571,7 +571,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_client_public_key(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_client_public_key(self.pointer, 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), $0
     )
 }
@@ -581,7 +581,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_client_keypackages(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_client_keypackages(self.pointer, 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), 
         FfiConverterUInt32.lower(`amountRequested`), $0
     )
@@ -592,17 +592,18 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_client_valid_keypackages_count(self.pointer, 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), $0
     )
 }
         )
     }
-    public func `createConversation`(`conversationId`: ConversationId, `config`: ConversationConfiguration) throws {
+    public func `createConversation`(`conversationId`: ConversationId, `creatorCredentialType`: MlsCredentialType, `config`: ConversationConfiguration) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_create_conversation(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_create_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
+        FfiConverterTypeMlsCredentialType.lower(`creatorCredentialType`), 
         FfiConverterTypeConversationConfiguration.lower(`config`), $0
     )
 }
@@ -611,7 +612,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt64.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_conversation_epoch(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_conversation_epoch(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -622,7 +623,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_c853_CoreCrypto_conversation_exists(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_conversation_exists(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -632,7 +633,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_process_welcome_message(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_process_welcome_message(self.pointer, 
         FfiConverterSequenceUInt8.lower(`welcomeMessage`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), $0
     )
@@ -643,7 +644,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeMemberAddedMessages.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_add_clients_to_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeInvitee.lower(`clients`), $0
     )
@@ -654,7 +655,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_remove_clients_from_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceTypeClientId.lower(`clients`), $0
     )
@@ -664,7 +665,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `markConversationAsChildOf`(`childId`: ConversationId, `parentId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_mark_conversation_as_child_of(self.pointer, 
         FfiConverterTypeConversationId.lower(`childId`), 
         FfiConverterTypeConversationId.lower(`parentId`), $0
     )
@@ -674,7 +675,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_update_keying_material(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_update_keying_material(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -684,7 +685,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterOptionTypeCommitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_commit_pending_proposals(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_commit_pending_proposals(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -693,7 +694,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `wipeConversation`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_wipe_conversation(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_wipe_conversation(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -702,7 +703,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeDecryptedMessage.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_decrypt_message(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_decrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`payload`), $0
     )
@@ -713,7 +714,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_encrypt_message(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_encrypt_message(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`message`), $0
     )
@@ -724,7 +725,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_new_add_proposal(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_new_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`keyPackage`), $0
     )
@@ -735,7 +736,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_new_update_proposal(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_new_update_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -745,7 +746,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProposalBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_new_remove_proposal(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_new_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterTypeClientId.lower(`clientId`), $0
     )
@@ -756,7 +757,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_new_external_add_proposal(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_new_external_add_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterTypeCiphersuiteName.lower(`ciphersuite`), 
@@ -769,7 +770,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_new_external_remove_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt64.lower(`epoch`), 
         FfiConverterSequenceUInt8.lower(`keyPackageRef`), $0
@@ -781,7 +782,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeConversationInitBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_join_by_external_commit(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_join_by_external_commit(self.pointer, 
         FfiConverterSequenceUInt8.lower(`publicGroupState`), 
         FfiConverterTypeCustomConfiguration.lower(`customConfiguration`), 
         FfiConverterTypeMlsCredentialType.lower(`credentialType`), $0
@@ -792,7 +793,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `mergePendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_merge_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -800,7 +801,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingGroupFromExternalCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_clear_pending_group_from_external_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -809,7 +810,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_export_group_state(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_export_group_state(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -819,7 +820,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_export_secret_key(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_export_secret_key(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterUInt32.lower(`keyLength`), $0
     )
@@ -830,7 +831,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceTypeClientId.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_get_client_ids(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_get_client_ids(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -840,7 +841,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_random_bytes(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_random_bytes(self.pointer, 
         FfiConverterUInt32.lower(`length`), $0
     )
 }
@@ -849,7 +850,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `reseedRng`(`seed`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_reseed_rng(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_reseed_rng(self.pointer, 
         FfiConverterSequenceUInt8.lower(`seed`), $0
     )
 }
@@ -857,7 +858,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `commitAccepted`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_commit_accepted(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_commit_accepted(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -865,7 +866,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingProposal`(`conversationId`: ConversationId, `proposalRef`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_clear_pending_proposal(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_clear_pending_proposal(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), 
         FfiConverterSequenceUInt8.lower(`proposalRef`), $0
     )
@@ -874,7 +875,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `clearPendingCommit`(`conversationId`: ConversationId) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_clear_pending_commit(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_clear_pending_commit(self.pointer, 
         FfiConverterTypeConversationId.lower(`conversationId`), $0
     )
 }
@@ -882,14 +883,14 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusInit`() throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_init(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_proteus_init(self.pointer, $0
     )
 }
     }
     public func `proteusSessionFromPrekey`(`sessionId`: String, `prekey`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_session_from_prekey(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
@@ -899,7 +900,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_session_from_message(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_session_from_message(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`envelope`), $0
     )
@@ -909,7 +910,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionSave`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_session_save(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_session_save(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -917,7 +918,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusSessionDelete`(`sessionId`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_session_delete(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_session_delete(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -926,7 +927,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterBool.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_session_exists(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_session_exists(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -936,7 +937,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_decrypt(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_decrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`ciphertext`), $0
     )
@@ -947,7 +948,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_encrypt(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_encrypt(self.pointer, 
         FfiConverterString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -958,7 +959,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterDictionaryStringSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_encrypt_batched(self.pointer, 
         FfiConverterSequenceString.lower(`sessionId`), 
         FfiConverterSequenceUInt8.lower(`plaintext`), $0
     )
@@ -969,7 +970,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_new_prekey(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_new_prekey(self.pointer, 
         FfiConverterUInt16.lower(`prekeyId`), $0
     )
 }
@@ -979,7 +980,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeProteusAutoPrekeyBundle.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_proteus_new_prekey_auto(self.pointer, $0
     )
 }
         )
@@ -988,7 +989,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey(self.pointer, $0
     )
 }
         )
@@ -997,7 +998,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterUInt16.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey_id(self.pointer, $0
     )
 }
         )
@@ -1006,7 +1007,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_fingerprint(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_proteus_fingerprint(self.pointer, $0
     )
 }
         )
@@ -1015,7 +1016,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_local(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1025,7 +1026,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_remote(self.pointer, 
         FfiConverterString.lower(`sessionId`), $0
     )
 }
@@ -1035,7 +1036,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_prekeybundle(self.pointer, 
         FfiConverterSequenceUInt8.lower(`prekey`), $0
     )
 }
@@ -1044,7 +1045,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `proteusCryptoboxMigrate`(`path`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_proteus_cryptobox_migrate(self.pointer, 
         FfiConverterString.lower(`path`), $0
     )
 }
@@ -1054,7 +1055,7 @@ public class CoreCrypto: CoreCryptoProtocol {
             try!
     rustCall() {
     
-    CoreCrypto_c853_CoreCrypto_proteus_last_error_code(self.pointer, $0
+    CoreCrypto_1fef_CoreCrypto_proteus_last_error_code(self.pointer, $0
     )
 }
         )
@@ -1063,7 +1064,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeWireE2eIdentity.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_e2ei_new_enrollment(self.pointer, 
         FfiConverterString.lower(`clientId`), 
         FfiConverterString.lower(`displayName`), 
         FfiConverterString.lower(`handle`), 
@@ -1076,7 +1077,7 @@ public class CoreCrypto: CoreCryptoProtocol {
     public func `e2eiMlsInit`(`enrollment`: WireE2eIdentity, `certificateChain`: String) throws {
         try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_e2ei_mls_init(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_e2ei_mls_init(self.pointer, 
         FfiConverterTypeWireE2eIdentity.lower(`enrollment`), 
         FfiConverterString.lower(`certificateChain`), $0
     )
@@ -1086,7 +1087,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash(self.pointer, 
         FfiConverterTypeWireE2eIdentity.lower(`enrollment`), $0
     )
 }
@@ -1096,7 +1097,7 @@ public class CoreCrypto: CoreCryptoProtocol {
         return try FfiConverterTypeWireE2eIdentity.lift(
             try
     rustCallWithError(FfiConverterTypeCryptoError.self) {
-    CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(self.pointer, 
+    CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash_pop(self.pointer, 
         FfiConverterSequenceUInt8.lower(`handle`), $0
     )
 }
@@ -1168,7 +1169,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     }
 
     deinit {
-        try! rustCall { ffi_CoreCrypto_c853_WireE2eIdentity_object_free(pointer, $0) }
+        try! rustCall { ffi_CoreCrypto_1fef_WireE2eIdentity_object_free(pointer, $0) }
     }
 
     
@@ -1178,7 +1179,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeAcmeDirectory.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_directory_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_directory_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`directory`), $0
     )
 }
@@ -1188,7 +1189,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_account_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_account_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1197,7 +1198,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newAccountResponse`(`account`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_account_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_account_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`account`), $0
     )
 }
@@ -1206,7 +1207,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_order_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_order_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1216,7 +1217,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeOrder.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_order_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1226,7 +1227,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_authz_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_authz_request(self.pointer, 
         FfiConverterString.lower(`url`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1237,7 +1238,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterTypeNewAcmeAuthz.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_authz_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_authz_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`authz`), $0
     )
 }
@@ -1247,7 +1248,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_create_dpop_token(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_create_dpop_token(self.pointer, 
         FfiConverterUInt32.lower(`expirySecs`), 
         FfiConverterString.lower(`backendNonce`), $0
     )
@@ -1258,7 +1259,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_dpop_challenge_request(self.pointer, 
         FfiConverterString.lower(`accessToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1269,7 +1270,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_oidc_challenge_request(self.pointer, 
         FfiConverterString.lower(`idToken`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1279,7 +1280,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
     public func `newChallengeResponse`(`challenge`: [UInt8]) throws {
         try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_new_challenge_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_new_challenge_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`challenge`), $0
     )
 }
@@ -1288,7 +1289,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_check_order_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_check_order_request(self.pointer, 
         FfiConverterString.lower(`orderUrl`), 
         FfiConverterString.lower(`previousNonce`), $0
     )
@@ -1299,7 +1300,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_check_order_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_check_order_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`order`), $0
     )
 }
@@ -1309,7 +1310,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_finalize_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_finalize_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -1319,7 +1320,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterString.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_finalize_response(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_finalize_response(self.pointer, 
         FfiConverterSequenceUInt8.lower(`finalize`), $0
     )
 }
@@ -1329,7 +1330,7 @@ public class WireE2eIdentity: WireE2eIdentityProtocol {
         return try FfiConverterSequenceUInt8.lift(
             try
     rustCallWithError(FfiConverterTypeE2eIdentityError.self) {
-    CoreCrypto_c853_WireE2eIdentity_certificate_request(self.pointer, 
+    CoreCrypto_1fef_WireE2eIdentity_certificate_request(self.pointer, 
         FfiConverterString.lower(`previousNonce`), $0
     )
 }
@@ -2733,6 +2734,9 @@ public enum CryptoError {
     // Simple error enums only carry a message
     case InvalidIdentity(message: String)
     
+    // Simple error enums only carry a message
+    case IdentityInitializationError(message: String)
+    
 }
 
 public struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
@@ -2901,6 +2905,10 @@ public struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             message: try FfiConverterString.read(from: &buf)
         )
         
+        case 40: return .IdentityInitializationError(
+            message: try FfiConverterString.read(from: &buf)
+        )
+        
 
         default: throw UniffiInternalError.unexpectedEnumCase
         }
@@ -3028,6 +3036,9 @@ public struct FfiConverterTypeCryptoError: FfiConverterRustBuffer {
             FfiConverterString.write(message, into: &buf)
         case let .InvalidIdentity(message):
             writeInt(&buf, Int32(39))
+            FfiConverterString.write(message, into: &buf)
+        case let .IdentityInitializationError(message):
+            writeInt(&buf, Int32(40))
             FfiConverterString.write(message, into: &buf)
 
         
@@ -3360,7 +3371,7 @@ fileprivate struct FfiConverterCallbackInterfaceCoreCryptoCallbacks {
     private static var callbackInitialized = false
     private static func initCallback() {
         try! rustCall { (err: UnsafeMutablePointer<RustCallStatus>) in
-                ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
+                ffi_CoreCrypto_1fef_CoreCryptoCallbacks_init_callback(foreignCallbackCallbackInterfaceCoreCryptoCallbacks, err)
         }
     }
     private static func ensureCallbackinitialized() {
@@ -3872,7 +3883,7 @@ public func `version`()  -> String {
     
     rustCall() {
     
-    CoreCrypto_c853_version($0)
+    CoreCrypto_1fef_version($0)
 }
     )
 }

--- a/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
+++ b/crypto-ffi/bindings/swift/lib/core_cryptoFFI.h
@@ -46,343 +46,343 @@ typedef struct RustCallStatus {
 // ⚠️ increment the version suffix in all instances of UNIFFI_SHARED_HEADER_V4 in this file.           ⚠️
 #endif // def UNIFFI_SHARED_H
 
-void ffi_CoreCrypto_c853_CoreCrypto_object_free(
+void ffi_CoreCrypto_1fef_CoreCrypto_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_c853_CoreCrypto_new(
+void*_Nonnull CoreCrypto_1fef_CoreCrypto_new(
       RustBuffer path,RustBuffer key,RustBuffer client_id,RustBuffer ciphersuites,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_c853_CoreCrypto_deferred_init(
+void*_Nonnull CoreCrypto_1fef_CoreCrypto_deferred_init(
       RustBuffer path,RustBuffer key,RustBuffer ciphersuites,RustBuffer entropy_seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_mls_init(
+void CoreCrypto_1fef_CoreCrypto_mls_init(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer ciphersuites,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_mls_generate_keypairs(
+RustBuffer CoreCrypto_1fef_CoreCrypto_mls_generate_keypairs(
       void*_Nonnull ptr,RustBuffer ciphersuites,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_mls_init_with_client_id(
+void CoreCrypto_1fef_CoreCrypto_mls_init_with_client_id(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer signature_public_keys,RustBuffer ciphersuites,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_restore_from_disk(
+void CoreCrypto_1fef_CoreCrypto_restore_from_disk(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_set_callbacks(
+void CoreCrypto_1fef_CoreCrypto_set_callbacks(
       void*_Nonnull ptr,uint64_t callbacks,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_client_public_key(
+RustBuffer CoreCrypto_1fef_CoreCrypto_client_public_key(
       void*_Nonnull ptr,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_client_keypackages(
+RustBuffer CoreCrypto_1fef_CoreCrypto_client_keypackages(
       void*_Nonnull ptr,RustBuffer ciphersuite,uint32_t amount_requested,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_c853_CoreCrypto_client_valid_keypackages_count(
+uint64_t CoreCrypto_1fef_CoreCrypto_client_valid_keypackages_count(
       void*_Nonnull ptr,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_create_conversation(
-      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer config,
+void CoreCrypto_1fef_CoreCrypto_create_conversation(
+      void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer creator_credential_type,RustBuffer config,
     RustCallStatus *_Nonnull out_status
     );
-uint64_t CoreCrypto_c853_CoreCrypto_conversation_epoch(
+uint64_t CoreCrypto_1fef_CoreCrypto_conversation_epoch(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_c853_CoreCrypto_conversation_exists(
+int8_t CoreCrypto_1fef_CoreCrypto_conversation_exists(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_process_welcome_message(
+RustBuffer CoreCrypto_1fef_CoreCrypto_process_welcome_message(
       void*_Nonnull ptr,RustBuffer welcome_message,RustBuffer custom_configuration,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_add_clients_to_conversation(
+RustBuffer CoreCrypto_1fef_CoreCrypto_add_clients_to_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_remove_clients_from_conversation(
+RustBuffer CoreCrypto_1fef_CoreCrypto_remove_clients_from_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer clients,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_mark_conversation_as_child_of(
+void CoreCrypto_1fef_CoreCrypto_mark_conversation_as_child_of(
       void*_Nonnull ptr,RustBuffer child_id,RustBuffer parent_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_update_keying_material(
+RustBuffer CoreCrypto_1fef_CoreCrypto_update_keying_material(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_commit_pending_proposals(
+RustBuffer CoreCrypto_1fef_CoreCrypto_commit_pending_proposals(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_wipe_conversation(
+void CoreCrypto_1fef_CoreCrypto_wipe_conversation(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_decrypt_message(
+RustBuffer CoreCrypto_1fef_CoreCrypto_decrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer payload,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_encrypt_message(
+RustBuffer CoreCrypto_1fef_CoreCrypto_encrypt_message(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer message,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_new_add_proposal(
+RustBuffer CoreCrypto_1fef_CoreCrypto_new_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer key_package,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_new_update_proposal(
+RustBuffer CoreCrypto_1fef_CoreCrypto_new_update_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_new_remove_proposal(
+RustBuffer CoreCrypto_1fef_CoreCrypto_new_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer client_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_new_external_add_proposal(
+RustBuffer CoreCrypto_1fef_CoreCrypto_new_external_add_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer ciphersuite,RustBuffer credential_type,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_new_external_remove_proposal(
+RustBuffer CoreCrypto_1fef_CoreCrypto_new_external_remove_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,uint64_t epoch,RustBuffer key_package_ref,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_join_by_external_commit(
+RustBuffer CoreCrypto_1fef_CoreCrypto_join_by_external_commit(
       void*_Nonnull ptr,RustBuffer public_group_state,RustBuffer custom_configuration,RustBuffer credential_type,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_merge_pending_group_from_external_commit(
+void CoreCrypto_1fef_CoreCrypto_merge_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_clear_pending_group_from_external_commit(
+void CoreCrypto_1fef_CoreCrypto_clear_pending_group_from_external_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_export_group_state(
+RustBuffer CoreCrypto_1fef_CoreCrypto_export_group_state(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_export_secret_key(
+RustBuffer CoreCrypto_1fef_CoreCrypto_export_secret_key(
       void*_Nonnull ptr,RustBuffer conversation_id,uint32_t key_length,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_get_client_ids(
+RustBuffer CoreCrypto_1fef_CoreCrypto_get_client_ids(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_random_bytes(
+RustBuffer CoreCrypto_1fef_CoreCrypto_random_bytes(
       void*_Nonnull ptr,uint32_t length,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_reseed_rng(
+void CoreCrypto_1fef_CoreCrypto_reseed_rng(
       void*_Nonnull ptr,RustBuffer seed,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_commit_accepted(
+void CoreCrypto_1fef_CoreCrypto_commit_accepted(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_clear_pending_proposal(
+void CoreCrypto_1fef_CoreCrypto_clear_pending_proposal(
       void*_Nonnull ptr,RustBuffer conversation_id,RustBuffer proposal_ref,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_clear_pending_commit(
+void CoreCrypto_1fef_CoreCrypto_clear_pending_commit(
       void*_Nonnull ptr,RustBuffer conversation_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_proteus_init(
+void CoreCrypto_1fef_CoreCrypto_proteus_init(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_proteus_session_from_prekey(
+void CoreCrypto_1fef_CoreCrypto_proteus_session_from_prekey(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_session_from_message(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_session_from_message(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer envelope,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_proteus_session_save(
+void CoreCrypto_1fef_CoreCrypto_proteus_session_save(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_proteus_session_delete(
+void CoreCrypto_1fef_CoreCrypto_proteus_session_delete(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-int8_t CoreCrypto_c853_CoreCrypto_proteus_session_exists(
+int8_t CoreCrypto_1fef_CoreCrypto_proteus_session_exists(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_decrypt(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_decrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer ciphertext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_encrypt(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_encrypt(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_encrypt_batched(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_encrypt_batched(
       void*_Nonnull ptr,RustBuffer session_id,RustBuffer plaintext,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_new_prekey(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_new_prekey(
       void*_Nonnull ptr,uint16_t prekey_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_new_prekey_auto(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_new_prekey_auto(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-uint16_t CoreCrypto_c853_CoreCrypto_proteus_last_resort_prekey_id(
+uint16_t CoreCrypto_1fef_CoreCrypto_proteus_last_resort_prekey_id(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_fingerprint(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint_local(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_local(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint_remote(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_remote(
       void*_Nonnull ptr,RustBuffer session_id,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_proteus_fingerprint_prekeybundle(
+RustBuffer CoreCrypto_1fef_CoreCrypto_proteus_fingerprint_prekeybundle(
       void*_Nonnull ptr,RustBuffer prekey,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_proteus_cryptobox_migrate(
+void CoreCrypto_1fef_CoreCrypto_proteus_cryptobox_migrate(
       void*_Nonnull ptr,RustBuffer path,
     RustCallStatus *_Nonnull out_status
     );
-uint32_t CoreCrypto_c853_CoreCrypto_proteus_last_error_code(
+uint32_t CoreCrypto_1fef_CoreCrypto_proteus_last_error_code(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_c853_CoreCrypto_e2ei_new_enrollment(
+void*_Nonnull CoreCrypto_1fef_CoreCrypto_e2ei_new_enrollment(
       void*_Nonnull ptr,RustBuffer client_id,RustBuffer display_name,RustBuffer handle,uint32_t expiry_days,RustBuffer ciphersuite,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_CoreCrypto_e2ei_mls_init(
+void CoreCrypto_1fef_CoreCrypto_e2ei_mls_init(
       void*_Nonnull ptr,void*_Nonnull enrollment,RustBuffer certificate_chain,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash(
+RustBuffer CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash(
       void*_Nonnull ptr,void*_Nonnull enrollment,
     RustCallStatus *_Nonnull out_status
     );
-void*_Nonnull CoreCrypto_c853_CoreCrypto_e2ei_enrollment_stash_pop(
+void*_Nonnull CoreCrypto_1fef_CoreCrypto_e2ei_enrollment_stash_pop(
       void*_Nonnull ptr,RustBuffer handle,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_c853_WireE2eIdentity_object_free(
+void ffi_CoreCrypto_1fef_WireE2eIdentity_object_free(
       void*_Nonnull ptr,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_directory_response(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_directory_response(
       void*_Nonnull ptr,RustBuffer directory,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_account_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_account_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_WireE2eIdentity_new_account_response(
+void CoreCrypto_1fef_WireE2eIdentity_new_account_response(
       void*_Nonnull ptr,RustBuffer account,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_order_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_order_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_order_response(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_authz_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_authz_request(
       void*_Nonnull ptr,RustBuffer url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_authz_response(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_authz_response(
       void*_Nonnull ptr,RustBuffer authz,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_create_dpop_token(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_create_dpop_token(
       void*_Nonnull ptr,uint32_t expiry_secs,RustBuffer backend_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_dpop_challenge_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_dpop_challenge_request(
       void*_Nonnull ptr,RustBuffer access_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_new_oidc_challenge_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_new_oidc_challenge_request(
       void*_Nonnull ptr,RustBuffer id_token,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void CoreCrypto_c853_WireE2eIdentity_new_challenge_response(
+void CoreCrypto_1fef_WireE2eIdentity_new_challenge_response(
       void*_Nonnull ptr,RustBuffer challenge,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_check_order_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_check_order_request(
       void*_Nonnull ptr,RustBuffer order_url,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_check_order_response(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_check_order_response(
       void*_Nonnull ptr,RustBuffer order,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_finalize_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_finalize_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_finalize_response(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_finalize_response(
       void*_Nonnull ptr,RustBuffer finalize,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_WireE2eIdentity_certificate_request(
+RustBuffer CoreCrypto_1fef_WireE2eIdentity_certificate_request(
       void*_Nonnull ptr,RustBuffer previous_nonce,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_c853_CoreCryptoCallbacks_init_callback(
+void ffi_CoreCrypto_1fef_CoreCryptoCallbacks_init_callback(
       ForeignCallback  _Nonnull callback_stub,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer CoreCrypto_c853_version(
+RustBuffer CoreCrypto_1fef_version(
       
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_c853_rustbuffer_alloc(
+RustBuffer ffi_CoreCrypto_1fef_rustbuffer_alloc(
       int32_t size,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_c853_rustbuffer_from_bytes(
+RustBuffer ffi_CoreCrypto_1fef_rustbuffer_from_bytes(
       ForeignBytes bytes,
     RustCallStatus *_Nonnull out_status
     );
-void ffi_CoreCrypto_c853_rustbuffer_free(
+void ffi_CoreCrypto_1fef_rustbuffer_free(
       RustBuffer buf,
     RustCallStatus *_Nonnull out_status
     );
-RustBuffer ffi_CoreCrypto_c853_rustbuffer_reserve(
+RustBuffer ffi_CoreCrypto_1fef_rustbuffer_reserve(
       RustBuffer buf,int32_t additional,
     RustCallStatus *_Nonnull out_status
     );

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -97,6 +97,7 @@ enum CryptoError {
     "TooManyIdentitiesPresent",
     "ParentGroupNotFound",
     "InvalidIdentity",
+    "IdentityInitializationError",
 };
 
 dictionary DecryptedMessage {
@@ -186,7 +187,7 @@ interface CoreCrypto {
     u64 client_valid_keypackages_count(CiphersuiteName ciphersuite);
 
     [Throws=CryptoError]
-    void create_conversation(ConversationId conversation_id, ConversationConfiguration config);
+    void create_conversation(ConversationId conversation_id, MlsCredentialType creator_credential_type, ConversationConfiguration config);
 
     [Throws=CryptoError]
     u64 conversation_epoch(ConversationId conversation_id);

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -531,6 +531,7 @@ impl CoreCrypto<'_> {
     pub fn create_conversation(
         &self,
         conversation_id: ConversationId,
+        creator_credential_type: MlsCredentialType,
         config: ConversationConfiguration,
     ) -> CryptoResult<()> {
         future::block_on(
@@ -538,7 +539,7 @@ impl CoreCrypto<'_> {
                 self.central
                     .lock()
                     .map_err(|_| CryptoError::LockPoisonError)?
-                    .new_conversation(conversation_id, config.try_into()?),
+                    .new_conversation(conversation_id, creator_credential_type, config.try_into()?),
             ),
         )
     }

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -1210,13 +1210,22 @@ impl CoreCrypto {
     /// Returns: [`WasmCryptoResult<()>`]
     ///
     /// see [core_crypto::mls::MlsCentral::new_conversation]
-    pub fn create_conversation(&self, conversation_id: Box<[u8]>, config: ConversationConfiguration) -> Promise {
+    pub fn create_conversation(
+        &self,
+        conversation_id: Box<[u8]>,
+        creator_credential_type: CredentialType,
+        config: ConversationConfiguration,
+    ) -> Promise {
         let this = self.inner.clone();
         future_to_promise(
             async move {
                 this.write()
                     .await
-                    .new_conversation(conversation_id.to_vec(), config.try_into()?)
+                    .new_conversation(
+                        conversation_id.to_vec(),
+                        creator_credential_type.into(),
+                        config.try_into()?,
+                    )
                     .await
                     .map_err(CoreCryptoError::from)?;
                 WasmCryptoResult::Ok(JsValue::UNDEFINED)

--- a/crypto/benches/create_group.rs
+++ b/crypto/benches/create_group.rs
@@ -32,7 +32,12 @@ fn create_group_bench(c: &mut Criterion) {
                         (central, id, cfg)
                     },
                     |(mut central, id, cfg)| async move {
-                        black_box(central.new_conversation(id, cfg).await.unwrap());
+                        black_box(
+                            central
+                                .new_conversation(id, MlsCredentialType::Basic, cfg)
+                                .await
+                                .unwrap(),
+                        );
                     },
                     BatchSize::SmallInput,
                 )

--- a/crypto/benches/utils/mls.rs
+++ b/crypto/benches/utils/mls.rs
@@ -7,6 +7,7 @@ use futures_lite::future::block_on;
 use openmls::prelude::{CredentialBundle, Extension, KeyPackage, KeyPackageBundle, LifetimeExtension};
 use openmls_traits::types::Ciphersuite;
 
+use core_crypto::prelude::MlsCredentialType;
 use core_crypto::{
     mls::{MlsCentral, MlsCiphersuite},
     prelude::{
@@ -129,6 +130,7 @@ pub fn setup_mls(
         central
             .new_conversation(
                 id.clone(),
+                MlsCredentialType::Basic,
                 MlsConversationConfiguration {
                     ciphersuite: ciphersuite.clone(),
                     ..Default::default()

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -146,6 +146,9 @@ pub enum CryptoError {
     /// Client presented an invalid identity
     #[error("Client presented an invalid identity")]
     InvalidIdentity,
+    /// MLS Client was not initialized the right way
+    #[error("MLS Client was not initialized the right way")]
+    IdentityInitializationError,
     /// Parent group cannot be found
     #[error("The specified parent group has not been found in the keystore")]
     ParentGroupNotFound,

--- a/crypto/src/mls/client/mod.rs
+++ b/crypto/src/mls/client/mod.rs
@@ -308,17 +308,14 @@ impl Client {
         cs: MlsCiphersuite,
         cb: &CredentialBundle,
     ) -> CryptoResult<()> {
-        Ok(backend
-            .key_store()
-            .save(MlsIdentity {
-                id: id.to_string(),
-                ciphersuite: cs.into(),
-                credential_type: cb.get_type() as u8,
-                signature: cb.keystore_key()?,
-                credential: cb.to_key_store_value().map_err(MlsError::from)?,
-            })
-            .await
-            .map(|_| ())?)
+        let identity = MlsIdentity {
+            id: id.to_string(),
+            ciphersuite: cs.into(),
+            credential_type: cb.get_type() as u8,
+            signature: cb.keystore_key()?,
+            credential: cb.to_key_store_value().map_err(MlsError::from)?,
+        };
+        Ok(backend.key_store().save(identity).await.map(|_| ())?)
     }
 
     /// Retrieves the client's client id. This is free-form and not inspected.
@@ -365,10 +362,9 @@ impl Client {
         cs: MlsCiphersuite,
         ct: MlsCredentialType,
     ) -> CryptoResult<&CredentialBundle> {
-        // TODO: proper error
         self.identities
             .find_credential_bundle(cs, ct)
-            .ok_or(CryptoError::ImplementationError)
+            .ok_or(CryptoError::IdentityInitializationError)
     }
 }
 

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -180,7 +180,7 @@ pub mod tests {
                     let id = conversation_id();
 
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 

--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -26,18 +26,13 @@ use openmls::prelude::{
 use openmls_traits::types::SignatureScheme;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    mls::{credential::typ::MlsCredentialType, MlsCiphersuite},
-    CryptoError, CryptoResult, MlsError,
-};
+use crate::{mls::MlsCiphersuite, CryptoError, CryptoResult, MlsError};
 
 /// The configuration parameters for a group/conversation
 #[derive(Debug, Clone, Default)]
 pub struct MlsConversationConfiguration {
     /// The `OpenMls` Ciphersuite used in the group
     pub ciphersuite: MlsCiphersuite,
-    /// Type of Credential to initialize the group with
-    pub credential_type: MlsCredentialType,
     /// Delivery service public signature key and credential
     pub external_senders: Vec<ExternalSender>,
     /// Implementation specific configuration

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -259,7 +259,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -289,7 +289,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -327,7 +327,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -367,7 +367,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -425,7 +425,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -528,7 +528,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -582,7 +582,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -671,7 +671,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -723,7 +723,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -761,7 +761,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -806,7 +806,7 @@ pub mod tests {
                         let id = conversation_id();
 
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -856,7 +856,7 @@ pub mod tests {
                         }));
 
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -905,7 +905,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -949,7 +949,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -989,7 +989,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1031,7 +1031,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1062,7 +1062,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1102,7 +1102,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1142,7 +1142,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1188,7 +1188,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1234,7 +1234,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1274,7 +1274,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1340,7 +1340,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
 

--- a/crypto/src/mls/conversation/encrypt.rs
+++ b/crypto/src/mls/conversation/encrypt.rs
@@ -79,7 +79,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     alice_central
@@ -114,7 +114,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     alice_central

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -107,7 +107,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -127,7 +127,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -148,7 +148,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -174,7 +174,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
 
@@ -198,7 +198,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 

--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -416,7 +416,7 @@ pub mod tests {
                         let id = conversation_id();
 
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         let MlsConversationCreationMessage { welcome, .. } = alice_central
@@ -466,7 +466,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
 
@@ -498,7 +498,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
 
@@ -538,7 +538,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -602,7 +602,7 @@ pub mod tests {
                         let id = conversation_id();
 
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -649,7 +649,7 @@ pub mod tests {
                         let id = conversation_id();
 
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -696,7 +696,7 @@ pub mod tests {
                         let id = conversation_id();
 
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -742,7 +742,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -802,7 +802,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -887,7 +887,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1006,7 +1006,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1058,7 +1058,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1102,7 +1102,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1196,7 +1196,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1228,7 +1228,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     assert!(alice_central.pending_proposals(&id).await.is_empty());
@@ -1248,7 +1248,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1293,7 +1293,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1325,7 +1325,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1366,7 +1366,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1399,7 +1399,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1444,7 +1444,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -1477,7 +1477,7 @@ pub mod tests {
                         Box::pin(async move {
                             let id = conversation_id();
                             alice_central
-                                .new_conversation(id.clone(), case.cfg.clone())
+                                .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                                 .await
                                 .unwrap();
                             alice_central
@@ -1547,7 +1547,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -158,7 +158,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -189,7 +189,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central.new_proposal(&id, MlsProposal::Update).await.unwrap();
@@ -222,7 +222,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -307,7 +307,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     assert!(alice_central.pending_proposals(&id).await.is_empty());
@@ -330,7 +330,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     assert!(alice_central.pending_commit(&id).await.is_none());
@@ -364,7 +364,7 @@ pub mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     assert!(alice_central.pending_commit(&id).await.is_none());

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -141,7 +141,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -195,7 +195,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -233,7 +233,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -306,7 +306,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -366,7 +366,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -411,7 +411,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -460,7 +460,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -517,7 +517,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -575,7 +575,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -620,7 +620,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -674,7 +674,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -729,7 +729,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -795,7 +795,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central
@@ -860,7 +860,7 @@ pub mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         alice_central

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -246,7 +246,7 @@ mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -309,7 +309,7 @@ mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -364,7 +364,7 @@ mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -404,7 +404,7 @@ mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     alice_central
@@ -458,7 +458,7 @@ mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -541,7 +541,7 @@ mod tests {
                     }));
 
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -581,7 +581,7 @@ mod tests {
                     }));
 
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 
@@ -615,7 +615,7 @@ mod tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 

--- a/crypto/src/mls/external_proposal.rs
+++ b/crypto/src/mls/external_proposal.rs
@@ -191,7 +191,7 @@ mod tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         owner_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         let epoch = owner_central.get_conversation_unchecked(&id).await.group.epoch();
@@ -253,7 +253,10 @@ mod tests {
                             let remove_key = ds.client_signature_key(&case).as_slice().to_vec();
                             let mut cfg = case.cfg.clone();
                             cfg.set_raw_external_senders(vec![remove_key]);
-                            owner_central.new_conversation(id.clone(), cfg).await.unwrap();
+                            owner_central
+                                .new_conversation(id.clone(), case.credential_type, cfg)
+                                .await
+                                .unwrap();
 
                             owner_central
                                 .invite(&id, &mut guest_central, case.custom_cfg())
@@ -318,7 +321,10 @@ mod tests {
                         let remove_key = ds.client_signature_key(&case).as_slice().to_vec();
                         let mut cfg = case.cfg.clone();
                         cfg.set_raw_external_senders(vec![remove_key]);
-                        owner_central.new_conversation(id.clone(), cfg).await.unwrap();
+                        owner_central
+                            .new_conversation(id.clone(), case.credential_type, cfg)
+                            .await
+                            .unwrap();
 
                         owner_central
                             .invite(&id, &mut guest_central, case.custom_cfg())
@@ -382,7 +388,10 @@ mod tests {
                         let short_remove_key = short_remove_key.tls_serialize_detached().unwrap();
                         let mut cfg = case.cfg.clone();
                         cfg.set_raw_external_senders(vec![short_remove_key.as_slice().to_vec()]);
-                        owner_central.new_conversation(id.clone(), cfg).await.unwrap();
+                        owner_central
+                            .new_conversation(id.clone(), case.credential_type, cfg)
+                            .await
+                            .unwrap();
 
                         owner_central
                             .invite(&id, &mut guest_central, case.custom_cfg())
@@ -445,7 +454,10 @@ mod tests {
                             let remove_key = ds.client_signature_key(&case).as_slice().to_vec();
                             let mut cfg = case.cfg.clone();
                             cfg.set_raw_external_senders(vec![remove_key]);
-                            alice_central.new_conversation(id.clone(), cfg).await.unwrap();
+                            alice_central
+                                .new_conversation(id.clone(), case.credential_type, cfg)
+                                .await
+                                .unwrap();
 
                             alice_central
                                 .invite(&id, &mut bob_central, case.custom_cfg())
@@ -547,7 +559,10 @@ mod tests {
                             let remove_key = ds.client_signature_key(&case).as_slice().to_vec();
                             let mut cfg = case.cfg.clone();
                             cfg.set_raw_external_senders(vec![remove_key]);
-                            alice_central.new_conversation(id.clone(), cfg).await.unwrap();
+                            alice_central
+                                .new_conversation(id.clone(), case.credential_type, cfg)
+                                .await
+                                .unwrap();
 
                             alice_central
                                 .invite(&id, &mut bob_central, case.custom_cfg())

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -127,7 +127,7 @@ pub mod proposal_tests {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
-                            .new_conversation(id.clone(), case.cfg.clone())
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                             .await
                             .unwrap();
                         let bob_kp = bob_central.get_one_key_package(&case).await;
@@ -155,10 +155,13 @@ pub mod proposal_tests {
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
         pub async fn should_update_key_package(case: TestCase) {
-            run_test_with_central(case.clone(), |[mut central]| {
+            run_test_with_central(case.clone(), move |[mut central]| {
                 Box::pin(async move {
                     let id = conversation_id();
-                    central.new_conversation(id.clone(), case.cfg.clone()).await.unwrap();
+                    central
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
                     let before = &(*central
                         .get_conversation_unchecked(&id)
                         .await
@@ -195,7 +198,7 @@ pub mod proposal_tests {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
                     alice_central
@@ -234,11 +237,11 @@ pub mod proposal_tests {
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
         pub async fn should_fail_when_unknown_client(case: TestCase) {
-            run_test_with_client_ids(case.clone(), ["alice"], |[mut alice_central]| {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
-                        .new_conversation(id.clone(), case.cfg.clone())
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
 

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -97,7 +97,7 @@ impl EmulatedMlsClient for CoreCryptoNativeClient {
     async fn add_client(&mut self, conversation_id: &[u8], client_id: &[u8], kp: &[u8]) -> Result<Vec<u8>> {
         if !self.cc.conversation_exists(&conversation_id.to_vec()).await {
             self.cc
-                .new_conversation(conversation_id.to_vec(), Default::default())
+                .new_conversation(conversation_id.to_vec(), MlsCredentialType::Basic, Default::default())
                 .await?;
         }
 

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -140,7 +140,7 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<()> {
 
     let conversation_id = MLS_CONVERSATION_ID.to_vec();
     master_client
-        .new_conversation(conversation_id.clone(), Default::default())
+        .new_conversation(conversation_id.clone(), MlsCredentialType::Basic, Default::default())
         .await?;
 
     spinner.success("[MLS] Step 0: Initializing clients [OK]");


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

creating a MLS group does not consume an existing KeyPackage anymore, instead it always generates a new local one. Also, explicitly ask for the credential type of the creator before creating a new MLS group.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
