### PR TITLE
feat!: buffer messages from future epochs [WPB-3786]

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -919,7 +919,12 @@ export class CoreCrypto {
     }
 
     /**
-     * Decrypts a message for a given conversation
+     * Decrypts a message for a given conversation.
+     *
+     * Note: you should catch & ignore the following error reasons:
+     * * "We already decrypted this message once"
+     * * "You tried to join with an external commit but did not merge it yet. We will reapply this message for you when you merge your external commit"
+     * * "Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives"
      *
      * @param conversationId - The ID of the conversation
      * @param payload - The encrypted message buffer
@@ -1337,6 +1342,7 @@ export class CoreCrypto {
      * and deletes the temporary one. This step makes the group operational and ready to encrypt/decrypt message
      *
      * @param conversationId - The ID of the conversation
+     * @returns the messages from current epoch which had been buffered, if any
      */
     async mergePendingGroupFromExternalCommit(conversationId: ConversationId): Promise<DecryptedMessage[] | undefined> {
         return await CoreCryptoError.asyncMapErr(this.#cc.merge_pending_group_from_external_commit(conversationId));
@@ -1358,8 +1364,9 @@ export class CoreCrypto {
      * into the local group state
      *
      * @param conversationId - The group's ID
+     * @returns the messages from current epoch which had been buffered, if any
      */
-    async commitAccepted(conversationId: ConversationId): Promise<void> {
+    async commitAccepted(conversationId: ConversationId): Promise<DecryptedMessage[] | undefined> {
         return await CoreCryptoError.asyncMapErr(this.#cc.commit_accepted(conversationId));
     }
 

--- a/crypto-ffi/bindings/kt/main/com/wire/crypto/client/MLSClient.kt
+++ b/crypto-ffi/bindings/kt/main/com/wire/crypto/client/MLSClient.kt
@@ -105,7 +105,7 @@ interface MLSClient {
         addTrustAnchors: List<PerDomainTrustAnchor>,
     ): CommitBundle?
 
-    suspend fun commitAccepted(groupId: MLSGroupId)
+    suspend fun commitAccepted(groupId: MLSGroupId): List<DecryptedMessage>?
 
     suspend fun commitPendingProposals(groupId: MLSGroupId): CommitBundle?
 
@@ -234,8 +234,8 @@ class MLSClientImpl(
         return cc.decryptMessage(groupId.toUByteList(), message.toUByteList()).toDecryptedMessageBundle()
     }
 
-    override suspend fun commitAccepted(groupId: MLSGroupId) {
-        cc.commitAccepted(groupId.toUByteList())
+    override suspend fun commitAccepted(groupId: MLSGroupId): List<DecryptedMessage>? {
+        return cc.commitAccepted(groupId.toUByteList())
     }
 
     override suspend fun commitPendingProposals(groupId: MLSGroupId): CommitBundle? {

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -723,6 +723,10 @@ public class CoreCryptoWrapper {
     }
 
     /// Deserializes a TLS-serialized message, then deciphers it
+    /// Note: you should catch & ignore the following error:
+    /// - `DuplicateMessage`
+    /// - `UnmergedPendingGroup`
+    /// - `BufferedFutureMessage`
     ///
     /// - parameter conversationId: conversation identifier
     /// - parameter payload: the encrypted message as a byte array
@@ -811,6 +815,7 @@ public class CoreCryptoWrapper {
     /// deletes the temporary one. After merging, the group should be fully functional.
     ///
     /// - parameter conversationId: conversation identifier
+    /// - returns the messages from current epoch which had been buffered, if any
     public func mergePendingGroupFromExternalCommit(conversationId: ConversationId) async throws -> [DecryptedMessage]? {
         try await self.coreCrypto.mergePendingGroupFromExternalCommit(conversationId: conversationId)
     }
@@ -861,7 +866,8 @@ public class CoreCryptoWrapper {
     /// in the keystore. The previous can be discarded to respect Forward Secrecy.
     ///
     /// - parameter conversationId: conversation identifier
-    public func commitAccepted(conversationId: ConversationId) async throws {
+    /// - returns the messages from current epoch which had been buffered, if any
+    public func commitAccepted(conversationId: ConversationId) async throws -> [DecryptedMessage]? {
         try await self.coreCrypto.commitAccepted(conversationId: conversationId)
     }
 

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -164,6 +164,7 @@ enum CryptoError {
     "InvalidHashReference",
     "DuplicateMessage",
     "WrongEpoch",
+    "BufferedFutureMessage",
     "DecryptionError",
     "HexDecodeError",
     "ProteusError",

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -863,8 +863,17 @@ impl CoreCrypto {
     }
 
     /// See [core_crypto::mls::MlsCentral::commit_accepted]
-    pub async fn commit_accepted(&self, conversation_id: Vec<u8>) -> CryptoResult<()> {
-        self.central.lock().await.commit_accepted(&conversation_id).await
+    pub async fn commit_accepted(&self, conversation_id: Vec<u8>) -> CryptoResult<Option<Vec<DecryptedMessage>>> {
+        if let Some(decrypted_messages) = self.central.lock().await.commit_accepted(&conversation_id).await? {
+            return Ok(Some(
+                decrypted_messages
+                    .into_iter()
+                    .map(DecryptedMessage::try_from)
+                    .collect::<CryptoResult<Vec<_>>>()?,
+            ));
+        }
+
+        Ok(None)
     }
 
     /// See [core_crypto::mls::MlsCentral::clear_pending_proposal]

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -122,6 +122,9 @@ pub enum CryptoError {
     /// Incoming message is for the wrong epoch
     #[error("Incoming message is for the wrong epoch")]
     WrongEpoch,
+    /// Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives
+    #[error("Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives")]
+    BufferedFutureMessage,
     /// Proteus Error Wrapper
     #[error(transparent)]
     ProteusError(#[from] ProteusError),

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -1,30 +1,79 @@
-//! This file is intended to fix some issues we have with the Delivery Service. When a client joins
-//! a group via an external commit, it sometimes receives messages (most of the time renewed external
-//! proposals) for the new epoch whereas it does not yet have the confirmation from the DS that his
-//! external has been accepted. Hence it is not merged locally and it cannot decrypt any message.
+//! This file is intended to fix some issues we have with the Delivery Service. Sometimes, clients
+//! receive for the next epoch before receiving the commit for this epoch.
 //!
 //! Feel free to delete all of this when the issue is fixed on the DS side !
 
-use crate::prelude::{ConversationId, CryptoError, CryptoResult, MlsCentral, MlsConversationDecryptMessage};
-use core_crypto_keystore::entities::{MlsPendingMessage, PersistedMlsPendingGroup};
+use crate::prelude::{
+    ConversationId, CryptoError, CryptoResult, MlsCentral, MlsConversation, MlsConversationDecryptMessage,
+};
+use crate::MlsError;
+use core_crypto_keystore::entities::{EntityFindParams, MlsPendingMessage};
+use openmls::prelude::{MlsMessageIn, MlsMessageInBody};
+use tls_codec::Deserialize;
 
 impl MlsCentral {
-    pub(crate) async fn handle_when_group_is_pending(
+    pub(crate) async fn handle_future_message(
         &mut self,
         id: &ConversationId,
         message: impl AsRef<[u8]>,
     ) -> CryptoResult<MlsConversationDecryptMessage> {
         let keystore = self.mls_backend.borrow_keystore();
-        let Ok(Some(pending_group)) = keystore.find::<PersistedMlsPendingGroup>(id).await else {
-            return Err(CryptoError::ConversationNotFound(id.clone()));
-        };
 
         let pending_msg = MlsPendingMessage {
-            id: pending_group.id.clone(),
+            id: id.clone(),
             message: message.as_ref().to_vec(),
         };
         keystore.save::<MlsPendingMessage>(pending_msg).await?;
-        Err(CryptoError::UnmergedPendingGroup)
+        Err(CryptoError::BufferedFutureMessage)
+    }
+
+    pub(crate) async fn restore_pending_messages(
+        &mut self,
+        conversation: &mut MlsConversation,
+    ) -> CryptoResult<Option<Vec<MlsConversationDecryptMessage>>> {
+        let keystore = self.mls_backend.borrow_keystore();
+
+        let mut pending_messages = keystore
+            .find_all::<MlsPendingMessage>(EntityFindParams::default())
+            .await?
+            .into_iter()
+            .filter(|pm| pm.id == conversation.id.as_slice())
+            .try_fold(vec![], |mut acc, m| {
+                let msg = MlsMessageIn::tls_deserialize_bytes(m.message.as_slice()).map_err(MlsError::from)?;
+                let ct = match msg.body_as_ref() {
+                    MlsMessageInBody::PublicMessage(m) => Ok(m.content_type()),
+                    MlsMessageInBody::PrivateMessage(m) => Ok(m.content_type()),
+                    _ => Err(CryptoError::ImplementationError),
+                }?;
+                acc.push((ct as u8, msg));
+                CryptoResult::Ok(acc)
+            })?;
+
+        // We want to restore application messages first, then Proposals & finally Commits
+        // luckily for us that's the exact same order as the [ContentType] enum
+        pending_messages.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let mut decrypted_messages = vec![];
+        for (_, m) in pending_messages {
+            let parent_conversation = if let Some(parent_id) = &conversation.parent_id {
+                Some(
+                    self.get_conversation(parent_id)
+                        .await
+                        .map_err(|_| CryptoError::ParentGroupNotFound)?,
+                )
+            } else {
+                None
+            };
+            let callbacks = self.callbacks.as_ref().map(|boxed| boxed.as_ref());
+            let decrypted = conversation
+                .decrypt_message(m, parent_conversation, self.mls_client()?, &self.mls_backend, callbacks)
+                .await?;
+            decrypted_messages.push(decrypted);
+        }
+
+        let decrypted_messages = (!decrypted_messages.is_empty()).then_some(decrypted_messages);
+
+        Ok(decrypted_messages)
     }
 }
 
@@ -39,7 +88,7 @@ pub mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_buffer_and_reapply_messages_after_external_commit_merged(case: TestCase) {
+    pub async fn should_buffer_and_reapply_messages_after_commit_merged(case: TestCase) {
         run_test_with_client_ids(
             case.clone(),
             ["alice", "bob", "charlie", "debbie"],
@@ -50,17 +99,14 @@ pub mod tests {
                         .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
+                    alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
 
-                    // Bob tries to join Alice's group with an external commit
-                    let gi = alice_central.get_group_info(&id).await;
-                    let external_commit = bob_central
-                        .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
-                        .await
-                        .unwrap();
+                    // Bob creates a commit but won't merge it immediately
+                    let unmerged_commit = bob_central.update_keying_material(&id).await.unwrap();
 
-                    // Alice decrypts the external commit...
+                    // Alice decrypts the commit...
                     alice_central
-                        .decrypt_message(&id, external_commit.commit.to_bytes().unwrap())
+                        .decrypt_message(&id, unmerged_commit.commit.to_bytes().unwrap())
                         .await
                         .unwrap();
 
@@ -73,11 +119,7 @@ pub mod tests {
 
                     // ...then Alice generates new messages for this epoch
                     let app_msg = alice_central.encrypt_message(&id, b"Hello Bob !").await.unwrap();
-                    let proposal = alice_central
-                        .new_update_proposal(&id)
-                        .await
-                        .unwrap()
-                        .proposal;
+                    let proposal = alice_central.new_update_proposal(&id).await.unwrap().proposal;
                     alice_central
                         .decrypt_message(&id, external_proposal.to_bytes().unwrap())
                         .await
@@ -88,22 +130,30 @@ pub mod tests {
                         .await
                         .unwrap();
                     alice_central.commit_accepted(&id).await.unwrap();
-                    charlie_central.process_welcome_message(commit.welcome.clone().into(), case.custom_cfg()).await.unwrap();
-                    debbie_central.process_welcome_message(commit.welcome.clone().into(), case.custom_cfg()).await.unwrap();
+                    charlie_central
+                        .process_welcome_message(commit.welcome.clone().into(), case.custom_cfg())
+                        .await
+                        .unwrap();
+                    debbie_central
+                        .process_welcome_message(commit.welcome.clone().into(), case.custom_cfg())
+                        .await
+                        .unwrap();
 
-                    // And now Bob will have to decrypt those messages while he hasn't yet merged its external commit
+                    // And now Bob will have to decrypt those messages while he hasn't yet merged its commit
                     // To add more fun, he will buffer the messages in exactly the wrong order (to make
                     // sure he reapplies them in the right order afterwards)
-                    let messages = vec![commit.commit, external_proposal, proposal].into_iter().map(|m| m.to_bytes().unwrap());
+                    let messages = vec![commit.commit, external_proposal, proposal]
+                        .into_iter()
+                        .map(|m| m.to_bytes().unwrap());
                     for m in messages {
                         let decrypt = bob_central.decrypt_message(&id, m).await;
-                        assert!(matches!(decrypt.unwrap_err(), CryptoError::UnmergedPendingGroup));
+                        assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
                     }
                     let decrypt = bob_central.decrypt_message(&id, app_msg).await;
-                        assert!(matches!(decrypt.unwrap_err(), CryptoError::UnmergedPendingGroup));
+                    assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
 
                     // Finally, Bob receives the green light from the DS and he can merge the external commit
-                    let Some(restored_messages) = bob_central.merge_pending_group_from_external_commit(&id).await.unwrap() else {
+                    let Some(restored_messages) = bob_central.commit_accepted(&id).await.unwrap() else {
                         panic!("Alice's messages should have been restored at this point");
                     };
                     for (i, m) in restored_messages.into_iter().enumerate() {
@@ -125,7 +175,7 @@ pub mod tests {
                             }
                             _ => unreachable!(),
                         }
-                    };
+                    }
                     // because external commit got merged
                     assert!(bob_central.try_talk_to(&id, &mut alice_central).await.is_ok());
                     // because Alice's commit got merged
@@ -134,7 +184,12 @@ pub mod tests {
                     assert!(bob_central.try_talk_to(&id, &mut debbie_central).await.is_ok());
 
                     // After merging we should erase all those pending messages
-                    let count_pending_messages = bob_central.mls_backend.key_store().count::<MlsPendingMessage>().await.unwrap();
+                    let count_pending_messages = bob_central
+                        .mls_backend
+                        .key_store()
+                        .count::<MlsPendingMessage>()
+                        .await
+                        .unwrap();
                     assert_eq!(count_pending_messages, 0);
                 })
             },

--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -1368,7 +1368,7 @@ pub mod tests {
 
                         // fails when a commit is skipped
                         let out_of_order = bob_central.decrypt_message(&id, &commit2).await;
-                        assert!(matches!(out_of_order.unwrap_err(), CryptoError::WrongEpoch));
+                        assert!(matches!(out_of_order.unwrap_err(), CryptoError::BufferedFutureMessage));
                         // works in the right order though
                         assert!(bob_central.decrypt_message(&id, &commit1).await.is_ok());
                         assert!(bob_central.decrypt_message(&id, &commit2).await.is_ok());

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -43,6 +43,7 @@ use crate::{
     prelude::{CryptoError, CryptoResult, MlsCiphersuite, MlsCredentialType, MlsError},
 };
 
+mod buffer_messages;
 mod commit_delay;
 pub mod config;
 #[cfg(test)]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Regular group members were also impacted by unordered messages. As a consequence, messages from future epochs are now buffered.

* `decryptMessage` might throw a `BufferedFutureMessage` error which you should catch & ignore
* `commitAccepted` now returns an optional list of decrypted messages

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
