### PR TITLE
fix: `e2ei_rotate_all` was returning 'undefined' on WASM

### DIFF
--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -2424,9 +2424,11 @@ impl CoreCrypto {
         future_to_promise(
             async move {
                 let mut this = this.write().await;
-                this.e2ei_rotate_all(enrollment.0, certificate_chain, new_key_packages_count as usize)
-                    .await?;
-                WasmCryptoResult::Ok(JsValue::UNDEFINED)
+                let rotate_bundle: RotateBundle = this
+                    .e2ei_rotate_all(enrollment.0, certificate_chain, new_key_packages_count as usize)
+                    .await?
+                    .try_into()?;
+                WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&rotate_bundle)?)
             }
             .err_into(),
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`e2ei_rotate_all` was returning `undefined` on Web

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
