### PR TITLE
test: add a roundtrip test for e2ei credential rotation to tackle a false positive regression

### DIFF
--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -166,7 +166,7 @@ impl MlsConversationCreationMessage {
 }
 
 /// Returned when a commit is created
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MlsCommitBundle {
     /// A welcome message if there are pending Add proposals
     pub welcome: Option<MlsMessageOut>,

--- a/crypto/src/test_utils/central.rs
+++ b/crypto/src/test_utils/central.rs
@@ -455,15 +455,14 @@ impl MlsCentral {
     pub fn verify_sender_identity(&self, case: &TestCase, decrypted: &MlsConversationDecryptMessage) {
         let mls_client = self.mls_client.as_ref().unwrap();
         let (sc, ct) = (case.signature_scheme(), case.credential_type);
-        let cb = mls_client.find_most_recent_credential_bundle(sc, ct).unwrap();
-        let sender_credential = cb.credential();
+        let sender_cb = mls_client.find_most_recent_credential_bundle(sc, ct).unwrap();
 
         if let openmls::prelude::MlsCredentialType::X509(openmls::prelude::Certificate {
             identity: dup_client_id,
             cert_data: cert_chain,
-        }) = &sender_credential.mls_credential()
+        }) = &sender_cb.credential().mls_credential()
         {
-            let leaf: Vec<u8> = cert_chain.get(0).map(|c| c.clone().into()).unwrap();
+            let leaf: Vec<u8> = cert_chain.first().unwrap().clone().into();
             let identity = leaf.as_slice().extract_identity().unwrap();
             let decr_identity = decrypted.identity.as_ref().unwrap();
             assert_eq!(decr_identity.client_id, identity.client_id);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
