### PR TITLE
feat: publish to Sonatype instead of Github Packages

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -52,6 +52,9 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: kotlin
-          arguments: "android:publishMavenPublicationToGithubRepository"
+          arguments: "android:publishToSonatype closeAndReleaseSonatypeStagingRepository"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -52,9 +52,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: kotlin
-          arguments: "android:publishToSonatype closeAndReleaseSonatypeStagingRepository"
+          arguments: "android:publishAllPublicationsToMavenCentral --no-configuration-cache"
         env:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -103,9 +103,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: kotlin
-          arguments: "jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository"
+          arguments: "jvm::publishAllPublicationsToMavenCentral --no-configuration-cache"
         env:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -103,6 +103,9 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: kotlin
-          arguments: "jvm:publishMavenPublicationToGithubRepository"
+          arguments: "jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -3,8 +3,7 @@ import java.util.*
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("maven-publish")
-    id("signing")
+    id("com.vanniktech.maven.publish") version "0.25.3"
 }
 
 android {
@@ -92,94 +91,4 @@ dependencies {
     androidTestImplementation(kotlin("test"))
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "GitHub"
-            url = uri("https://maven.pkg.github.com/wireapp/core-crypto")
-            credentials {
-                username =
-                        project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-                password =
-                        project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("maven") {
-                groupId = "com.wire"
-                artifactId = "core-crypto-android"
-                version = project.properties["coreCryptoVersion"] as String
-                from(components["release"])
-                pom {
-                    name.set("core-crypto-android")
-                    description.set(
-                            "MLS/Proteus multiplexer abstraction with encrypted persistent storage in Rust."
-                    )
-                    url.set("https://github.com/wireapp/core-crypto")
-                    licenses {
-                        license {
-                            name.set("GPL-3.0")
-                            url.set("https://github.com/wireapp/core-crypto/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            name.set("Jacob Persson")
-                            email.set("jacob.persson@wire.com")
-                        }
-                        developer {
-                            name.set("Beltram Maldant")
-                            email.set("beltram.maldant@wire.com")
-                        }
-                        developer {
-                            name.set("Mathieu Amiot")
-                            email.set("mathieu.amiot@wire.com")
-                        }
-                        developer {
-                            name.set("Augusto César Dias")
-                            email.set("augusto.c.dias@wire.com")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:github.com/wireapp/core-crypto.git")
-                        developerConnection.set("scm:git:ssh://github.com/wireapp/core-crypto.git")
-                        url.set("https://github.com/wireapp/core-crypto")
-                    }
-                }
-            }
-        }
-    }
-
-    signing {
-        val signingKey: String? = project.getLocalProperty("signingKey")
-        val signingPassword: String? = project.getLocalProperty("signingPassword")
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications["maven"])
-    }
-}
-
-fun <T> Project.getLocalProperty(propertyName: String): T? {
-    return getLocalProperty(propertyName, this)
-}
-
-/**
- * Util to obtain property declared on `$projectRoot/local.properties` file or default
- */
-@Suppress("UNCHECKED_CAST")
-fun <T> getLocalProperty(propertyName: String, project: Project): T? {
-    val localProperties = Properties().apply {
-        val localPropertiesFile = project.rootProject.file("local.properties")
-        if (localPropertiesFile.exists()) {
-            load(localPropertiesFile.inputStream())
-        }
-    }
-
-    return localProperties.get(propertyName) as? T
 }

--- a/kotlin/android/build.gradle.kts
+++ b/kotlin/android/build.gradle.kts
@@ -1,7 +1,10 @@
+import java.util.*
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
     id("maven-publish")
+    id("signing")
 }
 
 android {
@@ -112,7 +115,7 @@ afterEvaluate {
             create<MavenPublication>("maven") {
                 groupId = "com.wire"
                 artifactId = "core-crypto-android"
-                version = "1.0.0-pre.6"
+                version = project.properties["coreCryptoVersion"] as String
                 from(components["release"])
                 pom {
                     name.set("core-crypto-android")
@@ -126,6 +129,24 @@ afterEvaluate {
                             url.set("https://github.com/wireapp/core-crypto/blob/main/LICENSE")
                         }
                     }
+                    developers {
+                        developer {
+                            name.set("Jacob Persson")
+                            email.set("jacob.persson@wire.com")
+                        }
+                        developer {
+                            name.set("Beltram Maldant")
+                            email.set("beltram.maldant@wire.com")
+                        }
+                        developer {
+                            name.set("Mathieu Amiot")
+                            email.set("mathieu.amiot@wire.com")
+                        }
+                        developer {
+                            name.set("Augusto César Dias")
+                            email.set("augusto.c.dias@wire.com")
+                        }
+                    }
                     scm {
                         connection.set("scm:git:github.com/wireapp/core-crypto.git")
                         developerConnection.set("scm:git:ssh://github.com/wireapp/core-crypto.git")
@@ -135,4 +156,30 @@ afterEvaluate {
             }
         }
     }
+
+    signing {
+        val signingKey: String? = project.getLocalProperty("signingKey")
+        val signingPassword: String? = project.getLocalProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["maven"])
+    }
+}
+
+fun <T> Project.getLocalProperty(propertyName: String): T? {
+    return getLocalProperty(propertyName, this)
+}
+
+/**
+ * Util to obtain property declared on `$projectRoot/local.properties` file or default
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> getLocalProperty(propertyName: String, project: Project): T? {
+    val localProperties = Properties().apply {
+        val localPropertiesFile = project.rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            load(localPropertiesFile.inputStream())
+        }
+    }
+
+    return localProperties.get(propertyName) as? T
 }

--- a/kotlin/android/gradle.properties
+++ b/kotlin/android/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=core-crypto-android

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.*
+
 buildscript {
     repositories {
         google()
@@ -9,7 +11,27 @@ buildscript {
     }
 }
 
-plugins { id("maven-publish") }
+plugins {
+    id("maven-publish")
+    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+}
+
+val coreCryptoGroupId: String by project
+val coreCryptoVersion: String by project
+
+group = coreCryptoGroupId
+version = coreCryptoVersion
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            val sonatypeUser: String? = project.getLocalProperty("sonatypeUser")
+            val sonatypePassword: String? = project.getLocalProperty("sonatypePassword")
+            username.set(sonatypeUser)
+            password.set(sonatypePassword)
+        }
+    }
+}
 
 publishing {
     repositories {
@@ -31,4 +53,23 @@ allprojects {
         google()
         mavenCentral()
     }
+}
+
+fun <T> Project.getLocalProperty(propertyName: String): T? {
+    return getLocalProperty(propertyName, this)
+}
+
+/**
+ * Util to obtain property declared on `$projectRoot/local.properties` file or default
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> getLocalProperty(propertyName: String, project: Project): T? {
+    val localProperties = Properties().apply {
+        val localPropertiesFile = project.rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            load(localPropertiesFile.inputStream())
+        }
+    }
+
+    return localProperties.get(propertyName) as? T
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,51 +1,16 @@
-import java.util.*
-
 buildscript {
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
     }
 }
 
 plugins {
-    id("maven-publish")
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
-}
-
-val coreCryptoGroupId: String by project
-val coreCryptoVersion: String by project
-
-group = coreCryptoGroupId
-version = coreCryptoVersion
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            val sonatypeUser: String? = project.getLocalProperty("sonatypeUser")
-            val sonatypePassword: String? = project.getLocalProperty("sonatypePassword")
-            username.set(sonatypeUser)
-            password.set(sonatypePassword)
-        }
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "GitHub"
-            url = uri("https://maven.pkg.github.com/wireapp/core-crypto")
-            credentials {
-                username =
-                        project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-                password =
-                        project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
+    id("com.vanniktech.maven.publish") version "0.25.3"
 }
 
 allprojects {
@@ -53,23 +18,4 @@ allprojects {
         google()
         mavenCentral()
     }
-}
-
-fun <T> Project.getLocalProperty(propertyName: String): T? {
-    return getLocalProperty(propertyName, this)
-}
-
-/**
- * Util to obtain property declared on `$projectRoot/local.properties` file or default
- */
-@Suppress("UNCHECKED_CAST")
-fun <T> getLocalProperty(propertyName: String, project: Project): T? {
-    val localProperties = Properties().apply {
-        val localPropertiesFile = project.rootProject.file("local.properties")
-        if (localPropertiesFile.exists()) {
-            load(localPropertiesFile.inputStream())
-        }
-    }
-
-    return localProperties.get(propertyName) as? T
 }

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -1,5 +1,3 @@
-coreCryptoGroupId=com.wire
-coreCryptoVersion=1.0.0-pre.5
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*
@@ -21,3 +19,21 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# gradle-maven-publish configuration
+GROUP=com.wire
+VERSION_NAME=1.0.0-pre.5
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+POM_NAME=Core Crypto
+POM_DESCRIPTION=MLS/Proteus multiplexer abstraction with encrypted persistent storage in Rust
+POM_INCEPTION_YEAR=2022
+POM_URL=https://github.com/wireapp/core-crypto
+POM_LICENCE_NAME=GPL-3.0
+POM_LICENCE_URL=https://github.com/wireapp/core-crypto/blob/main/LICENSE
+POM_LICENSE_DIST=repo
+POM_SCM_URL=https://github.com/wireapp/core-crypto
+POM_SCM_CONNECTION=scm:git:github.com/wireapp/core-crypto.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com/wireapp/core-crypto.git
+POM_DEVELOPER_NAME=Jacob Persson
+POM_DEVELOPER_EMAIL=jacob.persson@wire.com

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -1,3 +1,5 @@
+coreCryptoGroupId=com.wire
+coreCryptoVersion=1.0.0-pre.5
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -22,8 +22,9 @@ kotlin.code.style=official
 
 # gradle-maven-publish configuration
 GROUP=com.wire
-VERSION_NAME=1.0.0-pre.5
+VERSION_NAME=1.0.0-pre.6
 SONATYPE_HOST=DEFAULT
+SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 POM_NAME=Core Crypto
 POM_DESCRIPTION=MLS/Proteus multiplexer abstraction with encrypted persistent storage in Rust

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/jvm/build.gradle.kts
+++ b/kotlin/jvm/build.gradle.kts
@@ -1,19 +1,15 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
-import java.util.*
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
     id("java-library")
-    id("maven-publish")
-    id("signing")
+    id("com.vanniktech.maven.publish") version "0.25.3"
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
-    withSourcesJar()
-    withJavadocJar()
 }
 
 val generatedDir = buildDir.resolve("generated").resolve("uniffi")
@@ -95,96 +91,4 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "GitHub"
-            url = uri("https://maven.pkg.github.com/wireapp/core-crypto")
-            credentials {
-                username =
-                        project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
-                password =
-                        project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-}
-
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("maven") {
-                groupId = "com.wire"
-                artifactId = "core-crypto-jvm"
-                version = project.properties["coreCryptoVersion"] as String
-
-                from(components["java"])
-
-                pom {
-                    name.set("core-crypto-jvm")
-                    description.set(
-                            "MLS/Proteus multiplexer abstraction with encrypted persistent storage in Rust"
-                    )
-                    url.set("https://github.com/wireapp/core-crypto")
-                    licenses {
-                        license {
-                            name.set("GPL-3.0")
-                            url.set("https://github.com/wireapp/core-crypto/blob/main/LICENSE")
-                        }
-                    }
-                    developers {
-                        developer {
-                            name.set("Jacob Persson")
-                            email.set("jacob.persson@wire.com")
-                        }
-                        developer {
-                            name.set("Beltram Maldant")
-                            email.set("beltram.maldant@wire.com")
-                        }
-                        developer {
-                            name.set("Mathieu Amiot")
-                            email.set("mathieu.amiot@wire.com")
-                        }
-                        developer {
-                            name.set("Augusto César Dias")
-                            email.set("augusto.c.dias@wire.com")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git:github.com/wireapp/core-crypto.git")
-                        developerConnection.set("scm:git:ssh://github.com/wireapp/core-crypto.git")
-                        url.set("https://github.com/wireapp/core-crypto")
-                    }
-                }
-            }
-        }
-    }
-
-    signing {
-        val signingKey: String? = project.getLocalProperty("signingKey")
-        val signingPassword: String? = project.getLocalProperty("signingPassword")
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications["maven"])
-    }
-}
-
-fun <T> Project.getLocalProperty(propertyName: String): T? {
-    return getLocalProperty(propertyName, this)
-}
-
-/**
- * Util to obtain property declared on `$projectRoot/local.properties` file or default
- */
-@Suppress("UNCHECKED_CAST")
-fun <T> getLocalProperty(propertyName: String, project: Project): T? {
-    val localProperties = Properties().apply {
-        val localPropertiesFile = project.rootProject.file("local.properties")
-        if (localPropertiesFile.exists()) {
-            load(localPropertiesFile.inputStream())
-        }
-    }
-
-    return localProperties.get(propertyName) as? T
 }

--- a/kotlin/jvm/gradle.properties
+++ b/kotlin/jvm/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=core-crypto-jvm


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We want to publish to Sonatype & Maven Central instead of GitHub Packages in order to be compatible with f-droid.

- Configure the https://vanniktech.github.io/gradle-maven-publish-plugin plugin
- Update GitHub publish workflows

The credentials and signing keys are can either be configured in your gradle user's private `gradle.properties`:
```
mavenCentralUsername=<username>
mavenCentralPassword=<password>

signing.keyId=<pgp_key_id>
signing.password=<pgp_key_passphrase>
signing.secretKeyRingFile=<path/to/.gnupg/secring.gpg>
```

Or via environment variables:
```
ORG_GRADLE_PROJECT_sonatypePassword
ORG_GRADLE_PROJECT_sonatypeUsername
ORG_GRADLE_PROJECT_signingInMemoryKeyId
ORG_GRADLE_PROJECT_signingInMemoryKey
ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
