### PR TITLE
feat!: canonicalize ClientId [WPB-5608]

### DIFF
--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -60,5 +60,8 @@ cfg-if = "1.0"
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1674,7 +1674,7 @@ export class CoreCrypto {
      * Creates an enrollment instance with private key material you can use in order to fetch
      * a new x509 certificate from the acme server.
      *
-     * @param clientId - client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+     * @param clientId - client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
      * @param displayName - human-readable name displayed in the application e.g. `Smith, Alice M (QA)`
      * @param handle - user handle e.g. `alice.smith.qa@example.com`
      * @param expiryDays - generated x509 certificate expiry
@@ -1691,7 +1691,7 @@ export class CoreCrypto {
      * Generates an E2EI enrollment instance for a "regular" client (with a Basic credential) willing to migrate to E2EI.
      * Once the enrollment is finished, use the instance in {@link CoreCrypto.e2eiRotateAll} to do the rotation.
      *
-     * @param clientId - client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+     * @param clientId - client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
      * @param displayName - human-readable name displayed in the application e.g. `Smith, Alice M (QA)`
      * @param handle - user handle e.g. `alice.smith.qa@example.com`
      * @param expiryDays - generated x509 certificate expiry
@@ -1710,7 +1710,7 @@ export class CoreCrypto {
      * has been revoked. It lets you change the DisplayName or the handle
      * if you need to. Once the enrollment is finished, use the instance in {@link CoreCrypto.e2eiRotateAll} to do the rotation.
      *
-     * @param clientId - client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+     * @param clientId - client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
      * @param expiryDays - generated x509 certificate expiry
      * @param ciphersuite - for generating signing key material
      * @param displayName - human-readable name displayed in the application e.g. `Smith, Alice M (QA)`
@@ -1821,7 +1821,7 @@ export class CoreCrypto {
      * If no member has a x509 certificate, it will return an empty Vec.
      *
      * @param conversationId - identifier of the conversation
-     * @param userIds - user identifiers e.g. t6wRpI8BRSeviBwwiFp5MQ which is a base64UrlUnpadded UUIDv4
+     * @param userIds - user identifiers hyphenated UUIDv4 e.g. 'bd4c7053-1c5a-4020-9559-cd7bf7961954'
      * @returns a Map with all the identities for a given users. Consumers are then recommended to reduce those identities to determine the actual status of a user.
      */
     async getUserIdentities(conversationId: ConversationId, userIds: string[]): Promise<Map<string, WireIdentity[]>> {

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.js
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.js
@@ -937,7 +937,7 @@ test("end-to-end-identity", async () => {
     const encoder = new TextEncoder();
     const jsonToByteArray = json => encoder.encode(JSON.stringify(json, null, 0));
 
-    const clientId = "t6wRpI8BRSeviBwwiFp5MQ:4959bc6ab12f2846@wire.com";
+    const clientId = "b7ac11a4-8f01-4527-af88-1c30885a7931:4959bc6ab12f2846@wire.com";
     const displayName = "Alice Smith";
     const handle = "alice_wire";
     const expiryDays = 90;

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
@@ -56,7 +56,7 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
     /**
      * Creates an enrollment instance with private key material you can use in order to fetch a new x509 certificate from the acme server.
      *
-     * @param clientId client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+     * @param clientId client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
      * @param displayName human-readable name displayed in the application e.g. `Smith, Alice M (QA)`
      * @param handle user handle e.g. `alice.smith.qa@example.com`
      * @param expiryDays generated x509 certificate expiry
@@ -79,7 +79,7 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
      * Generates an E2EI enrollment instance for a "regular" client (with a Basic credential) willing to migrate to E2EI.
      * Once the enrollment is finished, use the instance in [e2eiRotateAll] to do the rotation.
      *
-     * @param clientId client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+     * @param clientId client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
      * @param displayName human-readable name displayed in the application e.g. `Smith, Alice M (QA)`
      * @param handle user handle e.g. `alice.smith.qa@example.com`
      * @param expiryDays generated x509 certificate expiry
@@ -112,7 +112,7 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
      * their credential, either because the former one is expired or it has been revoked. It lets you change the DisplayName
      * or the handle if you need to. Once the enrollment is finished, use the instance in [e2eiRotateAll] to do the rotation.
      *
-     * @param clientId client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+     * @param clientId client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
      * @param expiryDays generated x509 certificate expiry
      * @param ciphersuite for generating signing key material
      * @param displayName human-readable name displayed in the application e.g. `Smith, Alice M (QA)`

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
@@ -466,7 +466,7 @@ class MLSClient(private val cc: com.wire.crypto.CoreCrypto) {
      * If no member has a x509 certificate, it will return an empty Vec.
      *
      * @param id conversation identifier
-     * @param userIds user identifiers e.g. t6wRpI8BRSeviBwwiFp5MQ which is a base64UrlUnpadded UUIDv4
+     * @param userIds user identifiers hyphenated UUIDv4 e.g. 'bd4c7053-1c5a-4020-9559-cd7bf7961954'
      * @returns a Map with all the identities for a given users. Consumers are then recommended to reduce those identities to determine the actual status of a user.
      */
     suspend fun getUserIdentities(id: MLSGroupId, userIds: List<String>): Map<String, List<WireIdentity>> {

--- a/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/client/E2EITest.kt
+++ b/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/client/E2EITest.kt
@@ -35,7 +35,7 @@ internal class E2EITest {
         val keyStore = root.resolve("keystore-$aliceId")
         val cc = CoreCryptoCentral(keyStore.absolutePath, "secret")
         val enrollment = cc.e2eiNewEnrollment(
-            clientId = "t6wRpI8BRSeviBwwiFp5MQ:6c1866f567616f31@wire.com",
+            clientId = "b7ac11a4-8f01-4527-af88-1c30885a7931:6c1866f567616f31@wire.com",
             displayName = "Alice Smith",
             handle = "alice_wire",
             expiryDays = 90u,

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -1147,7 +1147,7 @@ public class CoreCryptoWrapper {
     /// Creates an enrollment instance with private key material you can use in order to fetch
     /// a new x509 certificate from the acme server.
     ///
-    /// - parameter clientId: client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+    /// - parameter clientId: client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
     /// - parameter displayName: human readable name displayed in the application e.g. `Smith, Alice M (QA)`
     /// - parameter handle: user handle e.g. `alice.smith.qa@example.com`
     /// - parameter expiryDays: generated x509 certificate expiry
@@ -1162,7 +1162,7 @@ public class CoreCryptoWrapper {
     /// Generates an E2EI enrollment instance for a "regular" client (with a Basic credential) willing to migrate to E2EI.
     /// Once the enrollment is finished, use the instance in ``CoreCrypto/e2eiRotateAll`` to do the rotation.
     ///
-    /// - parameter clientId: client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+    /// - parameter clientId: client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
     /// - parameter displayName: human readable name displayed in the application e.g. `Smith, Alice M (QA)`
     /// - parameter handle: user handle e.g. `alice.smith.qa@example.com`
     /// - parameter expiryDays: generated x509 certificate expiry
@@ -1178,7 +1178,7 @@ public class CoreCryptoWrapper {
     /// their credential, either because the former one is expired or it has been revoked. It lets you change
     /// the DisplayName or the handle if you need to. Once the enrollment is finished, use the instance in ``CoreCrypto/e2eiRotateAll`` to do the rotation.
     ///
-    /// - parameter clientId: client identifier with user b64Url encoded & clientId hex encoded e.g. `t6wRpI8BRSeviBwwiFp5MQ:6add501bacd1d90e@example.com`
+    /// - parameter clientId: client identifier e.g. `b7ac11a4-8f01-4527-af88-1c30885a7931:6add501bacd1d90e@example.com`
     /// - parameter expiryDays: generated x509 certificate expiry
     /// - parameter ciphersuite: For generating signing key material.
     /// - parameter displayName: human readable name displayed in the application e.g. `Smith, Alice M (QA)`
@@ -1258,7 +1258,7 @@ public class CoreCryptoWrapper {
     /// If no member has a x509 certificate, it will return an empty Vec.
     ///
     /// - parameter conversationId: conversation identifier
-    /// - parameter userIds: user identifiers e.g. t6wRpI8BRSeviBwwiFp5MQ which is a base64UrlUnpadded UUIDv4
+    /// - parameter userIds: user identifiers hyphenated UUIDv4 e.g. 'bd4c7053-1c5a-4020-9559-cd7bf7961954'
     /// - returns: a Map with all the identities for a given users. Consumers are then recommended to reduce those identities to determine the actual status of a user.
     public func getUserIdentities(conversationId: ConversationId, userIds: [String]) async throws -> [String: [WireIdentity]] {
         return try await self.coreCrypto.getUserIdentities(conversationId: conversationId, userIds: userIds)

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -52,6 +52,8 @@ oid-registry = "0.6"
 async-recursion = "1"
 uniffi = { workspace = true, optional = true }
 itertools = "0.12"
+uuid = { version = "1.6", features = ["v4"] }
+base64 = "0.21"
 
 [dependencies.proteus-wasm]
 version = "2.1"
@@ -102,7 +104,6 @@ async-trait = "0.1"
 wire-e2e-identity = { version = "=0.6.1", features = ["identity-builder"] }
 fluvio-wasm-timer = "0.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }
-base64 = "0.21"
 
 [dev-dependencies.rcgen]
 git = "https://github.com/wireapp/rcgen"

--- a/crypto/src/e2e_identity/conversation_state.rs
+++ b/crypto/src/e2e_identity/conversation_state.rs
@@ -199,7 +199,7 @@ pub mod tests {
                             not_after: expiration,
                             ..Default::default()
                         };
-                        let cert = CertificateBundle::new_from_builder(case.signature_scheme(), builder);
+                        let cert = CertificateBundle::new_from_builder(builder, case.signature_scheme());
                         let cb = Client::new_x509_credential_bundle(cert).unwrap();
                         let commit = alice_central.e2ei_rotate(&id, &cb).await.unwrap().commit;
                         alice_central.commit_accepted(&id).await.unwrap();
@@ -247,7 +247,7 @@ pub mod tests {
                         not_after: expiration,
                         ..Default::default()
                     };
-                    let cert = CertificateBundle::new_from_builder(case.signature_scheme(), builder);
+                    let cert = CertificateBundle::new_from_builder(builder, case.signature_scheme());
                     let cb = Client::new_x509_credential_bundle(cert).unwrap();
                     alice_central.e2ei_rotate(&id, &cb).await.unwrap();
                     alice_central.commit_accepted(&id).await.unwrap();

--- a/crypto/src/e2e_identity/id.rs
+++ b/crypto/src/e2e_identity/id.rs
@@ -1,0 +1,135 @@
+use crate::{prelude::ClientId, CryptoError, CryptoResult};
+use base64::Engine;
+
+#[cfg(test)]
+const DOMAIN: &str = "wire.com";
+const COLON: u8 = 58;
+
+/// This format: 'bd4c7053-1c5a-4020-9559-cd7bf7961954:4959bc6ab12f2846@wire.com'
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Into, derive_more::Deref)]
+pub struct WireQualifiedClientId(ClientId);
+
+#[cfg(test)]
+impl WireQualifiedClientId {
+    pub fn get_user_id(&self) -> String {
+        let mut split = self.0.split(|b| b == &COLON);
+        let user_id = split.next().unwrap();
+        uuid::Uuid::try_parse_ascii(user_id).unwrap().to_string()
+    }
+
+    pub fn generate() -> Self {
+        let user_id = uuid::Uuid::new_v4().to_string();
+        let device_id = rand::random::<u64>();
+        let client_id = format!("{user_id}:{device_id:x}@{DOMAIN}");
+        Self(client_id.into_bytes().into())
+    }
+}
+
+/// e.g. from 'vUxwUxxaQCCVWc1795YZVA:4959bc6ab12f2846@wire.com'
+impl<'a> TryFrom<&'a [u8]> for WireQualifiedClientId {
+    type Error = CryptoError;
+
+    fn try_from(bytes: &'a [u8]) -> CryptoResult<Self> {
+        const COLON: u8 = 58;
+        let mut split = bytes.split(|b| b == &COLON);
+        let user_id = split.next().ok_or(CryptoError::InvalidClientId)?;
+
+        let user_id = base64::prelude::BASE64_URL_SAFE_NO_PAD
+            .decode(user_id)
+            .map_err(|_| CryptoError::InvalidClientId)?;
+
+        let user_id = uuid::Uuid::from_slice(&user_id).map_err(|_| CryptoError::InvalidClientId)?;
+        let mut buf = [0; uuid::fmt::Hyphenated::LENGTH];
+        let user_id = user_id.hyphenated().encode_lower(&mut buf);
+
+        let rest = split.next().ok_or(CryptoError::InvalidClientId)?;
+        if split.next().is_some() {
+            return Err(CryptoError::InvalidClientId);
+        }
+
+        let client_id = [user_id.as_bytes(), &[COLON], rest].concat();
+        Ok(Self(client_id.into()))
+    }
+}
+
+impl std::str::FromStr for WireQualifiedClientId {
+    type Err = CryptoError;
+
+    fn from_str(s: &str) -> CryptoResult<Self> {
+        s.as_bytes().try_into()
+    }
+}
+
+impl TryFrom<WireQualifiedClientId> for String {
+    type Error = CryptoError;
+
+    fn try_from(id: WireQualifiedClientId) -> CryptoResult<Self> {
+        Ok(String::from_utf8(id.to_vec())?)
+    }
+}
+
+/// This format: 'vUxwUxxaQCCVWc1795YZVA:4959bc6ab12f2846@wire.com'
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Into, derive_more::Deref)]
+pub struct QualifiedE2eiClientId(ClientId);
+
+#[cfg(test)]
+impl QualifiedE2eiClientId {
+    pub fn generate() -> Self {
+        Self::generate_from_user_id(&uuid::Uuid::new_v4())
+    }
+
+    pub fn generate_from_user_id(user_id: &uuid::Uuid) -> Self {
+        use base64::Engine as _;
+
+        let user_id = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(user_id.as_bytes());
+
+        let device_id = rand::random::<u64>();
+        let client_id = format!("{user_id}:{device_id:x}@{DOMAIN}");
+        Self(client_id.into_bytes().into())
+    }
+
+    pub fn from_str_unchecked(s: &str) -> Self {
+        Self(s.as_bytes().into())
+    }
+}
+
+/// e.g. from 'bd4c7053-1c5a-4020-9559-cd7bf7961954:4959bc6ab12f2846@wire.com'
+impl<'a> TryFrom<&'a [u8]> for QualifiedE2eiClientId {
+    type Error = CryptoError;
+
+    fn try_from(bytes: &'a [u8]) -> CryptoResult<Self> {
+        let mut split = bytes.split(|b| b == &COLON);
+        let user_id = split.next().ok_or(CryptoError::InvalidClientId)?;
+
+        let user_id = std::str::from_utf8(user_id)?
+            .parse::<uuid::Uuid>()
+            .map_err(|_| CryptoError::InvalidClientId)?;
+
+        let user_id = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(user_id.as_bytes());
+
+        let rest = split.next().ok_or(CryptoError::InvalidClientId)?;
+        if split.next().is_some() {
+            return Err(CryptoError::InvalidClientId);
+        }
+
+        let client_id = [user_id.as_bytes(), &[COLON], rest].concat();
+        Ok(Self(client_id.into()))
+    }
+}
+
+#[cfg(test)]
+impl std::str::FromStr for QualifiedE2eiClientId {
+    type Err = CryptoError;
+
+    fn from_str(s: &str) -> CryptoResult<Self> {
+        s.as_bytes().try_into()
+    }
+}
+
+impl TryFrom<QualifiedE2eiClientId> for String {
+    type Error = CryptoError;
+
+    fn try_from(id: QualifiedE2eiClientId) -> CryptoResult<Self> {
+        Ok(String::from_utf8(id.to_vec())?)
+    }
+}

--- a/crypto/src/e2e_identity/rotate.rs
+++ b/crypto/src/e2e_identity/rotate.rs
@@ -1,3 +1,11 @@
+use std::collections::HashMap;
+
+use openmls::prelude::{KeyPackage, KeyPackageRef, MlsCredentialType as OpenMlsCredential};
+use openmls_traits::OpenMlsCryptoProvider;
+
+use core_crypto_keystore::{entities::MlsKeyPackage, CryptoKeystoreMls};
+use mls_crypto_provider::MlsCryptoProvider;
+
 use crate::prelude::ConversationId;
 use crate::{
     mls::credential::{ext::CredentialExt, x509::CertificatePrivateKey, CredentialBundle},
@@ -7,11 +15,6 @@ use crate::{
     },
     MlsError,
 };
-use core_crypto_keystore::{entities::MlsKeyPackage, CryptoKeystoreMls};
-use mls_crypto_provider::MlsCryptoProvider;
-use openmls::prelude::{KeyPackage, KeyPackageRef, MlsCredentialType as OpenMlsCredential};
-use openmls_traits::OpenMlsCryptoProvider;
-use std::collections::HashMap;
 
 /// Result returned after rotating the Credential of the current client in all the local conversations
 #[derive(Debug, Clone)]
@@ -257,8 +260,13 @@ impl MlsConversation {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
+    use std::collections::HashSet;
+
+    use openmls::prelude::SignaturePublicKey;
     use tls_codec::Deserialize;
+    use wasm_bindgen_test::*;
+
+    use core_crypto_keystore::entities::{EntityFindParams, MlsCredential};
 
     use crate::{
         e2e_identity::tests::*,
@@ -267,24 +275,21 @@ pub mod tests {
         test_utils::*,
     };
 
-    use core_crypto_keystore::entities::{EntityFindParams, MlsCredential};
-    use openmls::prelude::SignaturePublicKey;
-    use std::collections::HashSet;
-    use wasm_bindgen_test::*;
+    use super::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     pub mod all {
-        use super::*;
         use crate::test_utils::central::TEAM;
+
+        use super::*;
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
         pub async fn enrollment_should_rotate_all(case: TestCase) {
-            let alice = "t6wRpI8BRSeviBwwiFp5MQ:a661e79735dc890f@wire.com";
             run_test_with_client_ids(
                 case.clone(),
-                [alice, "bob", "charlie"],
+                ["alice", "bob", "charlie"],
                 move |[mut alice_central, mut bob_central, mut charlie_central]| {
                     Box::pin(async move {
                         const N: usize = 50;
@@ -468,8 +473,7 @@ pub mod tests {
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
         pub async fn should_restore_credentials_in_order(case: TestCase) {
-            let alice = "t6wRpI8BRSeviBwwiFp5MQ:a661e79735dc890f@wire.com";
-            run_test_with_client_ids(case.clone(), [alice], move |[mut alice_central]| {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central
@@ -578,11 +582,9 @@ pub mod tests {
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
         pub async fn rotate_should_roundtrip(case: TestCase) {
-            let alice = "t6wRpI8BRSeviBwwiFp5MQ:a661e79735dc890f@wire.com";
-            let bob = "t6wRpI8BRSeviBwwiFp5MQ:ef6a91a91d3337a@wire.com";
             run_test_with_client_ids(
                 case.clone(),
-                [alice, bob],
+                ["alice", "bob"],
                 move |[mut alice_central, mut bob_central]| {
                     Box::pin(async move {
                         let id = conversation_id();

--- a/crypto/src/e2e_identity/stash.rs
+++ b/crypto/src/e2e_identity/stash.rs
@@ -57,6 +57,7 @@ impl MlsCentral {
 
 #[cfg(test)]
 pub mod tests {
+    use crate::e2e_identity::id::WireQualifiedClientId;
     use crate::{
         e2e_identity::tests::*,
         prelude::{E2eiEnrollment, MlsCentral, INITIAL_KEYING_MATERIAL_COUNT},
@@ -120,8 +121,9 @@ pub mod tests {
                     Box::pin(async move {
                         // this restore recreates a partial enrollment
                         let backend = MlsCryptoProvider::try_new_in_memory("new").await.unwrap();
+                        let client_id = e.client_id.parse::<WireQualifiedClientId>().unwrap();
                         let enrollment = E2eiEnrollment::try_new(
-                            e.client_id.as_str().into(),
+                            client_id.into(),
                             e.display_name,
                             e.handle,
                             e.team,

--- a/crypto/src/mls/client/identifier.rs
+++ b/crypto/src/mls/client/identifier.rs
@@ -51,9 +51,10 @@ impl ClientIdentifier {
                 },
             ),
             ClientIdentifier::X509(certs) => {
+                let cap = certs.len();
                 certs
                     .into_iter()
-                    .try_fold(vec![], |mut acc, (sc, cert)| -> CryptoResult<_> {
+                    .try_fold(Vec::with_capacity(cap), |mut acc, (sc, cert)| -> CryptoResult<_> {
                         let id = cert.get_client_id()?;
                         let cb = Client::new_x509_credential_bundle(cert)?;
                         acc.push((sc, id, cb));

--- a/crypto/src/mls/client/mod.rs
+++ b/crypto/src/mls/client/mod.rs
@@ -453,14 +453,10 @@ impl Client {
     ) -> CryptoResult<Self> {
         let user_uuid = uuid::Uuid::new_v4();
         let rnd_id = rand::random::<usize>();
-        let client_id: ClientId = format!("{}:{rnd_id:x}@members.wire.com", user_uuid.hyphenated())
-            .as_bytes()
-            .into();
+        let client_id = format!("{}:{rnd_id:x}@members.wire.com", user_uuid.hyphenated());
         let identity = match case.credential_type {
-            MlsCredentialType::Basic => ClientIdentifier::Basic(client_id),
-            MlsCredentialType::X509 => {
-                crate::prelude::CertificateBundle::rand_identifier(&[case.signature_scheme()], client_id)
-            }
+            MlsCredentialType::Basic => ClientIdentifier::Basic(client_id.as_str().into()),
+            MlsCredentialType::X509 => CertificateBundle::rand_identifier(&client_id, &[case.signature_scheme()]),
         };
         let nb_key_package = if provision {
             crate::prelude::INITIAL_KEYING_MATERIAL_COUNT

--- a/crypto/src/mls/conversation/self_commit.rs
+++ b/crypto/src/mls/conversation/self_commit.rs
@@ -102,8 +102,7 @@ pub mod tests {
     #[wasm_bindgen_test]
     pub async fn should_succeed_when_incoming_commit_same_as_pending(case: TestCase) {
         if !case.is_pure_ciphertext() {
-            let alice = "t6wRpI8BRSeviBwwiFp5MQ:a661e79735dc890f@wire.com";
-            run_test_with_client_ids(case.clone(), [alice], move |[mut alice_central]| {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
                     alice_central

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -172,8 +172,8 @@ pub mod tests {
     #[wasm_bindgen_test]
     async fn certificate_clients_can_send_messages(case: TestCase) {
         if case.is_x509() {
-            let alice_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "alice".into());
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let alice_identifier = CertificateBundle::rand_identifier("alice", &[case.signature_scheme()]);
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
             assert!(try_talk(&case, alice_identifier, bob_identifier).await.is_ok());
         }
     }
@@ -184,12 +184,12 @@ pub mod tests {
         // check that both credentials can initiate/join a group
         {
             let alice_identifier = ClientIdentifier::Basic("alice".into());
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
             assert!(try_talk(&case, alice_identifier, bob_identifier).await.is_ok());
             // drop alice & bob key stores
         }
         {
-            let alice_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "alice".into());
+            let alice_identifier = CertificateBundle::rand_identifier("alice", &[case.signature_scheme()]);
             let bob_identifier = ClientIdentifier::Basic("bob".into());
             assert!(try_talk(&case, alice_identifier, bob_identifier).await.is_ok());
         }
@@ -202,7 +202,7 @@ pub mod tests {
         certs.certificate_chain = vec![];
         let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), certs)]));
 
-        let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+        let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
         assert!(matches!(
             try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err(),
             CryptoError::InvalidIdentity
@@ -217,7 +217,7 @@ pub mod tests {
         certs.certificate_chain = vec![root_ca];
         let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), certs)]));
 
-        let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+        let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
         assert!(matches!(
             try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err(),
             CryptoError::InvalidIdentity
@@ -234,7 +234,7 @@ pub mod tests {
             certs.certificate_chain = vec![leaf];
             let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), certs)]));
 
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
 
             assert!(matches!(
                 try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err(),
@@ -253,7 +253,7 @@ pub mod tests {
         certs.certificate_chain.reverse();
         let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), certs)]));
 
-        let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+        let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
         assert!(matches!(
             try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err(),
             CryptoError::InvalidIdentity
@@ -272,7 +272,7 @@ pub mod tests {
             certs.certificate_chain.push(eve_ca.serialize_der().unwrap());
             let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), certs)]));
 
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
 
             assert!(matches!(
                 try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err(),
@@ -299,7 +299,7 @@ pub mod tests {
             };
             let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), cb)]));
 
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
 
             assert!(matches!(
                 try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err(),
@@ -330,7 +330,7 @@ pub mod tests {
             };
             let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), cb)]));
 
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
             // this should work since the certificate is not yet expired
             let (mut alice_central, mut bob_central, id) =
                 try_talk(&case, alice_identifier, bob_identifier).await.unwrap();
@@ -372,7 +372,7 @@ pub mod tests {
             };
             let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), cb)]));
 
-            let bob_identifier = CertificateBundle::rand_identifier(&[case.signature_scheme()], "bob".into());
+            let bob_identifier = CertificateBundle::rand_identifier("bob", &[case.signature_scheme()]);
 
             match try_talk(&case, alice_identifier, bob_identifier).await.unwrap_err() {
                 CryptoError::MlsError(MlsError::MlsCryptoError(openmls::prelude::CryptoError::ExpiredCertificate)) => {}

--- a/crypto/src/mls/credential/x509.rs
+++ b/crypto/src/mls/credential/x509.rs
@@ -1,9 +1,14 @@
 use openmls_traits::types::SignatureScheme;
 use wire_e2e_identity::prelude::WireIdentityReader;
-
-use crate::prelude::{ClientId, CryptoError, CryptoResult};
-
 use zeroize::Zeroize;
+
+#[cfg(test)]
+use wire_e2e_identity::prelude::{WireIdentityBuilder, WireIdentityBuilderOptions, WireIdentityBuilderX509};
+
+use crate::{
+    e2e_identity::id::WireQualifiedClientId,
+    prelude::{ClientId, CryptoError, CryptoResult},
+};
 
 #[derive(Debug, Clone, Zeroize)]
 #[zeroize(drop)]
@@ -35,8 +40,10 @@ impl CertificateBundle {
     /// Reads the client_id from the leaf certificate
     pub fn get_client_id(&self) -> CryptoResult<ClientId> {
         let leaf = self.certificate_chain.first().ok_or(CryptoError::InvalidIdentity)?;
+
         let identity = leaf.extract_identity().map_err(|_| CryptoError::InvalidIdentity)?;
-        Ok(identity.client_id.as_bytes().into())
+        let client_id = identity.client_id.parse::<WireQualifiedClientId>()?;
+        Ok(client_id.into())
     }
 
     /// Reads the 'Not Before' claim from the leaf certificate
@@ -49,21 +56,21 @@ impl CertificateBundle {
 #[cfg(test)]
 impl CertificateBundle {
     /// Generates a certificate that is later turned into a [openmls::prelude::CredentialBundle]
-    pub fn rand(client_id: &ClientId, sc: openmls::prelude::SignatureScheme) -> Self {
+    pub fn rand(name: &ClientId, sc: SignatureScheme) -> Self {
         // here in our tests client_id is generally just "alice" or "bob"
         // so we will use it to augment handle & display_name
         // and not a real client_id, instead we'll generate a random one
-        let handle = format!("{}_wire", client_id);
-        let display_name = format!("{} Smith", client_id);
+        let handle = format!("{name}_wire");
+        let display_name = format!("{name} Smith");
         Self::new(sc, &handle, &display_name, None, None)
     }
 
     /// Generates a certificate that is later turned into a [openmls::prelude::CredentialBundle]
     pub fn new(
-        sc: openmls::prelude::SignatureScheme,
+        sc: SignatureScheme,
         handle: &str,
         display_name: &str,
-        client_id: Option<&ClientId>,
+        client_id: Option<&crate::e2e_identity::id::QualifiedE2eiClientId>,
         cert_kp: Option<Vec<u8>>,
     ) -> Self {
         // here in our tests client_id is generally just "alice" or "bob"
@@ -71,31 +78,27 @@ impl CertificateBundle {
         // and not a real client_id, instead we'll generate a random one
         let domain = "wire.com";
         let (client_id, domain) = client_id
-            .and_then(|c| std::str::from_utf8(c.0.as_slice()).ok())
-            .map(|cid| (cid.to_string(), domain.to_string()))
-            .unwrap_or_else(|| {
-                wire_e2e_identity::prelude::WireIdentityBuilder::new_rand_client(Some(domain.to_string()))
-            });
-        let builder = wire_e2e_identity::prelude::WireIdentityBuilder {
+            .map(|cid| {
+                let cid = String::from_utf8(cid.to_vec()).unwrap();
+                (cid, domain.to_string())
+            })
+            .unwrap_or_else(|| WireIdentityBuilder::new_rand_client(Some(domain.to_string())));
+
+        let builder = WireIdentityBuilder {
             handle: handle.to_string(),
             display_name: display_name.to_string(),
             client_id,
             domain,
-            options: Some(wire_e2e_identity::prelude::WireIdentityBuilderOptions::X509(
-                wire_e2e_identity::prelude::WireIdentityBuilderX509 {
-                    cert_kp,
-                    ..Default::default()
-                },
-            )),
+            options: Some(WireIdentityBuilderOptions::X509(WireIdentityBuilderX509 {
+                cert_kp,
+                ..Default::default()
+            })),
             ..Default::default()
         };
-        Self::new_from_builder(sc, builder)
+        Self::new_from_builder(builder, sc)
     }
 
-    pub fn new_from_builder(
-        sc: openmls::prelude::SignatureScheme,
-        builder: wire_e2e_identity::prelude::WireIdentityBuilder,
-    ) -> Self {
+    pub fn new_from_builder(builder: WireIdentityBuilder, sc: SignatureScheme) -> Self {
         let (certificate_chain, sign_key) = builder.build_x509_der();
         Self {
             certificate_chain,
@@ -106,14 +109,11 @@ impl CertificateBundle {
         }
     }
 
-    pub fn rand_identifier(
-        signature_schemes: &[openmls::prelude::SignatureScheme],
-        client_id: ClientId,
-    ) -> crate::prelude::ClientIdentifier {
+    pub fn rand_identifier(name: &str, signature_schemes: &[SignatureScheme]) -> crate::prelude::ClientIdentifier {
         crate::prelude::ClientIdentifier::X509(
             signature_schemes
                 .iter()
-                .map(|sc| (*sc, Self::rand(&client_id, *sc)))
+                .map(|sc| (*sc, Self::rand(&name.into(), *sc)))
                 .collect::<std::collections::HashMap<_, _>>(),
         )
     }

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -638,11 +638,11 @@ pub mod tests {
                 let mut central = MlsCentral::try_new(configuration).await.unwrap();
                 assert!(central.mls_client.is_none());
                 // phase 2: init mls_client
-                let client_id = "alice".into();
+                let client_id = "alice";
                 let identifier = match case.credential_type {
-                    MlsCredentialType::Basic => ClientIdentifier::Basic(client_id),
+                    MlsCredentialType::Basic => ClientIdentifier::Basic(client_id.into()),
                     MlsCredentialType::X509 => {
-                        CertificateBundle::rand_identifier(&[case.signature_scheme()], client_id)
+                        CertificateBundle::rand_identifier(client_id, &[case.signature_scheme()])
                     }
                 };
                 central

--- a/crypto/src/proteus.rs
+++ b/crypto/src/proteus.rs
@@ -1012,10 +1012,10 @@ mod tests {
         // proteus is initialized, prekeys can be generated
         assert!(cc.proteus_new_prekey(1).await.is_ok());
         // 👇 and so a unique 'client_id' can be fetched from wire-server
-        let client_id = "alice".into();
+        let client_id = "alice";
         let identifier = match case.credential_type {
-            MlsCredentialType::Basic => ClientIdentifier::Basic(client_id),
-            MlsCredentialType::X509 => CertificateBundle::rand_identifier(&[case.signature_scheme()], client_id),
+            MlsCredentialType::Basic => ClientIdentifier::Basic(client_id.into()),
+            MlsCredentialType::X509 => CertificateBundle::rand_identifier(client_id, &[case.signature_scheme()]),
         };
         cc.mls_init(
             identifier,

--- a/mls-provider/src/crypto_provider.rs
+++ b/mls-provider/src/crypto_provider.rs
@@ -63,12 +63,7 @@ impl OpenMlsCrypto for RustCrypto {
         ]
     }
 
-    fn hkdf_extract(
-        &self,
-        hash_type: openmls_traits::types::HashType,
-        salt: &[u8],
-        ikm: &[u8],
-    ) -> Result<SecretVLBytes, CryptoError> {
+    fn hkdf_extract(&self, hash_type: HashType, salt: &[u8], ikm: &[u8]) -> Result<SecretVLBytes, CryptoError> {
         match hash_type {
             HashType::Sha2_256 => Ok(Hkdf::<Sha256>::extract(Some(salt), ikm).0.as_slice().into()),
             HashType::Sha2_384 => Ok(Hkdf::<Sha384>::extract(Some(salt), ikm).0.as_slice().into()),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

So far regular supplied ClientId in MLS had their UserId portion encoded with the UUIDv4 hyphenated string representation whereas in e2ei certificate the uint128 base64UrlUnpadded representation was used. This tends to harmonize this.

From now on only the former format will surface in the public API so users won't be confused anymore.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
