### PR TITLE
fix: Return specialised error when the epoch from the message is past the config's value - WPB-1179

### DIFF
--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+use crate::mls::conversation::config::MAX_PAST_EPOCHS;
+
 /// CoreCrypto errors
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 pub enum CryptoError {
@@ -149,6 +151,9 @@ pub enum CryptoError {
     /// Parent group cannot be found
     #[error("The specified parent group has not been found in the keystore")]
     ParentGroupNotFound,
+    /// Message epoch is too old
+    #[error("The epoch in which message was encrypted is older than {MAX_PAST_EPOCHS}")]
+    MessageEpochTooOld,
 }
 
 /// A simpler definition for Result types that the Error is a [CryptoError]

--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -27,6 +27,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{mls::MlsCiphersuite, CryptoResult};
 
+/// Sets the config in OpenMls for the oldest possible epoch(past current) that a message can be decrypted
+pub(crate) const MAX_PAST_EPOCHS: usize = 2;
+
 /// The configuration parameters for a group/conversation
 #[derive(Debug, Clone, Default)]
 pub struct MlsConversationConfiguration {
@@ -48,7 +51,7 @@ impl MlsConversationConfiguration {
     pub fn as_openmls_default_configuration(&self) -> CryptoResult<openmls::group::MlsGroupConfig> {
         Ok(openmls::group::MlsGroupConfig::builder()
             .wire_format_policy(self.custom.wire_policy.into())
-            .max_past_epochs(3)
+            .max_past_epochs(MAX_PAST_EPOCHS)
             .padding_size(Self::PADDING_SIZE)
             .number_of_resumption_psks(1)
             .sender_ratchet_configuration(SenderRatchetConfiguration::new(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Returns a specialised error when trying to decrypt a message encrypted on a older than 2 epochs.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
