### PR TITLE
fix(e2ei): register intermediate certificates at issuance since they're not fetchable afterwards

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1988,7 +1988,7 @@ export class CoreCrypto {
         enrollment: E2eiEnrollment,
         certificateChain: string,
         nbKeyPackage?: number
-    ): Promise<void> {
+    ): Promise<string[] | undefined> {
         return await this.#cc.e2ei_mls_init_only(
             enrollment.inner() as CoreCryptoFfiTypes.FfiWireE2EIdentity,
             certificateChain,

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
@@ -149,9 +149,9 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
         enrollment: E2EIEnrollment,
         certificateChain: String,
         nbKeyPackage: UInt? = DEFAULT_NB_KEY_PACKAGE
-    ): MLSClient {
-        cc.e2eiMlsInitOnly(enrollment.lower(), certificateChain, nbKeyPackage)
-        return MLSClient(cc)
+    ): Pair<MLSClient, CrlDistributionPoints?> {
+        val crlsDps = cc.e2eiMlsInitOnly(enrollment.lower(), certificateChain, nbKeyPackage)
+        return MLSClient(cc) to crlsDps?.toCrlDistributionPoint()
     }
 
     /**
@@ -166,7 +166,6 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
         return cc.e2eiRegisterAcmeCa(trustAnchorPEM)
     }
 
-
     /**
      * Registers an Intermediate CA for the use in E2EI processing.
      *
@@ -175,10 +174,9 @@ class CoreCryptoCentral private constructor(private val cc: CoreCrypto, private 
      *
      * @param certPEM PEM certificate to register as an Intermediate CA
      */
-    suspend fun e2eiRegisterIntermediateCA(certPEM: String): CrlDistributionPoint? {
+    suspend fun e2eiRegisterIntermediateCA(certPEM: String): CrlDistributionPoints? {
         return cc.e2eiRegisterIntermediateCa(certPEM)?.toCrlDistributionPoint()
     }
-
 
     /**
      * Registers a CRL for the use in E2EI processing.

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/E2EIModel.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/E2EIModel.kt
@@ -1,7 +1,5 @@
 package com.wire.crypto.client
 
-import com.wire.crypto.client.ClientId
-
 @JvmInline
 value class RotateBundle(private val value: com.wire.crypto.RotateBundle) {
     val commits: Map<ClientId, CommitBundle>
@@ -11,7 +9,7 @@ value class RotateBundle(private val value: com.wire.crypto.RotateBundle) {
     /**
      * New CRL distribution points that appeared by the introduction of a new credential
      */
-    val crlNewDistributionPoints: List<String>? get() = value.crlNewDistributionPoints
+    val crlNewDistributionPoints: CrlDistributionPoints? get() = value.crlNewDistributionPoints?.toCrlDistributionPoint()
 }
 
 fun com.wire.crypto.RotateBundle.toRotateBundle() = RotateBundle(this)

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MlsModel.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MlsModel.kt
@@ -148,14 +148,14 @@ value class ExternallyGeneratedHandle(override val value: List<ByteArray>) :
 fun List<ByteArray>.toExternallyGeneratedHandle() = ExternallyGeneratedHandle(map { it })
 
 @JvmInline
-value class CrlDistributionPoint(override val value: Set<java.net.URI>) :
+value class CrlDistributionPoints(override val value: Set<java.net.URI>) :
     FfiType<Set<java.net.URI>, List<String>> {
     override fun lower(): List<String> = value.asSequence().map { it.toString() }.toList()
 
     override fun toString() = value.joinToString(", ") { it.toString() }
 }
 
-fun List<String>.toCrlDistributionPoint() = CrlDistributionPoint(asSequence().map { java.net.URI(it) }.toSet())
+fun List<String>.toCrlDistributionPoint() = CrlDistributionPoints(asSequence().map { java.net.URI(it) }.toSet())
 
 
 @JvmInline
@@ -190,7 +190,7 @@ data class CommitBundle(
     /**
      * New CRL distribution points that appeared by the introduction of a new credential
      */
-    val crlNewDistributionPoints: CrlDistributionPoint?,
+    val crlNewDistributionPoints: CrlDistributionPoints?,
 )
 
 fun com.wire.crypto.CommitBundle.lift() =
@@ -217,7 +217,7 @@ data class ProposalBundle(
     /**
      * New CRL distribution points that appeared by the introduction of a new credential
      */
-    val crlNewDistributionPoints: CrlDistributionPoint?,
+    val crlNewDistributionPoints: CrlDistributionPoints?,
 )
 
 fun com.wire.crypto.ProposalBundle.lift() =
@@ -238,7 +238,7 @@ data class WelcomeBundle(
     /**
      * New CRL distribution points that appeared by the introduction of a new credential
      */
-    val crlNewDistributionPoints: CrlDistributionPoint?,
+    val crlNewDistributionPoints: CrlDistributionPoints?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -308,7 +308,7 @@ data class DecryptedMessage(
     /**
      * New CRL distribution points that appeared by the introduction of a new credential
      */
-    val crlNewDistributionPoints: CrlDistributionPoint?,
+    val crlNewDistributionPoints: CrlDistributionPoints?,
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -376,7 +376,7 @@ data class BufferedDecryptedMessage(
     /** @see DecryptedMessage.identity */
     val identity: WireIdentity?,
     /** @see DecryptedMessage.crlNewDistributionPoints */
-    val crlNewDistributionPoints: CrlDistributionPoint?,
+    val crlNewDistributionPoints: CrlDistributionPoints?,
 ) {
 
     override fun equals(other: Any?): Boolean {

--- a/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/Sources/CoreCrypto/CoreCrypto.swift
@@ -1210,7 +1210,7 @@ public class CoreCryptoWrapper {
     /// - parameter e2ei: the enrollment instance used to fetch the certificates
     /// - parameter certificateChain: the raw response from ACME server
     /// - parameter nbKeyPackage: number of initial KeyPackage to create when initializing the client
-    public func e2eiMlsInitOnly(enrollment: E2eiEnrollment, certificateChain: String, nbKeyPackage: UInt32 = 100) async throws {
+    public func e2eiMlsInitOnly(enrollment: E2eiEnrollment, certificateChain: String, nbKeyPackage: UInt32 = 100) async throws -> [string]? {
         return try await self.coreCrypto.e2eiMlsInitOnly(enrollment: enrollment.lower(), certificateChain: certificateChain, nbKeyPackage: nbKeyPackage)
     }
 

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -1575,13 +1575,13 @@ impl CoreCrypto {
             .await?)
     }
 
-    /// See [core_crypto::mls::MlsCentral::e2ei_register_intermediate_ca]
+    /// See [core_crypto::mls::MlsCentral::e2ei_register_intermediate_ca_pem]
     pub async fn e2ei_register_intermediate_ca(&self, cert_pem: String) -> CoreCryptoResult<Option<Vec<String>>> {
         Ok(self
             .central
             .lock()
             .await
-            .e2ei_register_intermediate_ca(cert_pem)
+            .e2ei_register_intermediate_ca_pem(cert_pem)
             .await?)
     }
 
@@ -1602,7 +1602,7 @@ impl CoreCrypto {
         enrollment: std::sync::Arc<E2eiEnrollment>,
         certificate_chain: String,
         nb_key_package: Option<u32>,
-    ) -> CoreCryptoResult<()> {
+    ) -> CoreCryptoResult<Option<Vec<String>>> {
         if std::sync::Arc::strong_count(&enrollment) > 1 {
             unsafe {
                 // it is required because in order to pass the enrollment to Rust, uniffi lowers it by cloning the Arc

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -146,7 +146,7 @@ pub async fn run_test_with_deterministic_client_ids<const N: usize>(
 
                         for intermediate in &x509_test_chain.intermediates {
                             central
-                                .e2ei_register_intermediate_ca(
+                                .e2ei_register_intermediate_ca_pem(
                                     intermediate
                                         .certificate
                                         .to_pem(x509_cert::der::pem::LineEnding::LF)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
