### PR TITLE
feat!: catch duplicate messages [WPB-2788]

### DIFF
--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -94,7 +94,7 @@ enum CryptoError {
     "UnauthorizedExternalAddProposal",
     "UnauthorizedExternalCommit",
     "InvalidHashReference",
-    "GenerationOutOfBound",
+    "DuplicateMessage",
     "WrongEpoch",
     "DecryptionError",
     "HexDecodeError",

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -113,11 +113,6 @@ pub enum CryptoError {
     /// A supplied [`HashReference`] is not of the expected size: 16
     #[error("A supplied reference is not of the expected size: 16")]
     InvalidHashReference,
-    /// The client who created this message is likely to have reused a ratchet generation or
-    /// we are trying to decrypt the same message twice. For the former, this client MLS
-    /// implementation has a loophole and it'd better be evicted from the group.
-    #[error("Decrypted an application message twice")]
-    GenerationOutOfBound,
     /// Tried to decrypt a message in the wrong epoch
     #[error("Decrypted an application message from the wrong epoch")]
     DecryptionError,
@@ -163,6 +158,9 @@ pub enum CryptoError {
     /// The MLS group is in an invalid state for an unknown reason
     #[error("The MLS group is in an invalid state for an unknown reason")]
     InternalMlsError,
+    /// We already decrypted this message once
+    #[error("We already decrypted this message once")]
+    DuplicateMessage,
 }
 
 /// A simpler definition for Result types that the Error is a [CryptoError]

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -1,0 +1,273 @@
+//! Due the current delivery semantics on backend side (at least once) we have to deal with this
+//! in CoreCrypto so as not to return a decryption error to the client. Remove this when this is used
+//! with a DS guaranteeing exactly once delivery semantics since the following degrades the performances
+
+use crate::prelude::MlsConversation;
+use crate::{CryptoError, MlsError};
+use mls_crypto_provider::MlsCryptoProvider;
+use openmls::prelude::{ContentType, FramedContentBodyIn, Proposal, PublicMessageIn, Sender};
+
+impl MlsConversation {
+    pub(crate) fn is_duplicate_message(
+        &self,
+        backend: &MlsCryptoProvider,
+        msg: &PublicMessageIn,
+    ) -> Result<bool, CryptoError> {
+        let (sender, content_type) = (msg.sender(), msg.body().content_type());
+
+        match (content_type, sender) {
+            (ContentType::Commit, Sender::Member(_) | Sender::NewMemberCommit) => {
+                // we use the confirmation tag to detect duplicate since it is issued from the GroupContext
+                // which is supposed to be unique per epoch
+                if let Some(msg_ct) = msg.confirmation_tag() {
+                    let group_ct = self.group.compute_confirmation_tag(backend).map_err(MlsError::from)?;
+                    Ok(msg_ct == &group_ct)
+                } else {
+                    // a commit MUST have a ConfirmationTag
+                    Err(CryptoError::InternalMlsError)
+                }
+            }
+            (ContentType::Proposal, Sender::Member(_) | Sender::NewMemberProposal) => {
+                match msg.body() {
+                    FramedContentBodyIn::Proposal(proposal) => {
+                        let proposal = Proposal::from(proposal.clone()); // TODO: eventually remove this clone 😮‍💨
+                        let already_exists = self.group.pending_proposals().any(|pp| pp.proposal() == &proposal);
+                        Ok(already_exists)
+                    }
+                    _ => Err(CryptoError::InternalMlsError),
+                }
+            }
+            (_, _) => Ok(false),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::{prelude::MlsProposal, test_utils::*, CryptoError};
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn decrypting_duplicate_member_commit_should_fail(case: TestCase) {
+        // cannot work in pure ciphertext since we'd have to decrypt the message first
+        if !case.is_pure_ciphertext() {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
+                            .await
+                            .unwrap();
+                        alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
+
+                        // an commit to verify that we can still detect wrong epoch correctly
+                        let unknown_commit = alice_central.update_keying_material(&id).await.unwrap().commit;
+                        alice_central.clear_pending_commit(&id).await.unwrap();
+
+                        let commit = alice_central.update_keying_material(&id).await.unwrap().commit;
+                        alice_central.commit_accepted(&id).await.unwrap();
+
+                        // decrypt once ... ok
+                        bob_central
+                            .decrypt_message(&id, &commit.to_bytes().unwrap())
+                            .await
+                            .unwrap();
+                        // decrypt twice ... not ok
+                        let decrypt_duplicate = bob_central.decrypt_message(&id, &commit.to_bytes().unwrap()).await;
+                        assert!(matches!(decrypt_duplicate.unwrap_err(), CryptoError::DuplicateMessage));
+
+                        // Decrypting unknown commit.
+                        // It fails with this error since it's not the commit who has created this epoch
+                        let decrypt_lost_commit = bob_central
+                            .decrypt_message(&id, &unknown_commit.to_bytes().unwrap())
+                            .await;
+                        assert!(matches!(decrypt_lost_commit.unwrap_err(), CryptoError::WrongEpoch));
+                    })
+                },
+            )
+            .await
+        }
+    }
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn decrypting_duplicate_external_commit_should_fail(case: TestCase) {
+        run_test_with_client_ids(
+            case.clone(),
+            ["alice", "bob"],
+            move |[mut alice_central, mut bob_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+
+                    let gi = alice_central.get_group_info(&id).await;
+
+                    // an external commit to verify that we can still detect wrong epoch correctly
+                    let unknown_ext_commit = bob_central
+                        .join_by_external_commit(gi.clone(), case.custom_cfg(), case.credential_type)
+                        .await
+                        .unwrap()
+                        .commit;
+                    bob_central.clear_pending_group_from_external_commit(&id).await.unwrap();
+
+                    let ext_commit = bob_central
+                        .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
+                        .await
+                        .unwrap()
+                        .commit;
+                    bob_central.merge_pending_group_from_external_commit(&id).await.unwrap();
+
+                    // decrypt once ... ok
+                    alice_central
+                        .decrypt_message(&id, &ext_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    // decrypt twice ... not ok
+                    let decryption = alice_central
+                        .decrypt_message(&id, &ext_commit.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::DuplicateMessage));
+
+                    // Decrypting unknown external commit.
+                    // It fails with this error since it's not the external commit who has created this epoch
+                    let decryption = alice_central
+                        .decrypt_message(&id, &unknown_ext_commit.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::WrongEpoch));
+                })
+            },
+        )
+        .await
+    }
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn decrypting_duplicate_proposal_should_fail(case: TestCase) {
+        run_test_with_client_ids(
+            case.clone(),
+            ["alice", "bob"],
+            move |[mut alice_central, mut bob_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
+
+                    let proposal = alice_central
+                        .new_proposal(&id, MlsProposal::Update)
+                        .await
+                        .unwrap()
+                        .proposal;
+
+                    // decrypt once ... ok
+                    bob_central
+                        .decrypt_message(&id, &proposal.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // decrypt twice ... not ok
+                    let decryption = bob_central.decrypt_message(&id, &proposal.to_bytes().unwrap()).await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::DuplicateMessage));
+
+                    // advance Bob's epoch to trigger failure
+                    bob_central.commit_pending_proposals(&id).await.unwrap();
+                    bob_central.commit_accepted(&id).await.unwrap();
+
+                    // Epoch has advanced so we cannot detect duplicates anymore
+                    let decryption = bob_central.decrypt_message(&id, &proposal.to_bytes().unwrap()).await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::WrongEpoch));
+                })
+            },
+        )
+        .await
+    }
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn decrypting_duplicate_external_proposal_should_fail(case: TestCase) {
+        run_test_with_client_ids(
+            case.clone(),
+            ["alice", "bob"],
+            move |[mut alice_central, mut bob_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+
+                    let epoch = alice_central.conversation_epoch(&id).await.unwrap();
+
+                    let ext_proposal = bob_central
+                        .new_external_add_proposal(id.clone(), epoch.into(), case.ciphersuite(), case.credential_type)
+                        .await
+                        .unwrap();
+
+                    // decrypt once ... ok
+                    alice_central
+                        .decrypt_message(&id, &ext_proposal.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // decrypt twice ... not ok
+                    let decryption = alice_central
+                        .decrypt_message(&id, &ext_proposal.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::DuplicateMessage));
+
+                    // advance alice's epoch
+                    alice_central.commit_pending_proposals(&id).await.unwrap();
+                    alice_central.commit_accepted(&id).await.unwrap();
+
+                    // Epoch has advanced so we cannot detect duplicates anymore
+                    let decryption = alice_central
+                        .decrypt_message(&id, &ext_proposal.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::WrongEpoch));
+                })
+            },
+        )
+        .await
+    }
+
+    // Ensures decrypting an application message is durable (we increment the messages generation & persist the group)
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn decrypting_duplicate_application_message_should_fail(case: TestCase) {
+        run_test_with_client_ids(
+            case.clone(),
+            ["alice", "bob"],
+            move |[mut alice_central, mut bob_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
+
+                    let msg = b"Hello bob";
+                    let encrypted = alice_central.encrypt_message(&id, msg).await.unwrap();
+
+                    // decrypt once .. ok
+                    bob_central.decrypt_message(&id, &encrypted).await.unwrap();
+                    // decrypt twice .. not ok
+                    let decryption = bob_central.decrypt_message(&id, &encrypted).await;
+                    assert!(matches!(decryption.unwrap_err(), CryptoError::DuplicateMessage));
+                })
+            },
+        )
+        .await
+    }
+}

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -46,6 +46,7 @@ use crate::{
 mod commit_delay;
 pub mod config;
 pub mod decrypt;
+mod duplicate;
 #[cfg(test)]
 mod durability;
 pub mod encrypt;

--- a/crypto/src/test_utils/fixtures.rs
+++ b/crypto/src/test_utils/fixtures.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use crate::prelude::MlsCredentialType;
 use crate::prelude::{MlsCiphersuite, MlsConversationConfiguration, MlsCustomConfiguration};
+use crate::prelude::{MlsCredentialType, MlsWirePolicy};
 use openmls_traits::types::SignatureScheme;
 pub use rstest::*;
 pub use rstest_reuse::{self, *};
@@ -127,6 +127,10 @@ impl TestCase {
 
     pub fn is_basic(&self) -> bool {
         matches!(self.credential_type, MlsCredentialType::Basic)
+    }
+
+    pub fn is_pure_ciphertext(&self) -> bool {
+        matches!(self.cfg.custom.wire_policy, MlsWirePolicy::Ciphertext)
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

To prevent clients from failing with decryption errors whenever a message is replayed by the server.

**THIS DOES NOT DETECT DUPLICATES ACROSS EPOCHS ! It just does so for incoming messages with epoch == current_epoch - 1**

**This also does not work when handshake messages are encrypted (which we do not do ATM and probably never will)**

How it works:
* commits: compute the local group `ConfirmationTag` and compare it with the commit's one
* proposals: compare the proposal with the ones in store
* application message: just change the openmls error mapping 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
