### PR TITLE
fix: figure out linux builtins on different setups

### DIFF
--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -68,6 +68,7 @@ features = ["build", "bindgen"]
 
 [build-dependencies]
 cfg-if = "1.0"
+glob = "0.3.1"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crypto-ffi/build.rs
+++ b/crypto-ffi/build.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+use glob::glob;
+use std::path::Path;
+
 fn main() {
     cfg_if::cfg_if! {
         if #[cfg(target_family = "wasm")] {
@@ -31,8 +34,40 @@ fn main() {
     if target_arch == "x86_64" && target_os == "android" {
         let android_home = std::env::var("ANDROID_HOME").expect("ANDROID_HOME not set");
         const ANDROID_NDK_VERSION: &str = "25.2.9519653";
-        const LINUX_X86_64_LIB_DIR: &str = "/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/";
-        println!("cargo:rustc-link-search={android_home}/ndk/{ANDROID_NDK_VERSION}/{LINUX_X86_64_LIB_DIR}");
+
+        let ndk_root_str = format!("{android_home}/ndk/{ANDROID_NDK_VERSION}");
+        let ndk_root = Path::new(ndk_root_str.as_str());
+        if !ndk_root.exists() {
+            panic!("Error: Couldn't find NDK at path {ndk_root_str}. NDK {ANDROID_NDK_VERSION} is required")
+        }
+
+        let search_path = format!(
+            "{}/toolchains/llvm/prebuilt/*/lib*/clang/*/lib/linux/",
+            ndk_root.to_str().unwrap()
+        );
+
+        let results: Vec<_> = glob(search_path.as_str())
+            .expect("Failed to read glob pattern")
+            .filter_map(Result::ok)
+            .collect();
+
+        if results.len() != 1 {
+            if results.is_empty() {
+                panic!("Could not find the directory for x86_64 clang builtins in {ndk_root_str}. A directory structure like this is expected inside the NDK root directory: '/toolchains/llvm/prebuilt/*/lib*/clang/*/lib/linux/'")
+            }
+            let all_results = results
+                .iter()
+                .map(|result| {
+                    let path = result.as_os_str().to_str().unwrap();
+                    format!("  - {path}")
+                })
+                .collect::<Vec<String>>()
+                .join("\n");
+            panic!("Found more than one alternative for x86_64 clang builtins in {ndk_root_str}:\n{all_results}");
+        }
+
+        let linux_libs_dir = results.first().unwrap().to_str().unwrap();
+        println!("cargo:rustc-link-search={linux_libs_dir}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Building Android x86_64 in different setups leads to errors as `clang_rt.builtins-x86_64-android` is not found in the specified directory.

### Causes

Hardcoded NDK path.

### Solutions

There are two parts:

#### NDK

For this PR, we assume the NDK is `25.2.9519653`, as it is being used by CI, and it is also being used in `crypto-ffi/Makefile.toml`:, as `ANDROID_NDK_PREFER_VERSION = "25.2"`

Ideally (in the future): this value could be solved just like it is being solved in `Makefile`.
But for now, we handle the possibility of this specific NDK not being installed and print a clearer error message.

#### NDK Internals

Depending on the machine building it, the path within the NDK might be different, for example `linux-x86_64` changing to `darwin-x86_64` when running on macOS:
- `../25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/lib/clang/14.0.7/lib/linux`
- `../25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/14.0.7/lib/linux`

It may also be different depending on the NDK version itself, where the first `lib` changes to `lib64` and `clang` version changes:
- `../27.0.11718014/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/18/lib/linux`

So to make lives easier when changing the NDK or the OS, use [glob](https://docs.rs/glob/latest/glob/) to find possible paths within the NDK root. It's expected that only _one_ directory will be found. Anything different from 1 will result in an error.

### Testing

I tested locally by changing these folders and different directory structures and It's Working Fine On My Machine™.

<img width="1263" alt="image" src="https://github.com/wireapp/core-crypto/assets/9389043/5278aff7-ebe6-4564-9488-32161d641d76">

<img width="1263" alt="image" src="https://github.com/wireapp/core-crypto/assets/9389043/df7ff316-4af2-475a-b1a3-0b08b942feab">

#### How to Test

Mess up your SDK directories.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
