### PR TITLE
feat!: e2ei changes [WPB-5470] [WPB-5473]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
@@ -454,10 +454,23 @@ class MLSClient(private val cc: com.wire.crypto.CoreCrypto) {
      * Certificate Credential (after turning on end-to-end identity).
      *
      * @param id conversation identifier
-     * @param clientIds identifiers of the user
+     * @param deviceIds identifiers of the devices
      * @returns identities or if no member has a x509 certificate, it will return an empty List
      */
-    suspend fun getUserIdentities(id: MLSGroupId, clientIds: List<ClientId>): List<WireIdentity> {
-        return cc.getUserIdentities(id.lower(), clientIds.map { it.lower() }).map { it.lift() }
+    suspend fun getDeviceIdentities(id: MLSGroupId, deviceIds: List<ClientId>): List<WireIdentity> {
+        return cc.getDeviceIdentities(id.lower(), deviceIds.map { it.lower() }).map { it.lift() }
+    }
+
+    /**
+     * From a given conversation, get the identity of the users (device holders) supplied.
+     * Identity is only present for devices with a Certificate Credential (after turning on end-to-end identity).
+     * If no member has a x509 certificate, it will return an empty Vec.
+     *
+     * @param id conversation identifier
+     * @param userIds user identifiers e.g. t6wRpI8BRSeviBwwiFp5MQ which is a base64UrlUnpadded UUIDv4
+     * @returns a Map with all the identities for a given users. Consumers are then recommended to reduce those identities to determine the actual status of a user.
+     */
+    suspend fun getUserIdentities(id: MLSGroupId, userIds: List<String>): Map<String, List<WireIdentity>> {
+        return cc.getUserIdentities(id.lower(), userIds).mapValues { (_, v) -> v.map { it.lift() } }
     }
 }

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MlsModel.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MlsModel.kt
@@ -368,7 +368,43 @@ data class WireIdentity(
     /**
      * X509 certificate identifying this client in the MLS group ; PEM encoded
      */
-    val certificate: String
+    val certificate: String,
+    /**
+     * Status of the Credential at the moment T when this object is created
+     */
+    val status: DeviceStatus,
+    /**
+     * MLS thumbprint
+     */
+    val thumbprint: String,
 )
 
-fun com.wire.crypto.WireIdentity.lift() = WireIdentity(clientId, handle, displayName, domain, certificate)
+fun com.wire.crypto.WireIdentity.lift() =
+    WireIdentity(clientId, handle, displayName, domain, certificate, status.lift(), thumbprint)
+
+/**
+ * Indicates the standalone status of a device Credential in a MLS group at a moment T. This does not represent the
+ * states where a device is not using MLS or is not using end-to-end identity
+ */
+enum class DeviceStatus {
+    /**
+     * All is fine
+     */
+    Valid,
+
+    /**
+     * The Credential's certificate is expired
+     */
+    Expired,
+
+    /**
+     * The Credential's certificate is revoked (not implemented yet)
+     */
+    Revoked,
+}
+
+fun com.wire.crypto.DeviceStatus.lift(): DeviceStatus = when (this) {
+    com.wire.crypto.DeviceStatus.VALID -> DeviceStatus.Valid
+    com.wire.crypto.DeviceStatus.EXPIRED -> DeviceStatus.Expired
+    com.wire.crypto.DeviceStatus.REVOKED -> DeviceStatus.Revoked
+}

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -51,6 +51,7 @@ pem = "3.0"
 oid-registry = "0.6"
 async-recursion = "1"
 uniffi = { workspace = true, optional = true }
+itertools = "0.12"
 
 [dependencies.proteus-wasm]
 version = "2.1"
@@ -101,6 +102,7 @@ async-trait = "0.1"
 wire-e2e-identity = { version = "0.5", features = ["identity-builder"] }
 fluvio-wasm-timer = "0.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }
+base64 = "0.21"
 
 [dev-dependencies.rcgen]
 git = "https://github.com/wireapp/rcgen"

--- a/crypto/src/e2e_identity/conversation_state.rs
+++ b/crypto/src/e2e_identity/conversation_state.rs
@@ -67,7 +67,7 @@ impl MlsConversation {
 #[cfg(test)]
 pub mod tests {
     use crate::{
-        e2e_identity::state::E2eiConversationState,
+        e2e_identity::conversation_state::E2eiConversationState,
         mls::credential::tests::now,
         prelude::{CertificateBundle, Client, MlsCredentialType},
         test_utils::*,

--- a/crypto/src/e2e_identity/device_status.rs
+++ b/crypto/src/e2e_identity/device_status.rs
@@ -1,0 +1,24 @@
+use wire_e2e_identity::prelude::IdentityStatus;
+
+/// Indicates the standalone status of a device Credential in a MLS group at a moment T.
+/// This does not represent the states where a device is not using MLS or is not using end-to-end identity
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[repr(u8)]
+pub enum DeviceStatus {
+    /// All is fine
+    Valid,
+    /// The Credential's certificate is expired
+    Expired,
+    /// The Credential's certificate is revoked (not implemented yet)
+    Revoked,
+}
+
+impl From<IdentityStatus> for DeviceStatus {
+    fn from(status: IdentityStatus) -> Self {
+        match status {
+            IdentityStatus::Valid => Self::Valid,
+            IdentityStatus::Expired => Self::Expired,
+            IdentityStatus::Revoked => Self::Revoked,
+        }
+    }
+}

--- a/crypto/src/e2e_identity/identity.rs
+++ b/crypto/src/e2e_identity/identity.rs
@@ -1,8 +1,10 @@
 use crate::{
+    e2e_identity::device_status::DeviceStatus,
     mls::credential::ext::CredentialExt,
-    prelude::{ClientId, ConversationId, CryptoResult, MlsCentral, MlsConversation},
-    CryptoError,
+    prelude::{user_id::UserId, ClientId, ConversationId, CryptoError, CryptoResult, MlsCentral, MlsConversation},
 };
+use itertools::Itertools;
+use std::collections::HashMap;
 use x509_cert::der::pem::LineEnding;
 
 /// Represents the identity claims identifying a client
@@ -19,6 +21,10 @@ pub struct WireIdentity {
     pub domain: String,
     /// X509 certificate identifying this client in the MLS group ; PEM encoded
     pub certificate: String,
+    /// Status of the Credential at the moment T when this object is created
+    pub status: DeviceStatus,
+    /// MLS thumbprint
+    pub thumbprint: String,
 }
 
 impl<'a> TryFrom<(wire_e2e_identity::prelude::WireIdentity, &'a [u8])> for WireIdentity {
@@ -34,6 +40,8 @@ impl<'a> TryFrom<(wire_e2e_identity::prelude::WireIdentity, &'a [u8])> for WireI
             display_name: i.display_name,
             domain: i.domain,
             certificate,
+            status: i.status.into(),
+            thumbprint: i.thumbprint,
         })
     }
 }
@@ -42,139 +50,265 @@ impl MlsCentral {
     /// From a given conversation, get the identity of the members supplied. Identity is only present for
     /// members with a Certificate Credential (after turning on end-to-end identity).
     /// If no member has a x509 certificate, it will return an empty Vec
-    pub async fn get_user_identities(
+    pub async fn get_device_identities(
         &mut self,
         conversation_id: &ConversationId,
-        client_ids: &[&ClientId],
+        client_ids: &[ClientId],
     ) -> CryptoResult<Vec<WireIdentity>> {
         self.get_conversation(conversation_id)
             .await?
             .read()
             .await
-            .get_user_identities(client_ids)
+            .get_device_identities(client_ids)
+    }
+
+    /// From a given conversation, get the identity of the users (device holders) supplied.
+    /// Identity is only present for devices with a Certificate Credential (after turning on end-to-end identity).
+    /// If no member has a x509 certificate, it will return an empty Vec.
+    ///
+    /// Returns a Map with all the identities for a given users. Consumers are then recommended to
+    /// reduce those identities to determine the actual status of a user.
+    pub async fn get_user_identities(
+        &mut self,
+        conversation_id: &ConversationId,
+        user_ids: &[String],
+    ) -> CryptoResult<HashMap<String, Vec<WireIdentity>>> {
+        self.get_conversation(conversation_id)
+            .await?
+            .read()
+            .await
+            .get_user_identities(user_ids)
     }
 }
 
 impl MlsConversation {
-    fn get_user_identities(&self, client_ids: &[&ClientId]) -> CryptoResult<Vec<WireIdentity>> {
+    fn get_device_identities(&self, device_ids: &[ClientId]) -> CryptoResult<Vec<WireIdentity>> {
+        if device_ids.is_empty() {
+            return Err(CryptoError::ImplementationError);
+        }
         self.members()
             .into_iter()
-            .filter(|(m, _)| client_ids.contains(&&ClientId::from(&m[..])))
+            .filter(|(m, _)| device_ids.contains(&ClientId::from(&m[..])))
             .filter_map(|(_, c)| c.extract_identity().transpose())
             .collect::<CryptoResult<Vec<_>>>()
+    }
+
+    fn get_user_identities(&self, user_ids: &[String]) -> CryptoResult<HashMap<String, Vec<WireIdentity>>> {
+        if user_ids.is_empty() {
+            return Err(CryptoError::ImplementationError);
+        }
+        let user_ids = user_ids.iter().map(|uid| uid.as_bytes()).collect::<Vec<_>>();
+        self.members()
+            .iter()
+            .filter_map(|(m, c)| UserId::try_from(m).ok().zip(Some(c)))
+            .filter(|(uid, _)| user_ids.contains(uid))
+            .filter_map(|(uid, c)| Some(uid).zip(c.extract_identity().transpose()))
+            .group_by(|(uid, _)| *uid)
+            .into_iter()
+            .map(|(uid, group)| {
+                let uid = String::try_from(uid);
+                let identities = group.into_iter().map(|(_, id)| id).collect::<CryptoResult<Vec<_>>>();
+                // TODO: simplify when `Result::zip` available
+                uid.and_then(|uid| identities.map(|ids| (uid, ids)))
+            })
+            .collect::<CryptoResult<HashMap<_, _>>>()
     }
 }
 
 #[cfg(test)]
 pub mod tests {
     use crate::test_utils::*;
+    use crate::CryptoError;
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    const ALICE_ANDROID: &str = "t6wRpI8BRSeviBwwiFp5MQ:a661e79735dc890f@wire.com";
-    const ALICE_IOS: &str = "t6wRpI8BRSeviBwwiFp5MQ:ce3c1921aacdbcfe@wire.com";
+    const ALICE_ANDROID: &'static str = "t6wRpI8BRSeviBwwiFp5MQ:a661e79735dc890f@wire.com";
+    const ALICE_IOS: &'static str = "t6wRpI8BRSeviBwwiFp5MQ:ce3c1921aacdbcfe@wire.com";
+    const BOB_ANDROID: &'static str = "wjoxZL5tTzi2-8iND-HimA:2af3cbe39aed8cc5@wire.com";
 
-    #[apply(all_cred_cipher)]
+    #[async_std::test]
     #[wasm_bindgen_test]
-    pub async fn should_read_identities(case: TestCase) {
-        if case.is_x509() {
-            run_test_with_client_ids(
-                case.clone(),
-                [ALICE_ANDROID, ALICE_IOS],
-                move |[mut alice_android_central, mut alice_ios_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_android_central
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_android_central
-                            .invite_all(&case, &id, [&mut alice_ios_central])
-                            .await
-                            .unwrap();
+    pub async fn should_read_device_identities() {
+        let case = TestCase::default_x509();
+        run_test_with_client_ids(
+            case.clone(),
+            [ALICE_ANDROID, ALICE_IOS],
+            move |[mut alice_android_central, mut alice_ios_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_android_central
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    alice_android_central
+                        .invite_all(&case, &id, [&mut alice_ios_central])
+                        .await
+                        .unwrap();
 
-                        let (android_id, ios_id) =
-                            (alice_android_central.get_client_id(), alice_ios_central.get_client_id());
+                    let (android_id, ios_id) =
+                        (alice_android_central.get_client_id(), alice_ios_central.get_client_id());
 
-                        let mut android_ids = alice_android_central
-                            .get_user_identities(&id, &[&android_id, &ios_id])
-                            .await
-                            .unwrap();
-                        android_ids.sort_by(|a, b| a.client_id.cmp(&b.client_id));
-                        assert_eq!(android_ids.len(), 2);
-                        let mut ios_ids = alice_ios_central
-                            .get_user_identities(&id, &[&android_id, &ios_id])
-                            .await
-                            .unwrap();
-                        ios_ids.sort_by(|a, b| a.client_id.cmp(&b.client_id));
-                        assert_eq!(ios_ids.len(), 2);
+                    let mut android_ids = alice_android_central
+                        .get_device_identities(&id, &[android_id.clone(), ios_id.clone()])
+                        .await
+                        .unwrap();
+                    android_ids.sort_by(|a, b| a.client_id.cmp(&b.client_id));
+                    assert_eq!(android_ids.len(), 2);
+                    let mut ios_ids = alice_ios_central
+                        .get_device_identities(&id, &[android_id.clone(), ios_id.clone()])
+                        .await
+                        .unwrap();
+                    ios_ids.sort_by(|a, b| a.client_id.cmp(&b.client_id));
+                    assert_eq!(ios_ids.len(), 2);
 
-                        assert_eq!(android_ids, ios_ids);
+                    assert_eq!(android_ids, ios_ids);
 
-                        let android_identities = alice_android_central
-                            .get_user_identities(&id, &[&android_id])
-                            .await
-                            .unwrap();
-                        let android_id = android_identities.first().unwrap();
-                        assert_eq!(
-                            android_id.client_id.as_bytes(),
-                            alice_android_central.client_id().unwrap().0.as_slice()
-                        );
+                    let android_identities = alice_android_central
+                        .get_device_identities(&id, &[android_id])
+                        .await
+                        .unwrap();
+                    let android_id = android_identities.first().unwrap();
+                    assert_eq!(
+                        android_id.client_id.as_bytes(),
+                        alice_android_central.client_id().unwrap().0.as_slice()
+                    );
 
-                        let ios_identities = alice_android_central
-                            .get_user_identities(&id, &[&ios_id])
-                            .await
-                            .unwrap();
-                        let ios_id = ios_identities.first().unwrap();
-                        assert_eq!(
-                            ios_id.client_id.as_bytes(),
-                            alice_ios_central.client_id().unwrap().0.as_slice()
-                        );
-                    })
-                },
-            )
-            .await
-        }
+                    let ios_identities = alice_android_central
+                        .get_device_identities(&id, &[ios_id])
+                        .await
+                        .unwrap();
+                    let ios_id = ios_identities.first().unwrap();
+                    assert_eq!(
+                        ios_id.client_id.as_bytes(),
+                        alice_ios_central.client_id().unwrap().0.as_slice()
+                    );
+
+                    let invalid = alice_android_central.get_device_identities(&id, &[]).await;
+                    assert!(matches!(invalid.unwrap_err(), CryptoError::ImplementationError));
+                })
+            },
+        )
+        .await
     }
 
-    #[apply(all_cred_cipher)]
+    #[async_std::test]
     #[wasm_bindgen_test]
-    pub async fn should_not_fail_when_basic(case: TestCase) {
-        if case.is_basic() {
-            run_test_with_client_ids(
-                case.clone(),
-                [ALICE_ANDROID, ALICE_IOS],
-                move |[mut alice_android_central, mut alice_ios_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_android_central
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_android_central
-                            .invite_all(&case, &id, [&mut alice_ios_central])
-                            .await
-                            .unwrap();
+    pub async fn should_not_fail_when_basic() {
+        let case = TestCase::default();
+        run_test_with_client_ids(
+            case.clone(),
+            [ALICE_ANDROID, ALICE_IOS],
+            move |[mut alice_android_central, mut alice_ios_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_android_central
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    alice_android_central
+                        .invite_all(&case, &id, [&mut alice_ios_central])
+                        .await
+                        .unwrap();
 
-                        let (android_id, ios_id) =
-                            (alice_android_central.get_client_id(), alice_ios_central.get_client_id());
+                    let (android_id, ios_id) =
+                        (alice_android_central.get_client_id(), alice_ios_central.get_client_id());
 
-                        let android_ids = alice_android_central
-                            .get_user_identities(&id, &[&android_id, &ios_id])
-                            .await
-                            .unwrap();
-                        assert!(android_ids.is_empty());
+                    let android_ids = alice_android_central
+                        .get_device_identities(&id, &[android_id.clone(), ios_id.clone()])
+                        .await
+                        .unwrap();
+                    assert!(android_ids.is_empty());
 
-                        let ios_ids = alice_ios_central
-                            .get_user_identities(&id, &[&android_id, &ios_id])
-                            .await
-                            .unwrap();
-                        assert!(ios_ids.is_empty());
-                    })
-                },
-            )
-            .await
-        }
+                    let ios_ids = alice_ios_central
+                        .get_device_identities(&id, &[android_id, ios_id])
+                        .await
+                        .unwrap();
+                    assert!(ios_ids.is_empty());
+                })
+            },
+        )
+        .await
+    }
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    pub async fn should_read_users() {
+        let case = TestCase::default_x509();
+        run_test_with_deterministic_client_ids(
+            case.clone(),
+            [
+                [ALICE_ANDROID, "alice_wire", "Alice Smith"],
+                [ALICE_IOS, "alice_wire", "Alice Smith"],
+                [BOB_ANDROID, "bob_wire", "Bob Doe"],
+            ],
+            move |[mut alice_android_central, mut alice_ios_central, mut bob_android_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_android_central
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    alice_android_central
+                        .invite_all(&case, &id, [&mut alice_ios_central, &mut bob_android_central])
+                        .await
+                        .unwrap();
+
+                    let nb_members = alice_android_central
+                        .get_conversation_unchecked(&id)
+                        .await
+                        .members()
+                        .len();
+                    assert_eq!(nb_members, 3);
+
+                    // Finds both Alice's devices
+                    let alice_identities = alice_android_central
+                        .get_user_identities(&id, &["t6wRpI8BRSeviBwwiFp5MQ".to_string()])
+                        .await
+                        .unwrap();
+                    assert_eq!(alice_identities.len(), 1);
+                    let identities = alice_identities.get(&"t6wRpI8BRSeviBwwiFp5MQ".to_string()).unwrap();
+                    assert_eq!(identities.len(), 2);
+
+                    // Finds Bob only device
+                    let bob_identities = alice_android_central
+                        .get_user_identities(&id, &["wjoxZL5tTzi2-8iND-HimA".to_string()])
+                        .await
+                        .unwrap();
+                    assert_eq!(bob_identities.len(), 1);
+                    let identities = bob_identities.get(&"wjoxZL5tTzi2-8iND-HimA".to_string()).unwrap();
+                    assert_eq!(identities.len(), 1);
+
+                    // Finds all devices
+                    let all_identities = alice_android_central
+                        .get_user_identities(
+                            &id,
+                            &[
+                                "t6wRpI8BRSeviBwwiFp5MQ".to_string(),
+                                "wjoxZL5tTzi2-8iND-HimA".to_string(),
+                            ],
+                        )
+                        .await
+                        .unwrap();
+                    assert_eq!(all_identities.len(), 2);
+                    let alice_identities = alice_identities.get(&"t6wRpI8BRSeviBwwiFp5MQ".to_string()).unwrap();
+                    assert_eq!(alice_identities.len(), 2);
+                    let bob_identities = bob_identities.get(&"wjoxZL5tTzi2-8iND-HimA".to_string()).unwrap();
+                    assert_eq!(bob_identities.len(), 1);
+
+                    // Not found
+                    let not_found = alice_android_central
+                        .get_user_identities(&id, &["aaaaaaaaaaaaa".to_string()])
+                        .await
+                        .unwrap();
+                    assert!(not_found.is_empty());
+
+                    // Invalid usage
+                    let invalid = alice_android_central.get_user_identities(&id, &[]).await;
+                    assert!(matches!(invalid.unwrap_err(), CryptoError::ImplementationError));
+                })
+            },
+        )
+        .await
     }
 }

--- a/crypto/src/e2e_identity/mod.rs
+++ b/crypto/src/e2e_identity/mod.rs
@@ -10,13 +10,14 @@ use crate::{
     prelude::{id::ClientId, identifier::ClientIdentifier, CertificateBundle, MlsCentral, MlsCiphersuite},
 };
 
+pub(crate) mod conversation_state;
 mod crypto;
+pub(crate) mod device_status;
 pub mod enabled;
 pub mod error;
 pub(crate) mod identity;
 pub(crate) mod rotate;
 pub(crate) mod stash;
-pub(crate) mod state;
 pub mod types;
 
 type Json = Vec<u8>;
@@ -509,7 +510,7 @@ pub mod tests {
         let client_id = client_id
             .map(|c| format!("{}{c}", wire_e2e_identity::prelude::E2eiClientId::URI_PREFIX))
             .unwrap_or_else(|| cc.get_e2ei_client_id().to_uri());
-        let identifier_value = format!("{{\"name\":\"{display_name}\",\"domain\":\"wire.com\",\"client-id\":\"{client_id}\",\"handle\":\"im:wireapp={handle}\"}}");
+        let identifier_value = format!("{{\"name\":\"{display_name}\",\"domain\":\"wire.com\",\"client-id\":\"{client_id}\",\"handle\":\"im:wireapp=%40{handle}@wire.com\"}}");
         let order_resp = json!({
             "status": "pending",
             "expires": "2037-01-05T14:09:07.99Z",

--- a/crypto/src/e2e_identity/rotate.rs
+++ b/crypto/src/e2e_identity/rotate.rs
@@ -357,7 +357,11 @@ pub mod tests {
 
                             alice_central.commit_accepted(&id).await.unwrap();
                             alice_central
-                                .verify_local_credential_rotated(&id, new_handle, new_display_name)
+                                .verify_local_credential_rotated(
+                                    &id,
+                                    &format!("{new_handle}@wire.com"),
+                                    new_display_name,
+                                )
                                 .await;
                         }
 
@@ -370,7 +374,7 @@ pub mod tests {
                             assert_eq!(c.credential_type(), openmls::prelude::CredentialType::X509);
                             let identity = c.extract_identity().unwrap().unwrap();
                             assert_eq!(identity.display_name, new_display_name);
-                            assert_eq!(identity.handle, new_handle);
+                            assert_eq!(identity.handle, format!("{new_handle}@wire.com"));
                         }
 
                         // Alice has to delete her old KeyPackages
@@ -512,7 +516,7 @@ pub mod tests {
                         .unwrap();
                     let identity = cb.credential().extract_identity().unwrap().unwrap();
                     assert_eq!(identity.display_name, new_display_name);
-                    assert_eq!(identity.handle, new_handle);
+                    assert_eq!(identity.handle, format!("{new_handle}@wire.com"));
 
                     // but keeps her old one since it's referenced from some KeyPackages
                     let old_spk = SignaturePublicKey::from(old_cb.signature_key.public());
@@ -553,7 +557,7 @@ pub mod tests {
                         .unwrap();
                     let identity = cb.credential().extract_identity().unwrap().unwrap();
                     assert_eq!(identity.display_name, new_display_name);
-                    assert_eq!(identity.handle, new_handle);
+                    assert_eq!(identity.handle, format!("{new_handle}@wire.com"));
 
                     assert_eq!(
                         alice_central.mls_client().unwrap().identities.iter().count(),
@@ -619,7 +623,11 @@ pub mod tests {
 
                         alice_central.commit_accepted(&id).await.unwrap();
                         alice_central
-                            .verify_local_credential_rotated(&id, alice_new_handle, alice_new_display_name)
+                            .verify_local_credential_rotated(
+                                &id,
+                                &format!("{alice_new_handle}@wire.com"),
+                                alice_new_display_name,
+                            )
                             .await;
 
                         // Bob's turn
@@ -659,7 +667,11 @@ pub mod tests {
 
                         bob_central.commit_accepted(&id).await.unwrap();
                         bob_central
-                            .verify_local_credential_rotated(&id, bob_new_handle, bob_new_display_name)
+                            .verify_local_credential_rotated(
+                                &id,
+                                &format!("{bob_new_handle}@wire.com"),
+                                bob_new_display_name,
+                            )
                             .await;
                     })
                 },
@@ -691,7 +703,7 @@ pub mod tests {
                             let init_count = alice_central.count_entities().await;
 
                             // Alice creates a new Credential, updating her handle/display_name
-                            let alice_cid = &alice_central.get_client_id();
+                            let alice_cid = alice_central.get_client_id();
                             let (new_handle, new_display_name) = ("new_alice_wire", "New Alice Smith");
                             let cb = alice_central
                                 .rotate_credential(&case, new_handle, new_display_name, None)
@@ -699,10 +711,10 @@ pub mod tests {
 
                             // Verify old identity is still there in the MLS group
                             let alice_old_identities =
-                                alice_central.get_user_identities(&id, &[alice_cid]).await.unwrap();
+                                alice_central.get_device_identities(&id, &[alice_cid]).await.unwrap();
                             let alice_old_identity = alice_old_identities.first().unwrap();
                             assert_ne!(alice_old_identity.display_name, new_display_name);
-                            assert_ne!(alice_old_identity.handle, new_handle);
+                            assert_ne!(alice_old_identity.handle, format!("{new_handle}@wire.com"));
 
                             // Alice issues an Update commit to replace her current identity
                             let commit = alice_central.e2ei_rotate(&id, &cb).await.unwrap();
@@ -718,7 +730,11 @@ pub mod tests {
                             // Finally, Alice merges her commit and verifies her new identity gets applied
                             alice_central.commit_accepted(&id).await.unwrap();
                             alice_central
-                                .verify_local_credential_rotated(&id, new_handle, new_display_name)
+                                .verify_local_credential_rotated(
+                                    &id,
+                                    &format!("{new_handle}@wire.com"),
+                                    new_display_name,
+                                )
                                 .await;
 
                             let final_count = alice_central.count_entities().await;
@@ -790,7 +806,11 @@ pub mod tests {
                             // Finally, Alice merges her commit and verifies her new identity gets applied
                             alice_central.commit_accepted(&id).await.unwrap();
                             alice_central
-                                .verify_local_credential_rotated(&id, new_handle, new_display_name)
+                                .verify_local_credential_rotated(
+                                    &id,
+                                    &format!("{new_handle}@wire.com"),
+                                    new_display_name,
+                                )
                                 .await;
 
                             // Bob verifies that now Alice is represented with her new identity

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -224,6 +224,9 @@ pub enum CryptoError {
     /// with an External Commit instead
     #[error("Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit")]
     OrphanWelcome,
+    /// The encountered ClientId does not match Wire's definition
+    #[error("The encountered ClientId does not match Wire's definition")]
+    InvalidClientId,
 }
 
 /// A simpler definition for Result types that the Error is a [CryptoError]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -66,10 +66,11 @@ pub mod prelude {
 
     pub use crate::{
         e2e_identity::{
+            conversation_state::E2eiConversationState,
+            device_status::DeviceStatus,
             error::{E2eIdentityError, E2eIdentityResult},
             identity::WireIdentity,
             rotate::MlsRotateBundle,
-            state::E2eiConversationState,
             types::{E2eiAcmeChallenge, E2eiAcmeDirectory, E2eiNewAcmeAuthz, E2eiNewAcmeOrder},
             E2eiEnrollment,
         },

--- a/crypto/src/mls/client/mod.rs
+++ b/crypto/src/mls/client/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod id;
 pub(crate) mod identifier;
 pub(crate) mod identities;
 pub(crate) mod key_package;
+pub(crate) mod user_id;
 
 use crate::{
     mls::{credential::ext::CredentialExt, credential::CredentialBundle},

--- a/crypto/src/mls/client/user_id.rs
+++ b/crypto/src/mls/client/user_id.rs
@@ -1,0 +1,79 @@
+use crate::prelude::MemberId;
+use crate::{CryptoError, CryptoResult};
+
+/// Unique identifier of a User (human person holding some devices).
+/// This contradicts the initial design requirements of this project since it was supposed to be
+/// agnostic from Wire.
+/// End-to-end Identity re-shuffled that... But we still want to keep this isolated from the rest
+/// of the crate that's why this should remain here and be used cautiously, having the context quoted
+/// above in mind.
+/// For example in `im:wireapp=LcksJb74Tm6N12cDjFy7lQ/8e6424430d3b28be@wire.com` the [UserId] is `LcksJb74Tm6N12cDjFy7lQ`
+#[derive(Debug, Clone, Copy, Eq, PartialEq, derive_more::Deref)]
+pub struct UserId<'a>(&'a [u8]);
+
+impl UserId<'_> {
+    const USER_ID_DELIMITER: u8 = 58; // the char ':'
+}
+
+impl<'a> TryFrom<&'a str> for UserId<'a> {
+    type Error = CryptoError;
+
+    fn try_from(client_id: &'a str) -> CryptoResult<Self> {
+        client_id.as_bytes().try_into()
+    }
+}
+
+impl<'a> TryFrom<&'a MemberId> for UserId<'a> {
+    type Error = CryptoError;
+
+    fn try_from(member_id: &'a MemberId) -> CryptoResult<Self> {
+        member_id.as_slice().try_into()
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for UserId<'a> {
+    type Error = CryptoError;
+
+    fn try_from(id: &'a [u8]) -> CryptoResult<Self> {
+        let found = id
+            .splitn(2, |&b| b == Self::USER_ID_DELIMITER)
+            .next()
+            .ok_or(CryptoError::InvalidClientId)?;
+        if found.len() == id.len() {
+            return Err(CryptoError::InvalidClientId);
+        }
+        Ok(Self(found))
+    }
+}
+
+impl TryFrom<UserId<'_>> for String {
+    type Error = CryptoError;
+
+    fn try_from(uid: UserId<'_>) -> CryptoResult<Self> {
+        Ok(std::str::from_utf8(&uid)?.to_string())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    pub async fn should_parse_client_id() {
+        let user_id = "LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@wire.com".as_bytes().to_vec();
+        let user_id = UserId::try_from(&user_id).unwrap();
+        assert_eq!(user_id, UserId("LcksJb74Tm6N12cDjFy7lQ".as_bytes()));
+    }
+
+    #[async_std::test]
+    #[wasm_bindgen_test]
+    pub async fn should_fail_when_invalid() {
+        let user_id = "LcksJb74Tm6N12cDjFy7lQ/8e6424430d3b28be@wire.com".as_bytes().to_vec();
+        let user_id = UserId::try_from(&user_id);
+        assert!(matches!(user_id.unwrap_err(), CryptoError::InvalidClientId));
+    }
+}

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -23,9 +23,9 @@ use crate::mls::{
 };
 
 impl MlsConversation {
-    const EXPORTER_LABEL: &str = "exporter";
+    const EXPORTER_LABEL: &'static str = "exporter";
     // TODO: check if this can be a constant or if we need to pass the group state
-    const EXPORTER_CONTEXT: &[u8] = &[];
+    const EXPORTER_CONTEXT: &'static [u8] = &[];
 
     /// See [MlsCentral::export_secret_key]
     pub fn export_secret_key(&self, backend: &MlsCryptoProvider, key_length: usize) -> CryptoResult<Vec<u8>> {

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -39,7 +39,7 @@ use config::MlsConversationConfiguration;
 
 use crate::group_store::GroupStoreValue;
 use crate::{
-    mls::{client::Client, member::MemberId, ClientId, MlsCentral},
+    mls::{client::Client, member::MemberId, MlsCentral},
     prelude::{CryptoError, CryptoResult, MlsCiphersuite, MlsCredentialType, MlsError},
 };
 
@@ -170,8 +170,7 @@ impl MlsConversation {
     pub fn members(&self) -> HashMap<MemberId, Credential> {
         self.group.members().fold(HashMap::new(), |mut acc, kp| {
             let credential = kp.credential;
-            let client_id: ClientId = credential.identity().into();
-            let member_id: MemberId = client_id.to_vec();
+            let member_id: MemberId = credential.identity().into();
             acc.entry(member_id).or_insert(credential);
             acc
         })
@@ -409,7 +408,7 @@ pub mod tests {
                     .unwrap();
                     let mut central = MlsCentral::try_new(config).await.unwrap();
 
-                    let client_id: ClientId = name.as_str().into();
+                    let client_id: crate::prelude::ClientId = name.as_str().into();
                     let identity = match case.credential_type {
                         MlsCredentialType::Basic => ClientIdentifier::Basic(client_id),
                         MlsCredentialType::X509 => {

--- a/crypto/src/mls/conversation/self_commit.rs
+++ b/crypto/src/mls/conversation/self_commit.rs
@@ -135,7 +135,7 @@ pub mod tests {
                     if case.is_x509() {
                         alice_central.verify_sender_identity(&case, &decrypt_self);
                         alice_central
-                            .verify_local_credential_rotated(&id, new_handle, new_display_name)
+                            .verify_local_credential_rotated(&id, &format!("{new_handle}@wire.com"), new_display_name)
                             .await;
                     }
                 })

--- a/extras/wasm-browser-run/src/webdriver.rs
+++ b/extras/wasm-browser-run/src/webdriver.rs
@@ -138,14 +138,14 @@ pub enum WebdriverKind {
 }
 
 impl WebdriverKind {
-    const CHROMIUM_MAJOR_VERSION: &str = "115";
+   const CHROMIUM_MAJOR_VERSION: &'static str = "119";
 
-    const EDGE_RELEASE_URL: &str = const_format::concatcp!(
+    const EDGE_RELEASE_URL: &'static str = const_format::concatcp!(
         "https://msedgedriver.azureedge.net/LATEST_RELEASE_",
         WebdriverKind::CHROMIUM_MAJOR_VERSION
     );
 
-    const GECKO_RELEASE_URL: &str = "https://api.github.com/repos/mozilla/geckodriver/releases/latest";
+    const GECKO_RELEASE_URL: &'static str = "https://api.github.com/repos/mozilla/geckodriver/releases/latest";
 
     pub fn as_exe_name(&self) -> &str {
         match self {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

* ~~`get_user_identities`~~ becomes `get_device_identities` and a new `get_user_identities` added to list identities in a group belonging to the same user
* handle is format changed from `im:wireapp={input}` to `im:wireapp=%40{input}@{domain}`
* WireIdentity contains JWK thumbprint of the certificate public key
* WireIdentity contains a validation status (Valid/Expired/Revoked)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
