### PR TITLE
feat: better errors

### DIFF
--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -2406,7 +2406,6 @@ impl CoreCrypto {
                         ciphersuite.into(),
                     )
                     .map(E2eiEnrollment)
-                    .map_err(|_| CryptoError::ImplementationError)
                     .map_err(CoreCryptoError::from)?;
 
                 WasmCryptoResult::Ok(enrollment.into())
@@ -2442,7 +2441,6 @@ impl CoreCrypto {
                         ciphersuite.into(),
                     )
                     .map(E2eiEnrollment)
-                    .map_err(|_| CryptoError::ImplementationError)
                     .map_err(CoreCryptoError::from)?;
 
                 WasmCryptoResult::Ok(enrollment.into())
@@ -2478,7 +2476,6 @@ impl CoreCrypto {
                         ciphersuite.into(),
                     )
                     .map(E2eiEnrollment)
-                    .map_err(|_| CryptoError::ImplementationError)
                     .map_err(CoreCryptoError::from)?;
 
                 WasmCryptoResult::Ok(enrollment.into())
@@ -2554,7 +2551,6 @@ impl CoreCrypto {
                     .e2ei_enrollment_stash_pop(handle.to_vec())
                     .await
                     .map(E2eiEnrollment)
-                    .map_err(|_| CryptoError::ImplementationError)
                     .map_err(CoreCryptoError::from)?;
 
                 WasmCryptoResult::Ok(enrollment.into())
@@ -2633,7 +2629,7 @@ impl CoreCrypto {
         let this = self.inner.clone();
         future_to_promise(
             async move {
-                let identities: HashMap<String, Vec<WireIdentity>> = this
+                let identities = this
                     .write()
                     .await
                     .get_user_identities(&conversation_id, user_ids.deref())

--- a/crypto/src/e2e_identity/enabled.rs
+++ b/crypto/src/e2e_identity/enabled.rs
@@ -12,7 +12,7 @@ impl MlsCentral {
             None => {
                 client
                     .find_most_recent_credential_bundle(signature_scheme, MlsCredentialType::Basic)
-                    .ok_or(CryptoError::CredentialNotFound)?;
+                    .ok_or(CryptoError::CredentialNotFound(MlsCredentialType::Basic))?;
                 Ok(false)
             }
             Some(_) => Ok(true),
@@ -69,7 +69,7 @@ pub mod tests {
                 };
                 assert!(matches!(
                     cc.e2ei_is_enabled(other_sc).unwrap_err(),
-                    CryptoError::CredentialNotFound
+                    CryptoError::CredentialNotFound(_)
                 ));
             })
         })

--- a/crypto/src/e2e_identity/error.rs
+++ b/crypto/src/e2e_identity/error.rs
@@ -1,6 +1,6 @@
 //! End to end identity errors
 
-use crate::CryptoError;
+use crate::prelude::MlsCredentialType;
 
 /// Wrapper over a [Result] of an end to end identity error
 pub type E2eIdentityResult<T> = Result<T, E2eIdentityError>;
@@ -16,6 +16,18 @@ pub enum E2eIdentityError {
     /// Incoming support
     #[error("Not yet supported")]
     NotYetSupported,
+    /// The required local MLS client was not initialized. It's likely a consumer error
+    #[error("Expected a MLS client with credential type {0:?} but none found")]
+    MissingExistingClient(MlsCredentialType),
+    /// Cannot read the identity in the EE certificate
+    #[error("Could not the identity information in the Credential's certificate")]
+    InvalidIdentity,
+    /// Failed converting the MLS signature key for the e2ei enrollment
+    #[error("Failed converting the MLS signature key for the e2ei enrollment")]
+    InvalidSignatureKey,
+    /// Enrollment methods are called out of order
+    #[error("Enrollment methods are called out of order: {0}")]
+    OutOfOrderEnrollment(&'static str),
     /// Error when an end-to-end-identity domain is not well-formed utf-16, which means it's out of spec
     #[error("The E2EI provided domain is invalid utf-16")]
     E2eiInvalidDomain,
@@ -34,9 +46,6 @@ pub enum E2eIdentityError {
     /// Utf8 error
     #[error(transparent)]
     Utf8Error(#[from] ::core::str::Utf8Error),
-    /// MLS error
-    #[error(transparent)]
-    MlsError(#[from] CryptoError),
     /// !!!! Something went very wrong and one of our locks has been poisoned by an in-thread panic !!!!
     #[error("One of the locks has been poisoned")]
     LockPoisonError,

--- a/crypto/src/e2e_identity/identity.rs
+++ b/crypto/src/e2e_identity/identity.rs
@@ -86,7 +86,7 @@ impl MlsCentral {
 impl MlsConversation {
     fn get_device_identities(&self, device_ids: &[ClientId]) -> CryptoResult<Vec<WireIdentity>> {
         if device_ids.is_empty() {
-            return Err(CryptoError::ImplementationError);
+            return Err(CryptoError::ConsumerError);
         }
         self.members()
             .into_iter()
@@ -97,7 +97,7 @@ impl MlsConversation {
 
     fn get_user_identities(&self, user_ids: &[String]) -> CryptoResult<HashMap<String, Vec<WireIdentity>>> {
         if user_ids.is_empty() {
-            return Err(CryptoError::ImplementationError);
+            return Err(CryptoError::ConsumerError);
         }
         let user_ids = user_ids.iter().map(|uid| uid.as_bytes()).collect::<Vec<_>>();
         self.members()
@@ -191,7 +191,7 @@ pub mod tests {
                     );
 
                     let invalid = alice_android_central.get_device_identities(&id, &[]).await;
-                    assert!(matches!(invalid.unwrap_err(), CryptoError::ImplementationError));
+                    assert!(matches!(invalid.unwrap_err(), CryptoError::ConsumerError));
                 })
             },
         )
@@ -311,7 +311,7 @@ pub mod tests {
 
                     // Invalid usage
                     let invalid = alice_android_central.get_user_identities(&id, &[]).await;
-                    assert!(matches!(invalid.unwrap_err(), CryptoError::ImplementationError));
+                    assert!(matches!(invalid.unwrap_err(), CryptoError::ConsumerError));
                 })
             },
         )

--- a/crypto/src/e2e_identity/stash.rs
+++ b/crypto/src/e2e_identity/stash.rs
@@ -1,4 +1,5 @@
-use crate::prelude::{CryptoError, E2eIdentityResult, E2eiEnrollment, MlsCentral};
+use crate::prelude::{CryptoError, E2eiEnrollment, MlsCentral};
+use crate::CryptoResult;
 use core_crypto_keystore::CryptoKeystoreMls;
 use mls_crypto_provider::MlsCryptoProvider;
 use openmls_traits::{random::OpenMlsRand, OpenMlsCryptoProvider};
@@ -8,7 +9,7 @@ use openmls_traits::{random::OpenMlsRand, OpenMlsCryptoProvider};
 pub(crate) type EnrollmentHandle = Vec<u8>;
 
 impl E2eiEnrollment {
-    pub(crate) async fn stash(self, backend: &MlsCryptoProvider) -> E2eIdentityResult<EnrollmentHandle> {
+    pub(crate) async fn stash(self, backend: &MlsCryptoProvider) -> CryptoResult<EnrollmentHandle> {
         // should be enough to prevent collisions
         const HANDLE_SIZE: usize = 32;
 
@@ -22,7 +23,7 @@ impl E2eiEnrollment {
         Ok(handle)
     }
 
-    pub(crate) async fn stash_pop(backend: &MlsCryptoProvider, handle: EnrollmentHandle) -> E2eIdentityResult<Self> {
+    pub(crate) async fn stash_pop(backend: &MlsCryptoProvider, handle: EnrollmentHandle) -> CryptoResult<Self> {
         let content = backend
             .key_store()
             .pop_e2ei_enrollment(&handle)
@@ -41,7 +42,7 @@ impl MlsCentral {
     ///
     /// # Returns
     /// A handle for retrieving the enrollment later on
-    pub async fn e2ei_enrollment_stash(&self, enrollment: E2eiEnrollment) -> E2eIdentityResult<EnrollmentHandle> {
+    pub async fn e2ei_enrollment_stash(&self, enrollment: E2eiEnrollment) -> CryptoResult<EnrollmentHandle> {
         enrollment.stash(&self.mls_backend).await
     }
 
@@ -49,7 +50,7 @@ impl MlsCentral {
     ///
     /// # Arguments
     /// * `handle` - returned by [MlsCentral::e2ei_enrollment_stash]
-    pub async fn e2ei_enrollment_stash_pop(&self, handle: EnrollmentHandle) -> E2eIdentityResult<E2eiEnrollment> {
+    pub async fn e2ei_enrollment_stash_pop(&self, handle: EnrollmentHandle) -> CryptoResult<E2eiEnrollment> {
         E2eiEnrollment::stash_pop(&self.mls_backend, handle).await
     }
 }

--- a/crypto/src/mls/client/identities.rs
+++ b/crypto/src/mls/client/identities.rs
@@ -52,7 +52,7 @@ impl ClientIdentities {
             Some(cbs) => {
                 let already_exists = !cbs.insert(cb);
                 if already_exists {
-                    return Err(CryptoError::ImplementationError);
+                    return Err(CryptoError::CredentialBundleConflict);
                 }
             }
             None => {
@@ -204,7 +204,10 @@ pub mod tests {
                     let cb = central.new_credential_bundle(&case).await;
                     let client = central.mls_client.as_mut().unwrap();
                     let push = client.identities.push_credential_bundle(case.signature_scheme(), cb);
-                    assert!(push.is_err());
+                    assert!(matches!(
+                        push.unwrap_err(),
+                        crate::CryptoError::CredentialBundleConflict
+                    ));
                 })
             })
             .await

--- a/crypto/src/mls/client/key_package.rs
+++ b/crypto/src/mls/client/key_package.rs
@@ -348,7 +348,7 @@ impl MlsCentral {
     #[cfg_attr(test, crate::dispotent)]
     pub async fn delete_keypackages(&mut self, refs: &[KeyPackageRef]) -> CryptoResult<()> {
         if refs.is_empty() {
-            return Err(CryptoError::ImplementationError);
+            return Err(CryptoError::ConsumerError);
         }
         let client = self.mls_client.as_mut().ok_or(CryptoError::MlsNotInitialized)?;
         client.prune_keypackages_and_credential(&self.mls_backend, refs).await
@@ -557,7 +557,7 @@ pub mod tests {
                     kp.leaf_node().capabilities().ciphersuites().to_vec(),
                     MlsConversationConfiguration::DEFAULT_SUPPORTED_CIPHERSUITES
                         .iter()
-                        .map(|c| VerifiableCiphersuite::try_from(*c).unwrap())
+                        .map(|c| VerifiableCiphersuite::from(*c))
                         .collect::<Vec<_>>()
                 );
                 assert!(kp.leaf_node().capabilities().proposals().is_empty());

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -88,7 +88,7 @@ impl MlsConversation {
                 let ct = match msg.body_as_ref() {
                     MlsMessageInBody::PublicMessage(m) => Ok(m.content_type()),
                     MlsMessageInBody::PrivateMessage(m) => Ok(m.content_type()),
-                    _ => Err(CryptoError::ImplementationError),
+                    _ => Err(CryptoError::ConsumerError),
                 }?;
                 acc.push((ct as u8, msg));
                 CryptoResult::Ok(acc)

--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -258,7 +258,7 @@ pub mod tests {
                     creator_capabilities.ciphersuites().to_vec(),
                     MlsConversationConfiguration::DEFAULT_SUPPORTED_CIPHERSUITES
                         .iter()
-                        .map(|c| VerifiableCiphersuite::try_from(*c).unwrap())
+                        .map(|c| VerifiableCiphersuite::from(*c))
                         .collect::<Vec<_>>()
                 );
 

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -327,7 +327,7 @@ pub mod tests {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
-                    let simple_ref = MlsProposalRef::try_from(vec![0; case.ciphersuite().hash_length()]).unwrap();
+                    let simple_ref = MlsProposalRef::from(vec![0; case.ciphersuite().hash_length()]);
                     let clear = alice_central.clear_pending_proposal(&id, simple_ref).await;
                     assert!(matches!(clear.unwrap_err(), CryptoError::ConversationNotFound(conv_id) if conv_id == id))
                 })
@@ -346,7 +346,7 @@ pub mod tests {
                         .await
                         .unwrap();
                     assert!(alice_central.pending_proposals(&id).await.is_empty());
-                    let any_ref = MlsProposalRef::try_from(vec![0; case.ciphersuite().hash_length()]).unwrap();
+                    let any_ref = MlsProposalRef::from(vec![0; case.ciphersuite().hash_length()]);
                     let clear = alice_central.clear_pending_proposal(&id, any_ref.clone()).await;
                     assert!(matches!(clear.unwrap_err(), CryptoError::PendingProposalNotFound(prop_ref) if prop_ref == any_ref))
                 })

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -218,7 +218,7 @@ impl MlsConversation {
         Ok(self
             .group
             .own_leaf_node()
-            .ok_or(CryptoError::ImplementationError)?
+            .ok_or(CryptoError::InternalMlsError)?
             .credential()
             .credential_type()
             .into())

--- a/crypto/src/mls/conversation/welcome.rs
+++ b/crypto/src/mls/conversation/welcome.rs
@@ -55,7 +55,7 @@ impl MlsCentral {
     ) -> CryptoResult<ConversationId> {
         let welcome = match welcome.extract() {
             MlsMessageInBody::Welcome(welcome) => welcome,
-            _ => return Err(CryptoError::ImplementationError),
+            _ => return Err(CryptoError::ConsumerError),
         };
         let cs = welcome.ciphersuite().into();
         let configuration = MlsConversationConfiguration {

--- a/crypto/src/mls/credential/x509.rs
+++ b/crypto/src/mls/credential/x509.rs
@@ -34,14 +34,14 @@ pub struct CertificateBundle {
 impl CertificateBundle {
     /// Reads the client_id from the leaf certificate
     pub fn get_client_id(&self) -> CryptoResult<ClientId> {
-        let leaf = self.certificate_chain.get(0).ok_or(CryptoError::InvalidIdentity)?;
+        let leaf = self.certificate_chain.first().ok_or(CryptoError::InvalidIdentity)?;
         let identity = leaf.extract_identity().map_err(|_| CryptoError::InvalidIdentity)?;
         Ok(identity.client_id.as_bytes().into())
     }
 
     /// Reads the 'Not Before' claim from the leaf certificate
     pub fn get_created_at(&self) -> CryptoResult<u64> {
-        let leaf = self.certificate_chain.get(0).ok_or(CryptoError::InvalidIdentity)?;
+        let leaf = self.certificate_chain.first().ok_or(CryptoError::InvalidIdentity)?;
         leaf.extract_created_at().map_err(|_| CryptoError::InvalidIdentity)
     }
 }

--- a/crypto/src/mls/external_proposal.rs
+++ b/crypto/src/mls/external_proposal.rs
@@ -127,7 +127,7 @@ impl MlsCentral {
 
                 self.mls_client()?
                     .find_most_recent_credential_bundle(ciphersuite.signature_algorithm(), credential_type)
-                    .ok_or(CryptoError::ImplementationError)?
+                    .ok_or(CryptoError::CredentialNotFound(credential_type))?
             }
             (None, MlsCredentialType::X509) => return Err(CryptoError::E2eiEnrollmentNotDone),
         };

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -243,7 +243,7 @@ impl MlsCentral {
     ) -> CryptoResult<()> {
         if self.mls_client.is_some() {
             // prevents wrong usage of the method instead of silently hiding the mistake
-            return Err(CryptoError::ImplementationError);
+            return Err(CryptoError::ConsumerError);
         }
         let nb_key_package = nb_init_key_packages.unwrap_or(INITIAL_KEYING_MATERIAL_COUNT);
         let mls_client = Client::init(identifier, &ciphersuites, &self.mls_backend, nb_key_package).await?;
@@ -259,7 +259,7 @@ impl MlsCentral {
     pub async fn mls_generate_keypairs(&self, ciphersuites: Vec<MlsCiphersuite>) -> CryptoResult<Vec<ClientId>> {
         if self.mls_client.is_some() {
             // prevents wrong usage of the method instead of silently hiding the mistake
-            return Err(CryptoError::ImplementationError);
+            return Err(CryptoError::ConsumerError);
         }
 
         Client::generate_raw_keypairs(&ciphersuites, &self.mls_backend).await
@@ -277,7 +277,7 @@ impl MlsCentral {
     ) -> CryptoResult<()> {
         if self.mls_client.is_some() {
             // prevents wrong usage of the method instead of silently hiding the mistake
-            return Err(CryptoError::ImplementationError);
+            return Err(CryptoError::ConsumerError);
         }
 
         let mls_client =

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -123,7 +123,7 @@ pub async fn run_test_wo_clients(
 ) {
     run_tests(move |paths: [String; 1]| {
         Box::pin(async move {
-            let p = paths.get(0).unwrap();
+            let p = paths.first().unwrap();
 
             let ciphersuites = vec![case.cfg.ciphersuite];
             let configuration = MlsCentralConfiguration::try_new(

--- a/crypto/src/test_utils/x509.rs
+++ b/crypto/src/test_utils/x509.rs
@@ -42,7 +42,7 @@ impl From<PkiPath> for PerDomainTrustAnchor {
             .map(|c| pem::Pem::new("CERTIFICATE", c.to_der().unwrap()))
             .collect::<Vec<_>>();
         Self {
-            domain_name: domains.get(0).cloned().unwrap_or_default(),
+            domain_name: domains.first().cloned().unwrap_or_default(),
             intermediate_certificate_chain: pem::encode_many(&pems),
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

'ImplementationError' was way too often used as a fallback when the developer was too lazy to create a new error. This tries to cure that, especially with e2ei errors. It also tries to distinguish client errors from internal errors

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
