### PR TITLE
fix: only restore PKI env if client is e2ei capable.

### DIFF
--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -188,9 +188,12 @@ impl MlsCentral {
 
         // Restore persisted groups if there are any
         let mls_groups = Self::restore_groups(&mls_backend).await?;
-        mls_backend
-            .authentication_service()
-            .update_env(Self::restore_pki_env(&mls_backend).await?)?;
+
+        if mls_client.as_ref().map(|c| c.is_e2ei_capable()).unwrap_or_default() {
+            mls_backend
+                .authentication_service()
+                .update_env(Self::restore_pki_env(&mls_backend).await?)?;
+        }
 
         Ok(Self {
             mls_backend,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
