### PR TITLE
fix: kotlin tests not compiling after methods became async

### DIFF
--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/client/CoreCryptoCentral.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/client/CoreCryptoCentral.kt
@@ -77,6 +77,7 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
     companion object {
         const val KEYSTORE_NAME = "keystore"
         fun CiphersuiteName.lower() = (ordinal + 1).toUShort()
+        val DEFAULT_CREDENTIAL_TYPE = MlsCredentialType.BASIC
         val DEFAULT_CIPHERSUITE = CiphersuiteName.MLS_128_DHKEMX25519_AES128GCM_SHA256_ED25519.lower()
         val DEFAULT_CIPHERSUITES = listOf(DEFAULT_CIPHERSUITE)
 

--- a/crypto-ffi/bindings/kt/test/com/wire/crypto/client/ProteusClientTest.kt
+++ b/crypto-ffi/bindings/kt/test/com/wire/crypto/client/ProteusClientTest.kt
@@ -34,7 +34,7 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProteusClientTest {
 
-    fun createProteusClient(clientId: ClientId): ProteusClient {
+    suspend fun createProteusClient(clientId: ClientId): ProteusClient {
         val root = Files.createTempDirectory("mls").toFile()
         val keyStore = root.resolve("keystore-$clientId")
         return CoreCryptoCentral(keyStore.absolutePath, "secret").proteusClient()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Kotlin wrapper tests were not compiling after the UniFFI upgrade which made most method suspendible.

- Wrap tests in `runTest  {}` to which runs the test inside a coroutine scope.
- Wrap `createClient` in `runBlocking`, we could also market he function as  `suspend` but currently that makes the tests hang, maybe because of https://github.com/mozilla/uniffi-rs/issues/1669

### Notes

Disabled `e2ei()` since it hangs.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
