### PR TITLE
feat!: add LeafNode validation [WPB-3731]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,25 +48,25 @@ branch = "2.x"
 package = "openmls"
 git = "https://github.com/wireapp/openmls"
 #tag = "v1.0.0-pre.core-crypto-1.0.0"
- branch = "feat/rfc9420"
+branch = "feat/rfc9420"
 
 [patch.crates-io.openmls_traits]
 package = "openmls_traits"
 git = "https://github.com/wireapp/openmls"
 #tag = "v1.0.0-pre.core-crypto-1.0.0"
- branch = "feat/rfc9420"
+branch = "feat/rfc9420"
 
 [patch.crates-io.openmls_basic_credential]
 package = "openmls_basic_credential"
 git = "https://github.com/wireapp/openmls"
 #tag = "v1.0.0-pre.core-crypto-1.0.0"
- branch = "feat/rfc9420"
+branch = "feat/rfc9420"
 
 [patch.crates-io.openmls_x509_credential]
 package = "openmls_x509_credential"
 git = "https://github.com/wireapp/openmls"
 #tag = "v1.0.0-pre.core-crypto-1.0.0"
- branch = "feat/rfc9420"
+branch = "feat/rfc9420"
 
 [patch.crates-io.hpke]
 git = "https://github.com/wireapp/rust-hpke.git"

--- a/crypto/benches/utils/mls.rs
+++ b/crypto/benches/utils/mls.rs
@@ -239,6 +239,7 @@ pub async fn rand_key_package(ciphersuite: MlsCiphersuite) -> (KeyPackage, Clien
 
     let cfg = CryptoConfig::with_default_version(cs);
     let kp = KeyPackage::builder()
+        .leaf_node_capabilities(MlsConversationConfiguration::default_leaf_capabilities())
         .build(cfg, &backend, &signer, credential)
         .await
         .unwrap();

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -341,6 +341,9 @@ pub enum MlsError {
     MlsUpdateExtensionsError(
         #[from] openmls::prelude::UpdateExtensionsError<core_crypto_keystore::CryptoKeystoreError>,
     ),
+    /// OpenMLS LeafNode validation error
+    #[error(transparent)]
+    MlsLeafNodeValidationError(#[from] openmls::prelude::LeafNodeValidationError),
 }
 
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]

--- a/crypto/src/mls/client/mod.rs
+++ b/crypto/src/mls/client/mod.rs
@@ -83,8 +83,7 @@ impl Client {
             .into_iter()
             .filter(|c| &c.id[..] == id.as_slice())
             .try_fold(vec![], |mut acc, c| {
-                let credential = openmls::prelude::Credential::tls_deserialize_bytes(c.credential.as_slice())
-                    .map_err(MlsError::from)?;
+                let credential = Credential::tls_deserialize_bytes(c.credential.as_slice()).map_err(MlsError::from)?;
                 acc.push((credential, c.created_at));
                 CryptoResult::Ok(acc)
             })?;

--- a/crypto/src/mls/conversation/leaf_node_validation.rs
+++ b/crypto/src/mls/conversation/leaf_node_validation.rs
@@ -1,0 +1,194 @@
+//! cf https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-validation
+
+#[cfg(test)]
+pub mod tests {
+    use openmls::prelude::Lifetime;
+    use wasm_bindgen_test::*;
+
+    use crate::prelude::ConversationMember;
+    use crate::test_utils::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    mod stages {
+        use openmls::prelude::{
+            AddMembersError, KeyPackageVerifyError, LeafNodeValidationError, ProcessMessageError,
+            ProposeAddMemberError, ValidationError, WelcomeError,
+        };
+
+        use crate::{CryptoError, MlsError};
+
+        use super::*;
+
+        /// The validity of a LeafNode needs to be verified at the following stages:
+        /// When a LeafNode is downloaded in a KeyPackage, before it is used to add the client to the group
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_validate_leaf_node_when_adding(case: TestCase) {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob"],
+                move |[mut alice_central, bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(&id, case.credential_type, case.cfg.clone())
+                            .await
+                            .unwrap();
+
+                        // should fail when creating Add proposal
+                        let invalid_kp = bob_central.new_invalid_keypackage(&case).await;
+
+                        let proposal_creation = alice_central.new_add_proposal(&id, invalid_kp).await;
+                        assert!(matches!(
+                            proposal_creation.unwrap_err(),
+                            CryptoError::MlsError(MlsError::ProposeAddMemberError(
+                                ProposeAddMemberError::KeyPackageVerifyError(KeyPackageVerifyError::InvalidLeafNode(_))
+                            ))
+                        ));
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+
+                        // should fail when creating Add commits
+                        let invalid_kp = bob_central.new_invalid_keypackage(&case).await;
+                        let invalid_member = ConversationMember::new(bob_central.get_client_id(), invalid_kp);
+                        let commit_creation = alice_central
+                            .add_members_to_conversation(&id, &mut [invalid_member])
+                            .await;
+
+                        assert!(matches!(
+                            commit_creation.unwrap_err(),
+                            CryptoError::MlsError(MlsError::MlsAddMembersError(
+                                AddMembersError::KeyPackageVerifyError(KeyPackageVerifyError::InvalidLeafNode(_))
+                            ))
+                        ));
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert!(alice_central.pending_commit(&id).await.is_none());
+                    })
+                },
+            )
+            .await
+        }
+
+        /// The validity of a LeafNode needs to be verified at the following stages:
+        /// When a LeafNode is received by a group member in an Add, Update, or Commit message
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_validate_leaf_node_when_receiving_expired_add_proposal(case: TestCase) {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(&id, case.credential_type, case.cfg.clone())
+                            .await
+                            .unwrap();
+                        alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
+
+                        let invalid_kp = charlie_central.new_keypackage(&case, Lifetime::new(1)).await;
+
+                        let proposal = alice_central.new_add_proposal(&id, invalid_kp).await.unwrap();
+                        let proposal = proposal.proposal.to_bytes().unwrap();
+
+                        async_std::task::sleep(core::time::Duration::from_secs(2)).await; // have it expire
+
+                        let decrypting = bob_central.decrypt_message(&id, proposal).await;
+                        assert!(matches!(
+                            decrypting.unwrap_err(),
+                            CryptoError::MlsError(MlsError::MlsMessageError(ProcessMessageError::ValidationError(
+                                ValidationError::KeyPackageVerifyError(KeyPackageVerifyError::InvalidLeafNode(
+                                    LeafNodeValidationError::Lifetime(_)
+                                ))
+                            )))
+                        ));
+                    })
+                },
+            )
+            .await
+        }
+
+        /// The validity of a LeafNode needs to be verified at the following stages:
+        /// When a LeafNode is received by a group member in an Add, Update, or Commit message
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_validate_leaf_node_when_receiving_add_commit(case: TestCase) {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, mut bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(&id, case.credential_type, case.cfg.clone())
+                            .await
+                            .unwrap();
+                        alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
+
+                        // should fail when receiving Add commit
+                        let invalid_kp = charlie_central.new_keypackage(&case, Lifetime::new(1)).await;
+                        let invalid_member = ConversationMember::new(bob_central.get_client_id(), invalid_kp);
+
+                        let commit = alice_central
+                            .add_members_to_conversation(&id, &mut [invalid_member])
+                            .await
+                            .unwrap();
+                        let commit = commit.commit.to_bytes().unwrap();
+
+                        async_std::task::sleep(core::time::Duration::from_secs(2)).await; // have it expire
+
+                        let decrypting = bob_central.decrypt_message(&id, commit).await;
+                        assert!(matches!(
+                            decrypting.unwrap_err(),
+                            CryptoError::MlsError(MlsError::MlsMessageError(ProcessMessageError::ValidationError(
+                                ValidationError::KeyPackageVerifyError(KeyPackageVerifyError::InvalidLeafNode(_))
+                            )))
+                        ));
+                    })
+                },
+            )
+            .await
+        }
+
+        /// The validity of a LeafNode needs to be verified at the following stages:
+        /// When a client validates a ratchet tree, e.g., when joining a group or after processing a Commit
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_validate_leaf_node_when_receiving_welcome(case: TestCase) {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob"],
+                move |[mut alice_central, mut bob_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .new_conversation(&id, case.credential_type, case.cfg.clone())
+                            .await
+                            .unwrap();
+
+                        let invalid_kp = bob_central.new_keypackage(&case, Lifetime::new(1)).await;
+                        let invalid_member = ConversationMember::new(bob_central.get_client_id(), invalid_kp);
+                        let commit = alice_central
+                            .add_members_to_conversation(&id, &mut [invalid_member])
+                            .await
+                            .unwrap();
+                        alice_central.commit_accepted(&id).await.unwrap();
+
+                        async_std::task::sleep(core::time::Duration::from_secs(2)).await; // have it expire
+
+                        let process_welcome = bob_central
+                            .process_welcome_message(commit.welcome.into(), case.custom_cfg())
+                            .await;
+                        assert!(matches!(
+                            process_welcome.unwrap_err(),
+                            CryptoError::MlsError(MlsError::MlsWelcomeError(WelcomeError::KeyPackageVerifyError(
+                                KeyPackageVerifyError::InvalidLeafNode(LeafNodeValidationError::Lifetime(_))
+                            )))
+                        ));
+                    })
+                },
+            )
+            .await
+        }
+    }
+}

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -56,13 +56,13 @@ pub mod encrypt;
 pub mod export;
 pub(crate) mod group_info;
 pub mod handshake;
+mod leaf_node_validation;
 pub mod merge;
 mod orphan_welcome;
 mod renew;
 mod self_commit;
 pub(crate) mod welcome;
 mod wipe;
-
 /// A unique identifier for a group/conversation. The identifier must be unique within a client.
 pub type ConversationId = Vec<u8>;
 

--- a/crypto/src/mls/credential/ext.rs
+++ b/crypto/src/mls/credential/ext.rs
@@ -60,7 +60,6 @@ impl CredentialExt for openmls::prelude::Certificate {
     fn extract_identity(&self) -> CryptoResult<Option<WireIdentity>> {
         let leaf = self.certificates.get(0).ok_or(CryptoError::InvalidIdentity)?;
         let leaf = leaf.as_slice();
-
         use wire_e2e_identity::prelude::WireIdentityReader as _;
         let identity = leaf.extract_identity().map_err(|_| CryptoError::InvalidIdentity)?;
         let identity = WireIdentity::try_from((identity, leaf))?;

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -71,7 +71,7 @@ impl MlsProposal {
         mut conversation: impl std::ops::DerefMut<Target = MlsConversation>,
     ) -> CryptoResult<MlsProposalBundle> {
         let proposal = match self {
-            MlsProposal::Add(key_package) => (*conversation).propose_add_member(client, backend, &key_package).await,
+            MlsProposal::Add(key_package) => (*conversation).propose_add_member(client, backend, key_package).await,
             MlsProposal::Update => (*conversation).propose_self_update(client, backend).await,
             MlsProposal::Remove(client_id) => {
                 let index = conversation


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Implement [RFC 9420 7.3](https://www.rfc-editor.org/rfc/rfc9420.html#name-leaf-node-validation)

* fix: generated LeafNodes capabilities as per spec /!\ Not backward compatible now that LeafNode validation in place
* fix: also fixes explicit updates (used in credential rotation) where LeafNode was not automatically rekeyed. No it is i.e. every update makes sure a new encryption key is created and replaces the previous one for the updated member.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
