### PR TITLE
feat(e2ei)!: rework refreshToken

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -2353,19 +2353,16 @@ export class E2eiEnrollment {
      * Creates a new challenge request for Wire Oidc challenge.
      *
      * @param idToken you get back from Identity Provider
-     * @param refreshToken you get back from Identity Provider to renew the access token
      * @param previousNonce `replay-nonce` response header from `POST /acme/{provisioner-name}/authz/{authz-id}`
      * @see https://www.rfc-editor.org/rfc/rfc8555.html#section-7.5.1
      */
     async newOidcChallengeRequest(
         idToken: string,
-        refreshToken: string,
         previousNonce: string
     ): Promise<JsonRawData> {
         return await CoreCryptoError.asyncMapErr(
             this.#enrollment.new_oidc_challenge_request(
                 idToken,
-                refreshToken,
                 previousNonce
             )
         );
@@ -2378,15 +2375,9 @@ export class E2eiEnrollment {
      * @param challenge HTTP response body
      * @see https://www.rfc-editor.org/rfc/rfc8555.html#section-7.5.1
      */
-    async newOidcChallengeResponse(
-        cc: CoreCrypto,
-        challenge: JsonRawData
-    ): Promise<void> {
+    async newOidcChallengeResponse(challenge: JsonRawData): Promise<void> {
         return await CoreCryptoError.asyncMapErr(
-            this.#enrollment.new_oidc_challenge_response(
-                cc.inner() as CoreCryptoFfiTypes.CoreCrypto,
-                challenge
-            )
+            this.#enrollment.new_oidc_challenge_response(challenge)
         );
     }
 
@@ -2453,17 +2444,6 @@ export class E2eiEnrollment {
     async certificateRequest(previousNonce: string): Promise<JsonRawData> {
         return await CoreCryptoError.asyncMapErr(
             this.#enrollment.certificate_request(previousNonce)
-        );
-    }
-
-    /**
-     * Lets clients retrieve the OIDC refresh token to try to renew the user's authorization.
-     * If it's expired, the user needs to reauthenticate and they will update the refresh token
-     * in {@link newOidcChallengeRequest}
-     */
-    async getRefreshToken(): Promise<String> {
-        return await CoreCryptoError.asyncMapErr(
-            this.#enrollment.get_refresh_token()
         );
     }
 }

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.js
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.js
@@ -924,7 +924,7 @@ test("proteus", async () => {
 test("end-to-end-identity", async () => {
   const [ctx, page] = await initBrowser();
 
-  let refreshToken = await page.evaluate(async () => {
+  await page.evaluate(async () => {
     const { CoreCrypto, Ciphersuite, CoreCryptoError } = await import("./corecrypto.js");
 
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
@@ -1050,9 +1050,7 @@ test("end-to-end-identity", async () => {
     enrollment = await cc.e2eiEnrollmentStashPop(storeHandle);
 
     const idToken = "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NzU5NjE3NTYsImV4cCI6MTY3NjA0ODE1NiwibmJmIjoxNjc1OTYxNzU2LCJpc3MiOiJodHRwOi8vaWRwLyIsInN1YiI6ImltcHA6d2lyZWFwcD1OREV5WkdZd05qYzJNekZrTkRCaU5UbGxZbVZtTWpReVpUSXpOVGM0TldRLzY1YzNhYzFhMTYzMWMxMzZAZXhhbXBsZS5jb20iLCJhdWQiOiJodHRwOi8vaWRwLyIsIm5hbWUiOiJTbWl0aCwgQWxpY2UgTSAoUUEpIiwiaGFuZGxlIjoiaW1wcDp3aXJlYXBwPWFsaWNlLnNtaXRoLnFhQGV4YW1wbGUuY29tIiwia2V5YXV0aCI6IlNZNzR0Sm1BSUloZHpSdEp2cHgzODlmNkVLSGJYdXhRLi15V29ZVDlIQlYwb0ZMVElSRGw3cjhPclZGNFJCVjhOVlFObEw3cUxjbWcifQ.0iiq3p5Bmmp8ekoFqv4jQu_GrnPbEfxJ36SCuw-UvV6hCi6GlxOwU7gwwtguajhsd1sednGWZpN8QssKI5_CDQ";
-    const refreshToken = "refresh-token";
-    const oidcChallengeReq = await enrollment.newOidcChallengeRequest(idToken, refreshToken, previousNonce);
-    const storedRefreshToken = await enrollment.getRefreshToken();
+    const oidcChallengeReq = await enrollment.newOidcChallengeRequest(idToken, previousNonce);
 
     const oidcChallengeResp = {
       "type": "wire-oidc-01",
@@ -1061,7 +1059,7 @@ test("end-to-end-identity", async () => {
       "token": "2FpTOmNQvNfWDktNWt1oIJnjLE3MkyFb",
       "target": "http://example.com/target"
     };
-    await enrollment.newOidcChallengeResponse(cc, jsonToByteArray(oidcChallengeResp));
+    await enrollment.newOidcChallengeResponse(jsonToByteArray(oidcChallengeResp));
 
     const orderUrl = "https://example.com/acme/wire-acme/order/C7uOXEgg5KPMPtbdE3aVMzv7cJjwUVth";
     const checkOrderReq = await enrollment.checkOrderRequest(orderUrl, previousNonce);
@@ -1115,10 +1113,7 @@ test("end-to-end-identity", async () => {
       await enrollment.finalizeResponse(jsonToByteArray(finalizeResp));
 
     const certificateReq = await enrollment.certificateRequest(previousNonce);
-    return storedRefreshToken;
   });
-
-  expect(refreshToken).toBe("refresh-token");
 
   await page.close();
   await ctx.close();

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -2798,17 +2798,12 @@ impl E2eiEnrollment {
     }
 
     /// See [core_crypto::e2e_identity::WireE2eIdentity::new_oidc_challenge_request]
-    pub fn new_oidc_challenge_request(
-        &mut self,
-        id_token: String,
-        refresh_token: String,
-        previous_nonce: String,
-    ) -> Promise {
+    pub fn new_oidc_challenge_request(&mut self, id_token: String, previous_nonce: String) -> Promise {
         let this = self.0.clone();
         future_to_promise(
             async move {
                 let mut this = this.write().await;
-                let chall = this.new_oidc_challenge_request(id_token, refresh_token, previous_nonce)?;
+                let chall = this.new_oidc_challenge_request(id_token, previous_nonce)?;
                 WasmCryptoResult::Ok(Uint8Array::from(chall.as_slice()).into())
             }
             .err_into(),
@@ -2816,15 +2811,12 @@ impl E2eiEnrollment {
     }
 
     /// See [core_crypto::e2e_identity::WireE2eIdentity::new_oidc_challenge_response]
-    pub fn new_oidc_challenge_response(&mut self, cc: &CoreCrypto, challenge: Uint8Array) -> Promise {
-        let cc = cc.inner.clone();
+    pub fn new_oidc_challenge_response(&mut self, challenge: Uint8Array) -> Promise {
         let this = self.0.clone();
         future_to_promise(
             async move {
-                let cc = cc.write().await;
                 let mut this = this.write().await;
-                this.new_oidc_challenge_response(cc.provider(), challenge.to_vec())
-                    .await?;
+                this.new_oidc_challenge_response(challenge.to_vec()).await?;
                 WasmCryptoResult::Ok(JsValue::UNDEFINED)
             }
             .err_into(),
@@ -2889,18 +2881,6 @@ impl E2eiEnrollment {
                 let mut this = this.write().await;
                 let certificate_req = this.certificate_request(previous_nonce)?;
                 WasmCryptoResult::Ok(Uint8Array::from(certificate_req.as_slice()).into())
-            }
-            .err_into(),
-        )
-    }
-
-    /// See [core_crypto::e2e_identity::WireE2eIdentity::get_refresh_token]
-    pub fn get_refresh_token(&mut self) -> Promise {
-        let this = self.0.clone();
-        future_to_promise(
-            async move {
-                let this = this.read().await;
-                WasmCryptoResult::Ok(this.get_refresh_token()?.to_string().into())
             }
             .err_into(),
         )

--- a/crypto/src/e2e_identity/stash.rs
+++ b/crypto/src/e2e_identity/stash.rs
@@ -146,6 +146,7 @@ pub mod tests {
                             &backend,
                             e.ciphersuite,
                             None,
+                            #[cfg(not(target_family = "wasm"))]
                             None,
                         )
                         .unwrap();


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

remove refreshToken handling from WASM altogether as it is not used and tentatively fix an issue with CoreCrypto's PkiEnv being dropped.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
