### PR TITLE
feat: adjust max past epoch [WPB-505]

### DIFF
--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -30,7 +30,7 @@ use crate::mls::credential::trust_anchor::PerDomainTrustAnchor;
 use crate::prelude::{CryptoResult, MlsCiphersuite};
 
 /// Sets the config in OpenMls for the oldest possible epoch(past current) that a message can be decrypted
-pub(crate) const MAX_PAST_EPOCHS: usize = 2;
+pub(crate) const MAX_PAST_EPOCHS: usize = 3;
 
 /// The configuration parameters for a group/conversation
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Client `max_past_epoch` should be backend's one + 1 since there might be unordered messages. Also removed a useless check

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
