### PR TITLE
feat!: also restore buffered messages on the receiver side [WPB-3786]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
@@ -180,7 +180,7 @@ class MLSClient(private val cc: com.wire.crypto.CoreCrypto) {
      * @param id conversation identifier
      * @return eventually decrypted buffered messages if any
      */
-    suspend fun mergePendingGroupFromExternalCommit(id: MLSGroupId): List<DecryptedMessage>? {
+    suspend fun mergePendingGroupFromExternalCommit(id: MLSGroupId): List<BufferedDecryptedMessage>? {
         return cc.mergePendingGroupFromExternalCommit(id.lower())?.map { it.lift() }
     }
 
@@ -373,7 +373,7 @@ class MLSClient(private val cc: com.wire.crypto.CoreCrypto) {
      *
      * @param id conversation identifier
      */
-    suspend fun commitAccepted(id: MLSGroupId): List<DecryptedMessage>? {
+    suspend fun commitAccepted(id: MLSGroupId): List<BufferedDecryptedMessage>? {
         return cc.commitAccepted(id.lower())?.map { it.lift() }
     }
 

--- a/crypto-ffi/src/CoreCrypto.udl
+++ b/crypto-ffi/src/CoreCrypto.udl
@@ -38,6 +38,17 @@ dictionary DecryptedMessage {
     ClientId? sender_client_id;
     boolean has_epoch_changed;
     WireIdentity? identity;
+    sequence<BufferedDecryptedMessage>? buffered_messages;
+};
+
+dictionary BufferedDecryptedMessage {
+    bytes? message;
+    sequence<ProposalBundle> proposals;
+    boolean is_active;
+    u64? commit_delay;
+    ClientId? sender_client_id;
+    boolean has_epoch_changed;
+    WireIdentity? identity;
 };
 
 dictionary WireIdentity {

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -47,6 +47,7 @@ indexmap = "2"
 x509-cert = "0.2"
 pem = "3.0"
 oid-registry = "0.6"
+async-recursion = "1"
 
 [dependencies.proteus-wasm]
 version = "2.1"

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -82,7 +82,7 @@ pub mod prelude {
             config::MlsCentralConfiguration,
             conversation::{
                 config::{MlsConversationConfiguration, MlsCustomConfiguration, MlsWirePolicy},
-                decrypt::MlsConversationDecryptMessage,
+                decrypt::{MlsBufferedConversationDecryptMessage, MlsConversationDecryptMessage},
                 group_info::{GroupInfoPayload, MlsGroupInfoBundle, MlsGroupInfoEncryptionType, MlsRatchetTreeType},
                 handshake::{MlsCommitBundle, MlsConversationCreationMessage, MlsProposalBundle},
                 *,

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -3,11 +3,14 @@
 //!
 //! Feel free to delete all of this when the issue is fixed on the DS side !
 
+use crate::group_store::GroupStoreValue;
+use crate::prelude::decrypt::MlsBufferedConversationDecryptMessage;
 use crate::prelude::{
-    ConversationId, CryptoError, CryptoResult, MlsCentral, MlsConversation, MlsConversationDecryptMessage,
+    Client, ConversationId, CryptoError, CryptoResult, MlsCentral, MlsConversation, MlsConversationDecryptMessage,
 };
-use crate::MlsError;
+use crate::{CoreCryptoCallbacks, MlsError};
 use core_crypto_keystore::entities::{EntityFindParams, MlsPendingMessage};
+use mls_crypto_provider::MlsCryptoProvider;
 use openmls::prelude::{MlsMessageIn, MlsMessageInBody};
 use tls_codec::Deserialize;
 
@@ -30,14 +33,40 @@ impl MlsCentral {
     pub(crate) async fn restore_pending_messages(
         &mut self,
         conversation: &mut MlsConversation,
-    ) -> CryptoResult<Option<Vec<MlsConversationDecryptMessage>>> {
-        let keystore = self.mls_backend.borrow_keystore();
+    ) -> CryptoResult<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
+        let parent_conversation = match &conversation.parent_id {
+            Some(id) => self.get_conversation(id).await.ok(),
+            _ => None,
+        };
+        let callbacks = self.callbacks.as_ref().map(|boxed| boxed.as_ref());
+        conversation
+            .restore_pending_messages(
+                self.mls_client()?,
+                &self.mls_backend,
+                callbacks,
+                parent_conversation.as_ref(),
+            )
+            .await
+    }
+}
+
+impl MlsConversation {
+    #[cfg_attr(target_family = "wasm", async_recursion::async_recursion(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_recursion::async_recursion)]
+    pub(crate) async fn restore_pending_messages<'a>(
+        &'a mut self,
+        client: &'a Client,
+        backend: &'a MlsCryptoProvider,
+        callbacks: Option<&'a dyn CoreCryptoCallbacks>,
+        parent_conversation: Option<&'a GroupStoreValue<Self>>,
+    ) -> CryptoResult<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
+        let keystore = backend.borrow_keystore();
 
         let mut pending_messages = keystore
             .find_all::<MlsPendingMessage>(EntityFindParams::default())
             .await?
             .into_iter()
-            .filter(|pm| pm.id == conversation.id.as_slice())
+            .filter(|pm| pm.id == self.id.as_slice())
             .try_fold(vec![], |mut acc, m| {
                 let msg = MlsMessageIn::tls_deserialize_bytes(m.message.as_slice()).map_err(MlsError::from)?;
                 let ct = match msg.body_as_ref() {
@@ -53,22 +82,17 @@ impl MlsCentral {
         // luckily for us that's the exact same order as the [ContentType] enum
         pending_messages.sort_by(|(a, _), (b, _)| a.cmp(b));
 
-        let mut decrypted_messages = vec![];
+        let mut decrypted_messages = Vec::with_capacity(pending_messages.len());
         for (_, m) in pending_messages {
-            let parent_conversation = if let Some(parent_id) = &conversation.parent_id {
-                Some(
-                    self.get_conversation(parent_id)
-                        .await
-                        .map_err(|_| CryptoError::ParentGroupNotFound)?,
-                )
-            } else {
-                None
+            let parent_conversation = match &self.parent_id {
+                Some(_) => Some(parent_conversation.ok_or(CryptoError::ParentGroupNotFound)?),
+                _ => None,
             };
-            let callbacks = self.callbacks.as_ref().map(|boxed| boxed.as_ref());
-            let decrypted = conversation
-                .decrypt_message(m, parent_conversation, self.mls_client()?, &self.mls_backend, callbacks)
+            let restore_pending = false; // to prevent infinite recursion
+            let decrypted = self
+                .decrypt_message(m, parent_conversation, client, backend, callbacks, restore_pending)
                 .await?;
-            decrypted_messages.push(decrypted);
+            decrypted_messages.push(decrypted.into());
         }
 
         let decrypted_messages = (!decrypted_messages.is_empty()).then_some(decrypted_messages);
@@ -80,15 +104,13 @@ impl MlsCentral {
 #[cfg(test)]
 pub mod tests {
     use crate::{test_utils::*, CryptoError};
-    use core_crypto_keystore::entities::MlsPendingMessage;
-    use openmls_traits::OpenMlsCryptoProvider;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_buffer_and_reapply_messages_after_commit_merged(case: TestCase) {
+    pub async fn should_buffer_and_reapply_messages_after_commit_merged_for_sender(case: TestCase) {
         run_test_with_client_ids(
             case.clone(),
             ["alice", "bob", "charlie", "debbie"],
@@ -152,6 +174,9 @@ pub mod tests {
                     let decrypt = bob_central.decrypt_message(&id, app_msg).await;
                     assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
 
+                    // Bob should have buffered the messages
+                    assert_eq!(bob_central.count_entities().await.pending_messages, 4);
+
                     // Finally, Bob receives the green light from the DS and he can merge the external commit
                     let Some(restored_messages) = bob_central.commit_accepted(&id).await.unwrap() else {
                         panic!("Alice's messages should have been restored at this point");
@@ -184,13 +209,117 @@ pub mod tests {
                     assert!(bob_central.try_talk_to(&id, &mut debbie_central).await.is_ok());
 
                     // After merging we should erase all those pending messages
-                    let count_pending_messages = bob_central
-                        .mls_backend
-                        .key_store()
-                        .count::<MlsPendingMessage>()
+                    assert_eq!(bob_central.count_entities().await.pending_messages, 0);
+                })
+            },
+        )
+        .await
+    }
+
+    #[apply(all_cred_cipher)]
+    #[wasm_bindgen_test]
+    pub async fn should_buffer_and_reapply_messages_after_commit_merged_for_receivers(case: TestCase) {
+        run_test_with_client_ids(
+            case.clone(),
+            ["alice", "bob", "charlie", "debbie"],
+            move |[mut alice_central, mut bob_central, mut charlie_central, mut debbie_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .new_conversation(id.clone(), case.credential_type, case.cfg.clone())
                         .await
                         .unwrap();
-                    assert_eq!(count_pending_messages, 0);
+
+                    // Bob joins the group with an external commit...
+                    let gi = alice_central.get_group_info(&id).await;
+                    let ext_commit = bob_central
+                        .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
+                        .await
+                        .unwrap();
+                    bob_central.merge_pending_group_from_external_commit(&id).await.unwrap();
+
+                    // And before others had the chance to get the commit, Bob will create & send messages in the next epoch
+                    // which Alice will have to buffer until she receives the commit.
+                    // This simulates what the DS does with unordered messages
+                    let epoch = bob_central.conversation_epoch(&id).await.unwrap();
+                    let external_proposal = charlie_central
+                        .new_external_add_proposal(id.clone(), epoch.into(), case.ciphersuite(), case.credential_type)
+                        .await
+                        .unwrap();
+                    let app_msg = bob_central.encrypt_message(&id, b"Hello Alice !").await.unwrap();
+                    let proposal = bob_central.new_update_proposal(&id).await.unwrap().proposal;
+                    bob_central
+                        .decrypt_message(&id, external_proposal.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    let debbie = debbie_central.rand_member(&case).await;
+                    let commit = bob_central
+                        .add_members_to_conversation(&id, &mut [debbie])
+                        .await
+                        .unwrap();
+                    bob_central.commit_accepted(&id).await.unwrap();
+                    charlie_central
+                        .process_welcome_message(commit.welcome.clone().into(), case.custom_cfg())
+                        .await
+                        .unwrap();
+                    debbie_central
+                        .process_welcome_message(commit.welcome.clone().into(), case.custom_cfg())
+                        .await
+                        .unwrap();
+
+                    // And now Alice will have to decrypt those messages while he hasn't yet merged the commit
+                    // To add more fun, he will buffer the messages in exactly the wrong order (to make
+                    // sure he reapplies them in the right order afterwards)
+                    let messages = vec![commit.commit, external_proposal, proposal]
+                        .into_iter()
+                        .map(|m| m.to_bytes().unwrap());
+                    for m in messages {
+                        let decrypt = alice_central.decrypt_message(&id, m).await;
+                        assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                    }
+                    let decrypt = alice_central.decrypt_message(&id, app_msg).await;
+                    assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+
+                    // Alice should have buffered the messages
+                    assert_eq!(alice_central.count_entities().await.pending_messages, 4);
+
+                    // Finally, Alice receives the original commit for this epoch
+                    let original_commit = ext_commit.commit.to_bytes().unwrap();
+
+
+                    let Some(restored_messages) = alice_central.decrypt_message(&id, original_commit).await.unwrap().buffered_messages else {
+                        panic!("Bob's messages should have been restored at this point");
+                    };
+                    for (i, m) in restored_messages.into_iter().enumerate() {
+                        match i {
+                            0 => {
+                                // this is the application message
+                                assert_eq!(&m.app_msg.unwrap(), b"Hello Alice !");
+                                assert!(!m.has_epoch_changed);
+                            }
+                            1 | 2 => {
+                                // this is either the member or the external proposal
+                                assert!(m.app_msg.is_none());
+                                assert!(!m.has_epoch_changed);
+                            }
+                            3 => {
+                                // this is the commit
+                                assert!(m.app_msg.is_none());
+                                assert!(m.has_epoch_changed);
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    // because external commit got merged
+                    assert!(alice_central.try_talk_to(&id, &mut bob_central).await.is_ok());
+                    // because Alice's commit got merged
+                    assert!(alice_central.try_talk_to(&id, &mut charlie_central).await.is_ok());
+                    // because Debbie's external proposal got merged through the commit
+                    assert!(alice_central.try_talk_to(&id, &mut debbie_central).await.is_ok());
+
+                    // After merging we should erase all those pending messages
+                    assert_eq!(alice_central.count_entities().await.pending_messages, 0);
+
                 })
             },
         )

--- a/crypto/src/mls/conversation/db_count.rs
+++ b/crypto/src/mls/conversation/db_count.rs
@@ -1,7 +1,7 @@
 use crate::prelude::MlsCentral;
 use core_crypto_keystore::entities::{
     E2eiEnrollment, MlsCredential, MlsEncryptionKeyPair, MlsEpochEncryptionKeyPair, MlsHpkePrivateKey, MlsKeyPackage,
-    MlsPskBundle, MlsSignatureKeyPair, PersistedMlsGroup, PersistedMlsPendingGroup,
+    MlsPendingMessage, MlsPskBundle, MlsSignatureKeyPair, PersistedMlsGroup, PersistedMlsPendingGroup,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -14,6 +14,7 @@ pub struct EntitiesCount {
     pub hpke_private_key: usize,
     pub key_package: usize,
     pub pending_group: usize,
+    pub pending_messages: usize,
     /// TODO: PreSharedKey are never ever deleted by openmls. Pay attention to this we introducing them
     pub psk_bundle: usize,
     pub signature_keypair: usize,
@@ -30,6 +31,7 @@ impl MlsCentral {
         let hpke_private_key = keystore.count::<MlsHpkePrivateKey>().await.unwrap();
         let key_package = keystore.count::<MlsKeyPackage>().await.unwrap();
         let pending_group = keystore.count::<PersistedMlsPendingGroup>().await.unwrap();
+        let pending_messages = keystore.count::<MlsPendingMessage>().await.unwrap();
         let psk_bundle = keystore.count::<MlsPskBundle>().await.unwrap();
         let signature_keypair = keystore.count::<MlsSignatureKeyPair>().await.unwrap();
         EntitiesCount {
@@ -41,6 +43,7 @@ impl MlsCentral {
             hpke_private_key,
             key_package,
             pending_group,
+            pending_messages,
             psk_bundle,
             signature_keypair,
         }

--- a/crypto/src/mls/conversation/handshake.rs
+++ b/crypto/src/mls/conversation/handshake.rs
@@ -1369,9 +1369,10 @@ pub mod tests {
                         // fails when a commit is skipped
                         let out_of_order = bob_central.decrypt_message(&id, &commit2).await;
                         assert!(matches!(out_of_order.unwrap_err(), CryptoError::BufferedFutureMessage));
+
                         // works in the right order though
-                        assert!(bob_central.decrypt_message(&id, &commit1).await.is_ok());
-                        assert!(bob_central.decrypt_message(&id, &commit2).await.is_ok());
+                        // NB: here 'commit2' has been buffered so it is also applied when we decrypt commit1
+                        bob_central.decrypt_message(&id, &commit1).await.unwrap();
 
                         // and then fails again when trying to decrypt a commit with an epoch in the past
                         let past_commit = bob_central.decrypt_message(&id, &commit1).await;

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -17,9 +17,9 @@ use openmls_traits::OpenMlsCryptoProvider;
 
 use mls_crypto_provider::MlsCryptoProvider;
 
-use crate::prelude::{MlsConversationDecryptMessage, MlsProposalRef};
 use crate::{
     mls::{ConversationId, MlsCentral, MlsConversation},
+    prelude::{decrypt::MlsBufferedConversationDecryptMessage, MlsProposalRef},
     CryptoError, CryptoResult, MlsError,
 };
 
@@ -94,7 +94,7 @@ impl MlsCentral {
     pub async fn commit_accepted(
         &mut self,
         id: &ConversationId,
-    ) -> CryptoResult<Option<Vec<MlsConversationDecryptMessage>>> {
+    ) -> CryptoResult<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
         let conv = self.get_conversation(id).await?;
         let mut conv = conv.write().await;
         conv.commit_accepted(&self.mls_backend).await?;

--- a/crypto/src/mls/conversation/self_commit.rs
+++ b/crypto/src/mls/conversation/self_commit.rs
@@ -84,6 +84,7 @@ impl MlsConversation {
             sender_client_id: None,
             has_epoch_changed: true,
             identity,
+            buffered_messages: None,
         })
     }
 }

--- a/crypto/src/mls/credential/trust_anchor.rs
+++ b/crypto/src/mls/credential/trust_anchor.rs
@@ -1647,10 +1647,8 @@ mod tests {
                             .await;
                         alice_central.commit_accepted(&id).await.unwrap();
                         // bob parses the commit
-                        let error = bob_central
-                            .decrypt_message(&id, &commit.to_bytes().unwrap())
-                            .await
-                            .unwrap_err();
+                        let message = &commit.to_bytes().unwrap();
+                        let error = bob_central.decrypt_message(&id, message).await.unwrap_err();
 
                         assert!(matches!(
                             error,

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -21,12 +21,13 @@ use core_crypto_keystore::entities::MlsPendingMessage;
 use core_crypto_keystore::{entities::PersistedMlsPendingGroup, CryptoKeystoreMls};
 use tls_codec::Serialize;
 
+use crate::prelude::decrypt::MlsBufferedConversationDecryptMessage;
 use crate::{
     group_store::GroupStoreValue,
     prelude::{
         id::ClientId, ConversationId, CoreCryptoCallbacks, CryptoError, CryptoResult, MlsCentral, MlsCiphersuite,
-        MlsConversation, MlsConversationConfiguration, MlsConversationDecryptMessage, MlsCredentialType,
-        MlsCustomConfiguration, MlsError, MlsGroupInfoBundle,
+        MlsConversation, MlsConversationConfiguration, MlsCredentialType, MlsCustomConfiguration, MlsError,
+        MlsGroupInfoBundle,
     },
 };
 
@@ -145,7 +146,7 @@ impl MlsCentral {
     pub async fn merge_pending_group_from_external_commit(
         &mut self,
         id: &ConversationId,
-    ) -> CryptoResult<Option<Vec<MlsConversationDecryptMessage>>> {
+    ) -> CryptoResult<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
         // Retrieve the pending MLS group from the keystore
         let (group, cfg) = self.mls_backend.key_store().mls_pending_groups_load(id).await?;
 
@@ -213,7 +214,7 @@ impl MlsConversation {
         &self,
         commit: &StagedCommit,
         sender: ClientId,
-        parent_conversation: Option<GroupStoreValue<MlsConversation>>,
+        parent_conversation: Option<&GroupStoreValue<MlsConversation>>,
         callbacks: Option<&dyn CoreCryptoCallbacks>,
     ) -> CryptoResult<()> {
         // i.e. has this commit been created by [MlsCentral::join_by_external_commit] ?

--- a/crypto/src/mls/external_proposal.rs
+++ b/crypto/src/mls/external_proposal.rs
@@ -18,7 +18,7 @@ impl MlsConversation {
     pub(crate) async fn validate_external_proposal(
         &self,
         proposal: &QueuedProposal,
-        parent_conversation: Option<GroupStoreValue<MlsConversation>>,
+        parent_conversation: Option<&GroupStoreValue<MlsConversation>>,
         callbacks: Option<&dyn CoreCryptoCallbacks>,
     ) -> CryptoResult<()> {
         let is_external_proposal = matches!(proposal.sender(), Sender::External(_) | Sender::NewMemberProposal);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The issue can of course also happen for receivers. Previous PR #383  was only considering the sender

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
