### PR TITLE
chore: quiet clippy new lint about non send in Arc because it comes from wasm-bindgen wrapped Javascript object which cannot be shared between threads anyway

### DIFF
--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-// FIXME
-#![allow(clippy::arc_with_non_send_sync)]
-
 use std::collections::HashMap;
 
 use core_crypto::prelude::*;
@@ -1026,6 +1023,7 @@ impl CoreCryptoWasmCallbacks {
         client_is_existing_group_user: js_sys::Function,
         ctx: JsValue,
     ) -> Self {
+        #[allow(clippy::arc_with_non_send_sync)] // see https://github.com/rustwasm/wasm-bindgen/pull/955
         Self {
             authorize: std::sync::Arc::new(authorize.into()),
             user_authorize: std::sync::Arc::new(user_authorize.into()),

--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-// FIXME
-#![allow(clippy::arc_with_non_send_sync)]
-
 pub mod platform {
     cfg_if::cfg_if! {
         if #[cfg(target_family = "wasm")] {
@@ -91,20 +88,20 @@ unsafe impl Sync for Connection {}
 
 impl Connection {
     pub async fn open_with_key(name: impl AsRef<str>, key: impl AsRef<str>) -> CryptoKeystoreResult<Self> {
-        let conn = Arc::new(
-            KeystoreDatabaseConnection::open(name.as_ref(), key.as_ref())
-                .await?
-                .into(),
-        );
+        let conn = KeystoreDatabaseConnection::open(name.as_ref(), key.as_ref())
+            .await?
+            .into();
+        #[allow(clippy::arc_with_non_send_sync)] // see https://github.com/rustwasm/wasm-bindgen/pull/955
+        let conn = Arc::new(conn);
         Ok(Self { conn })
     }
 
     pub async fn open_in_memory_with_key(name: impl AsRef<str>, key: impl AsRef<str>) -> CryptoKeystoreResult<Self> {
-        let conn = Arc::new(
-            KeystoreDatabaseConnection::open_in_memory(name.as_ref(), key.as_ref())
-                .await?
-                .into(),
-        );
+        let conn = KeystoreDatabaseConnection::open_in_memory(name.as_ref(), key.as_ref())
+            .await?
+            .into();
+        #[allow(clippy::arc_with_non_send_sync)] // see https://github.com/rustwasm/wasm-bindgen/pull/955
+        let conn = Arc::new(conn);
         Ok(Self { conn })
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
