### PR TITLE
fix: do not reapply buffered messages when rejoining with external commit

### DIFF
--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -174,7 +174,7 @@ impl MlsConversation {
 
                 let buffered_messages = if restore_pending {
                     if let Some(pm) = self
-                        .restore_pending_messages(client, backend, callbacks, parent_conv)
+                        .restore_pending_messages(client, backend, callbacks, parent_conv, false)
                         .await?
                     {
                         backend.key_store().remove::<MlsPendingMessage, _>(self.id()).await?;

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -99,7 +99,7 @@ impl MlsCentral {
         let mut conv = conv.write().await;
         conv.commit_accepted(&self.mls_backend).await?;
 
-        let pending_messages = self.restore_pending_messages(&mut conv).await?;
+        let pending_messages = self.restore_pending_messages(&mut conv, false).await?;
         if pending_messages.is_some() {
             self.mls_backend.key_store().remove::<MlsPendingMessage, _>(id).await?;
         }

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -166,11 +166,13 @@ impl MlsCentral {
             ..Default::default()
         };
 
+        let is_rejoin = self.mls_backend.key_store().mls_group_exists(id.as_slice()).await;
+
         // Persist the now usable MLS group in the keystore
         // TODO: find a way to make the insertion of the MlsGroup and deletion of the pending group transactional
         let mut conversation = MlsConversation::from_mls_group(mls_group, configuration, &self.mls_backend).await?;
 
-        let pending_messages = self.restore_pending_messages(&mut conversation).await?;
+        let pending_messages = self.restore_pending_messages(&mut conversation, is_rejoin).await?;
 
         self.mls_groups.insert(id.clone(), conversation);
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes an edge case when some handshake messages are dropped, external commit will contain a Remove Proposal i.e. try to rejoin the group. In that case, there's no need to try to decrypt buffered messages (it will likely fail)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
