### PR TITLE
feat!: expose keyauth in ACME authz

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/E2eiClient.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/E2eiClient.kt
@@ -37,8 +37,9 @@ fun com.wire.crypto.AcmeChallenge.toAcmeChallenge() = AcmeChallenge(this)
 
 data class NewAcmeAuthz(private val delegate: com.wire.crypto.NewAcmeAuthz) {
     val identifier: String get() = delegate.identifier
-    val wireOidcChallenge: AcmeChallenge? get() = delegate.wireOidcChallenge?.toAcmeChallenge()
-    val wireDpopChallenge: AcmeChallenge? get() = delegate.wireDpopChallenge?.toAcmeChallenge()
+    val keyauth: String get() = delegate.keyauth
+    val wireOidcChallenge: AcmeChallenge get() = delegate.wireOidcChallenge.toAcmeChallenge()
+    val wireDpopChallenge: AcmeChallenge get() = delegate.wireDpopChallenge.toAcmeChallenge()
 
     fun lower() = delegate
 }

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -1550,13 +1550,16 @@ public struct NewAcmeOrder: ConvertToInner {
 public struct NewAcmeAuthz: ConvertToInner {
     /// DNS entry associated with those challenge
     public var identifier: String
+    /// To use in the OAuth authorization request
+    public var keyauth: String
     /// Challenge for the deviceId owned by wire-server
-    public var wireDpopChallenge: AcmeChallenge?
+    public var wireDpopChallenge: AcmeChallenge
     /// Challenge for the userId and displayName owned by the identity provider
-    public var wireOidcChallenge: AcmeChallenge?
+    public var wireOidcChallenge: AcmeChallenge
 
-    public init(identifier: String, wireDpopChallenge: AcmeChallenge?, wireOidcChallenge: AcmeChallenge?) {
+    public init(identifier: String, keyauth: String, wireDpopChallenge: AcmeChallenge, wireOidcChallenge: AcmeChallenge) {
         self.identifier = identifier
+        self.keyauth = keyauth
         self.wireDpopChallenge = wireDpopChallenge
         self.wireOidcChallenge = wireOidcChallenge
     }
@@ -1564,7 +1567,7 @@ public struct NewAcmeAuthz: ConvertToInner {
     typealias Inner = CoreCryptoSwift.NewAcmeAuthz
 
     func convert() -> Inner {
-        return CoreCryptoSwift.NewAcmeAuthz(identifier: self.identifier, wireDpopChallenge: self.wireDpopChallenge, wireOidcChallenge: self.wireOidcChallenge)
+        return CoreCryptoSwift.NewAcmeAuthz(identifier: self.identifier, keyauth: self.keyauth, wireDpopChallenge: self.wireDpopChallenge, wireOidcChallenge: self.wireOidcChallenge)
     }
 }
 

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -1911,16 +1911,18 @@ impl From<NewAcmeOrder> for core_crypto::prelude::E2eiNewAcmeOrder {
 /// See [core_crypto::e2e_identity::types::E2eiNewAcmeAuthz]
 pub struct NewAcmeAuthz {
     pub identifier: String,
-    pub wire_dpop_challenge: Option<AcmeChallenge>,
-    pub wire_oidc_challenge: Option<AcmeChallenge>,
+    pub keyauth: String,
+    pub wire_dpop_challenge: AcmeChallenge,
+    pub wire_oidc_challenge: AcmeChallenge,
 }
 
 impl From<core_crypto::prelude::E2eiNewAcmeAuthz> for NewAcmeAuthz {
     fn from(new_authz: core_crypto::prelude::E2eiNewAcmeAuthz) -> Self {
         Self {
             identifier: new_authz.identifier,
-            wire_dpop_challenge: new_authz.wire_dpop_challenge.map(Into::into),
-            wire_oidc_challenge: new_authz.wire_oidc_challenge.map(Into::into),
+            keyauth: new_authz.keyauth,
+            wire_dpop_challenge: new_authz.wire_dpop_challenge.into(),
+            wire_oidc_challenge: new_authz.wire_oidc_challenge.into(),
         }
     }
 }
@@ -1929,8 +1931,9 @@ impl From<NewAcmeAuthz> for core_crypto::prelude::E2eiNewAcmeAuthz {
     fn from(new_authz: NewAcmeAuthz) -> Self {
         Self {
             identifier: new_authz.identifier,
-            wire_dpop_challenge: new_authz.wire_dpop_challenge.map(Into::into),
-            wire_oidc_challenge: new_authz.wire_oidc_challenge.map(Into::into),
+            keyauth: new_authz.keyauth,
+            wire_dpop_challenge: new_authz.wire_dpop_challenge.into(),
+            wire_oidc_challenge: new_authz.wire_oidc_challenge.into(),
         }
     }
 }

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -2987,20 +2987,24 @@ pub struct NewAcmeAuthz {
     /// DNS entry associated with those challenge
     #[wasm_bindgen(readonly, js_name = "identifier")]
     pub identifier: String,
+    /// ACME challenge + ACME key thumbprint
+    #[wasm_bindgen(readonly, js_name = "keyauth")]
+    pub keyauth: String,
     /// Challenge for the deviceId owned by wire-server
     #[wasm_bindgen(readonly, js_name = "wireDpopChallenge")]
-    pub wire_dpop_challenge: Option<AcmeChallenge>,
+    pub wire_dpop_challenge: AcmeChallenge,
     /// Challenge for the userId and displayName owned by the identity provider
     #[wasm_bindgen(readonly, js_name = "wireOidcChallenge")]
-    pub wire_oidc_challenge: Option<AcmeChallenge>,
+    pub wire_oidc_challenge: AcmeChallenge,
 }
 
 impl From<core_crypto::prelude::E2eiNewAcmeAuthz> for NewAcmeAuthz {
     fn from(authz: core_crypto::prelude::E2eiNewAcmeAuthz) -> Self {
         Self {
             identifier: authz.identifier,
-            wire_dpop_challenge: authz.wire_dpop_challenge.map(Into::into),
-            wire_oidc_challenge: authz.wire_oidc_challenge.map(Into::into),
+            keyauth: authz.keyauth,
+            wire_dpop_challenge: authz.wire_dpop_challenge.into(),
+            wire_oidc_challenge: authz.wire_oidc_challenge.into(),
         }
     }
 }
@@ -3009,8 +3013,9 @@ impl From<NewAcmeAuthz> for core_crypto::prelude::E2eiNewAcmeAuthz {
     fn from(authz: NewAcmeAuthz) -> Self {
         Self {
             identifier: authz.identifier,
-            wire_dpop_challenge: authz.wire_dpop_challenge.map(Into::into),
-            wire_oidc_challenge: authz.wire_oidc_challenge.map(Into::into),
+            keyauth: authz.keyauth,
+            wire_dpop_challenge: authz.wire_dpop_challenge.into(),
+            wire_oidc_challenge: authz.wire_oidc_challenge.into(),
         }
     }
 }

--- a/crypto/src/e2e_identity/mod.rs
+++ b/crypto/src/e2e_identity/mod.rs
@@ -484,12 +484,7 @@ impl E2eiEnrollment {
         let authz = self.authz.as_ref().ok_or(E2eIdentityError::OutOfOrderEnrollment(
             "You must first call 'newAuthzResponse()'",
         ))?;
-        let dpop_challenge = authz
-            .wire_dpop_challenge
-            .as_ref()
-            .ok_or(E2eIdentityError::OutOfOrderEnrollment(
-                "You must first call 'newAuthzResponse()'",
-            ))?;
+        let dpop_challenge = &authz.wire_dpop_challenge;
         Ok(self.new_dpop_token(
             &self.client_id,
             dpop_challenge,
@@ -513,12 +508,7 @@ impl E2eiEnrollment {
         let authz = self.authz.as_ref().ok_or(E2eIdentityError::OutOfOrderEnrollment(
             "You must first call 'newAuthzResponse()'",
         ))?;
-        let dpop_challenge = authz
-            .wire_dpop_challenge
-            .as_ref()
-            .ok_or(E2eIdentityError::OutOfOrderEnrollment(
-                "You must first call 'createDpopToken()'",
-            ))?;
+        let dpop_challenge = &authz.wire_dpop_challenge;
         let account = self.account.as_ref().ok_or(E2eIdentityError::OutOfOrderEnrollment(
             "You must first call 'newAccountResponse()'",
         ))?;
@@ -560,12 +550,7 @@ impl E2eiEnrollment {
         let authz = self.authz.as_ref().ok_or(E2eIdentityError::OutOfOrderEnrollment(
             "You must first call 'newAuthzResponse()'",
         ))?;
-        let oidc_challenge = authz
-            .wire_oidc_challenge
-            .as_ref()
-            .ok_or(E2eIdentityError::OutOfOrderEnrollment(
-                "You must first call 'newAuthzResponse()'",
-            ))?;
+        let oidc_challenge = &authz.wire_oidc_challenge;
         let account = self.account.as_ref().ok_or(E2eIdentityError::OutOfOrderEnrollment(
             "You must first call 'newAccountResponse()'",
         ))?;

--- a/crypto/src/e2e_identity/types.rs
+++ b/crypto/src/e2e_identity/types.rs
@@ -86,12 +86,12 @@ impl TryFrom<E2eiNewAcmeOrder> for wire_e2e_identity::prelude::E2eiNewAcmeOrder 
 pub struct E2eiNewAcmeAuthz {
     /// DNS entry associated with those challenge
     pub identifier: String,
+    /// ACME challenge + ACME key thumbprint
+    pub keyauth: String,
     /// Challenge for the clientId
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub wire_dpop_challenge: Option<E2eiAcmeChallenge>,
+    pub wire_dpop_challenge: E2eiAcmeChallenge,
     /// Challenge for the handle + display name
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub wire_oidc_challenge: Option<E2eiAcmeChallenge>,
+    pub wire_oidc_challenge: E2eiAcmeChallenge,
 }
 
 impl TryFrom<wire_e2e_identity::prelude::E2eiNewAcmeAuthz> for E2eiNewAcmeAuthz {
@@ -100,8 +100,9 @@ impl TryFrom<wire_e2e_identity::prelude::E2eiNewAcmeAuthz> for E2eiNewAcmeAuthz 
     fn try_from(authz: wire_e2e_identity::prelude::E2eiNewAcmeAuthz) -> E2eIdentityResult<Self> {
         Ok(Self {
             identifier: authz.identifier,
-            wire_dpop_challenge: authz.wire_dpop_challenge.map(TryFrom::try_from).transpose()?,
-            wire_oidc_challenge: authz.wire_oidc_challenge.map(TryFrom::try_from).transpose()?,
+            keyauth: authz.keyauth,
+            wire_dpop_challenge: authz.wire_dpop_challenge.try_into()?,
+            wire_oidc_challenge: authz.wire_oidc_challenge.try_into()?,
         })
     }
 }
@@ -112,8 +113,9 @@ impl TryFrom<&E2eiNewAcmeAuthz> for wire_e2e_identity::prelude::E2eiNewAcmeAuthz
     fn try_from(authz: &E2eiNewAcmeAuthz) -> E2eIdentityResult<Self> {
         Ok(Self {
             identifier: authz.identifier.clone(),
-            wire_dpop_challenge: authz.wire_dpop_challenge.as_ref().map(TryFrom::try_from).transpose()?,
-            wire_oidc_challenge: authz.wire_oidc_challenge.as_ref().map(TryFrom::try_from).transpose()?,
+            keyauth: authz.keyauth.clone(),
+            wire_dpop_challenge: (&authz.wire_dpop_challenge).try_into()?,
+            wire_oidc_challenge: (&authz.wire_oidc_challenge).try_into()?,
         })
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Return keyauth after creating the authorization to seal it in the OIDC Id token.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
