### PR TITLE
feat!: expose 'ClientId' in e2ei methods

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1647,35 +1647,35 @@ export class CoreCrypto {
 
     /**
      * Generates an E2EI enrollment instance for a "regular" client (with a Basic credential) willing to migrate to E2EI.
-     * As a consequence, this method does not support changing the ClientId which should remain the same as the Basic one.
      * Once the enrollment is finished, use the instance in {@link CoreCrypto.e2eiRotateAll} to do the rotation.
      *
+     * @param clientId client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
      * @param displayName human readable name displayed in the application e.g. `Smith, Alice M (QA)`
      * @param handle user handle e.g. `alice.smith.qa@example.com`
      * @param expiryDays generated x509 certificate expiry
      * @param ciphersuite - for generating signing key material
      * @returns The new {@link WireE2eIdentity} object
      */
-    async e2eiNewActivationEnrollment(displayName: string, handle: string, expiryDays: number, ciphersuite: Ciphersuite): Promise<WireE2eIdentity> {
-        const e2ei = await CoreCryptoError.asyncMapErr(this.#cc.e2ei_new_activation_enrollment(displayName, handle, expiryDays, ciphersuite));
+    async e2eiNewActivationEnrollment(clientId: string, displayName: string, handle: string, expiryDays: number, ciphersuite: Ciphersuite): Promise<WireE2eIdentity> {
+        const e2ei = await CoreCryptoError.asyncMapErr(this.#cc.e2ei_new_activation_enrollment(clientId, displayName, handle, expiryDays, ciphersuite));
         return new WireE2eIdentity(e2ei);
     }
 
     /**
      * Generates an E2EI enrollment instance for a E2EI client (with a X509 certificate credential)
      * having to change/rotate their credential, either because the former one is expired or it
-     * has been revoked. As a consequence, this method does not support changing neither ClientId which
-     * should remain the same as the previous one. It lets you change the DisplayName or the handle
+     * has been revoked. It lets you change the DisplayName or the handle
      * if you need to. Once the enrollment is finished, use the instance in {@link CoreCrypto.e2eiRotateAll} to do the rotation.
      *
+     * @param clientId client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
      * @param expiryDays generated x509 certificate expiry
      * @param ciphersuite - for generating signing key material
      * @param displayName human readable name displayed in the application e.g. `Smith, Alice M (QA)`
      * @param handle user handle e.g. `alice.smith.qa@example.com`
      * @returns The new {@link WireE2eIdentity} object
      */
-    async e2eiNewRotateEnrollment(expiryDays: number, ciphersuite: Ciphersuite, displayName?: string, handle?: string,): Promise<WireE2eIdentity> {
-        const e2ei = await CoreCryptoError.asyncMapErr(this.#cc.e2ei_new_rotate_enrollment(displayName, handle, expiryDays, ciphersuite));
+    async e2eiNewRotateEnrollment(clientId: string, expiryDays: number, ciphersuite: Ciphersuite, displayName?: string, handle?: string,): Promise<WireE2eIdentity> {
+        const e2ei = await CoreCryptoError.asyncMapErr(this.#cc.e2ei_new_rotate_enrollment(clientId, displayName, handle, expiryDays, ciphersuite));
         return new WireE2eIdentity(e2ei);
     }
 

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/client/CoreCryptoCentral.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/client/CoreCryptoCentral.kt
@@ -39,6 +39,26 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
         return E2EIClientImpl(cc.e2eiNewEnrollment(clientId, displayName, handle, expiryDays, ciphersuite))
     }
 
+    suspend fun e2eiNewActivationEnrollment(
+        clientId: String,
+        displayName: String,
+        handle: String,
+        expiryDays: UInt,
+        ciphersuite: Ciphersuite,
+    ): E2EIClient {
+        return E2EIClientImpl(cc.e2eiNewActivationEnrollment(clientId, displayName, handle, expiryDays, ciphersuite))
+    }
+
+    suspend fun e2eiNewRotateEnrollment(
+        clientId: String,
+        expiryDays: UInt,
+        ciphersuite: Ciphersuite,
+        displayName: String? = null,
+        handle: String? = null,
+    ): E2EIClient {
+        return E2EIClientImpl(cc.e2eiNewRotateEnrollment(clientId, displayName, handle, expiryDays, ciphersuite))
+    }
+
     suspend fun e2eiMlsInitOnly(enrollment: E2EIClient, certificateChain: String): MLSClient {
         cc.e2eiMlsInitOnly(enrollment.delegate, certificateChain)
         return MLSClientImpl(cc)

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -1044,30 +1044,30 @@ public class CoreCryptoWrapper {
     }
 
     /// Generates an E2EI enrollment instance for a "regular" client (with a Basic credential) willing to migrate to E2EI.
-    /// As a consequence, this method does not support changing the ClientId which should remain the same as the Basic one.
     /// Once the enrollment is finished, use the instance in ``CoreCrypto/e2eiRotateAll`` to do the rotation.
     ///
+    /// - parameter clientId: client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
     /// - parameter displayName: human readable name displayed in the application e.g. `Smith, Alice M (QA)`
     /// - parameter handle: user handle e.g. `alice.smith.qa@example.com`
     /// - parameter expiryDays: generated x509 certificate expiry
     /// - parameter ciphersuite: For generating signing key material.
     /// - returns: The new ``CoreCryptoSwift.WireE2eIdentity`` object
-    public func e2eiNewActivationEnrollment(displayName: String, handle: String, expiryDays: UInt32, ciphersuite: UInt16) async throws -> CoreCryptoSwift.WireE2eIdentity {
-        return try await self.coreCrypto.e2eiNewActivationEnrollment(displayName: displayName, handle: handle, expiryDays: expiryDays, ciphersuite: ciphersuite)
+    public func e2eiNewActivationEnrollment(clientId: String, displayName: String, handle: String, expiryDays: UInt32, ciphersuite: UInt16) async throws -> CoreCryptoSwift.WireE2eIdentity {
+        return try await self.coreCrypto.e2eiNewActivationEnrollment(clientId: clientId, displayName: displayName, handle: handle, expiryDays: expiryDays, ciphersuite: ciphersuite)
     }
 
     /// Generates an E2EI enrollment instance for a E2EI client (with a X509 certificate credential)having to change/rotate
-    /// their credential, either because the former one is expired or it has been revoked. As a consequence, this method
-    /// does not support changing neither ClientId which should remain the same as the previous one. It lets you change
+    /// their credential, either because the former one is expired or it has been revoked. It lets you change
     /// the DisplayName or the handle if you need to. Once the enrollment is finished, use the instance in ``CoreCrypto/e2eiRotateAll`` to do the rotation.
     ///
+    /// - parameter clientId: client identifier with user b64Url encoded & clientId hex encoded e.g. `NDUyMGUyMmY2YjA3NGU3NjkyZjE1NjJjZTAwMmQ2NTQ:6add501bacd1d90e@example.com`
     /// - parameter expiryDays: generated x509 certificate expiry
     /// - parameter ciphersuite: For generating signing key material.
     /// - parameter displayName: human readable name displayed in the application e.g. `Smith, Alice M (QA)`
     /// - parameter handle: user handle e.g. `alice.smith.qa@example.com`
     /// - returns: The new ``CoreCryptoSwift.WireE2eIdentity`` object
-    public func e2eiNewRotateEnrollment(expiryDays: UInt32, ciphersuite: UInt16, displayName: String? = nil, handle: String? = nil) async throws -> CoreCryptoSwift.WireE2eIdentity {
-        return try await self.coreCrypto.e2eiNewRotateEnrollment(expiryDays: expiryDays, ciphersuite: ciphersuite, displayName: displayName, handle: handle)
+    public func e2eiNewRotateEnrollment(clientId: String, expiryDays: UInt32, ciphersuite: UInt16, displayName: String? = nil, handle: String? = nil) async throws -> CoreCryptoSwift.WireE2eIdentity {
+        return try await self.coreCrypto.e2eiNewRotateEnrollment(clientId: clientId, expiryDays: expiryDays, ciphersuite: ciphersuite, displayName: displayName, handle: handle)
     }
 
     /// Use this method to initialize end-to-end identity when a client signs up and the grace period is already expired ; that means he cannot initialize with a Basic credential

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -934,6 +934,7 @@ impl CoreCrypto {
     /// See [core_crypto::mls::MlsCentral::e2ei_new_activation_enrollment]
     pub async fn e2ei_new_activation_enrollment(
         &self,
+        client_id: String,
         display_name: String,
         handle: String,
         expiry_days: u32,
@@ -942,7 +943,13 @@ impl CoreCrypto {
         self.central
             .lock()
             .await
-            .e2ei_new_activation_enrollment(display_name, handle, expiry_days, ciphersuite.into())
+            .e2ei_new_activation_enrollment(
+                client_id.into_bytes().into(),
+                display_name,
+                handle,
+                expiry_days,
+                ciphersuite.into(),
+            )
             .map(async_lock::Mutex::new)
             .map(std::sync::Arc::new)
             .map(WireE2eIdentity)
@@ -953,6 +960,7 @@ impl CoreCrypto {
     /// See [core_crypto::mls::MlsCentral::e2ei_new_rotate_enrollment]
     pub async fn e2ei_new_rotate_enrollment(
         &self,
+        client_id: String,
         display_name: Option<String>,
         handle: Option<String>,
         expiry_days: u32,
@@ -961,7 +969,13 @@ impl CoreCrypto {
         self.central
             .lock()
             .await
-            .e2ei_new_rotate_enrollment(display_name, handle, expiry_days, ciphersuite.into())
+            .e2ei_new_rotate_enrollment(
+                client_id.into_bytes().into(),
+                display_name,
+                handle,
+                expiry_days,
+                ciphersuite.into(),
+            )
             .map(async_lock::Mutex::new)
             .map(std::sync::Arc::new)
             .map(WireE2eIdentity)

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -2337,6 +2337,7 @@ impl CoreCrypto {
     /// see [core_crypto::mls::MlsCentral::e2ei_new_activation_enrollment]
     pub fn e2ei_new_activation_enrollment(
         &self,
+        client_id: String,
         display_name: String,
         handle: String,
         expiry_days: u32,
@@ -2348,7 +2349,13 @@ impl CoreCrypto {
             async move {
                 let this = this.read().await;
                 let enrollment = this
-                    .e2ei_new_activation_enrollment(display_name, handle, expiry_days, ciphersuite.into())
+                    .e2ei_new_activation_enrollment(
+                        client_id.into_bytes().into(),
+                        display_name,
+                        handle,
+                        expiry_days,
+                        ciphersuite.into(),
+                    )
                     .map(WireE2eIdentity)
                     .map_err(|_| CryptoError::ImplementationError)
                     .map_err(CoreCryptoError::from)?;
@@ -2364,6 +2371,7 @@ impl CoreCrypto {
     /// see [core_crypto::mls::MlsCentral::e2ei_new_rotate_enrollment]
     pub fn e2ei_new_rotate_enrollment(
         &self,
+        client_id: String,
         display_name: Option<String>,
         handle: Option<String>,
         expiry_days: u32,
@@ -2375,7 +2383,13 @@ impl CoreCrypto {
             async move {
                 let this = this.read().await;
                 let enrollment = this
-                    .e2ei_new_rotate_enrollment(display_name, handle, expiry_days, ciphersuite.into())
+                    .e2ei_new_rotate_enrollment(
+                        client_id.into_bytes().into(),
+                        display_name,
+                        handle,
+                        expiry_days,
+                        ciphersuite.into(),
+                    )
                     .map(WireE2eIdentity)
                     .map_err(|_| CryptoError::ImplementationError)
                     .map_err(CoreCryptoError::from)?;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Expose 'ClientId' in e2ei methods for credential rotation since the e2ei client identifier differs from the one used in MLS

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
