### PR TITLE
refactor: crypto-ffi: statically link the runtime lib via Makefile.toml [WPB-8945]

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -263,7 +263,9 @@ args = [
     "--crate-type=staticlib",
     "--release",
     "--",
-    "-C", "strip=symbols"
+    "-C", "strip=symbols",
+    "-l", "static=clang_rt.builtins-x86_64-android",
+    "-L", "${CLANG_RT_DIR}"
 ]
 dependencies = ["ffi-kotlin", "android-env"]
 
@@ -416,6 +418,14 @@ fn update_android_env
 
     set_env ANDROID_NDK_HOME "${base_ndk_path}"
     set_env NDK_HOME "${base_ndk_path}"
+
+    # Determine the clang runtime lib dir so we can statically link
+    # clang_rt.builtins-x86_64-android on x86_64 Android.
+    output = exec ${base_ndk_path}/bin/clang --print-runtime-dir
+    clang_rt_dir = trim_end ${output.stdout}
+    clang_rt_dir = dirname ${clang_rt_dir}
+    clang_rt_dir = join_path ${clang_rt_dir} linux
+    set_env CLANG_RT_DIR "${clang_rt_dir}"
 
     set_env CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_ANDROID_NDK "${base_ndk_path}"
     set_env CARGO_TARGET_AARCH64_LINUX_ANDROID_ANDROID_NDK "${base_ndk_path}"

--- a/crypto-ffi/build.rs
+++ b/crypto-ffi/build.rs
@@ -25,14 +25,4 @@ fn main() {
             println!("cargo:rustc-cfg=android");
         }
     }
-
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    if target_arch == "x86_64" && target_os == "android" {
-        let android_home = std::env::var("ANDROID_HOME").expect("ANDROID_HOME not set");
-        const ANDROID_NDK_VERSION: &str = "25.2.9519653";
-        const LINUX_X86_64_LIB_DIR: &str = "/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/";
-        println!("cargo:rustc-link-search={android_home}/ndk/{ANDROID_NDK_VERSION}/{LINUX_X86_64_LIB_DIR}");
-        println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
-    }
 }


### PR DESCRIPTION
On Android x86-64 we need to link the runtime lib statically because       
the compiler fails to do so due to -nodefaultlibs being given by           
default. This is not a problem on other Android platforms, though.         
                                                                           
More details at https://github.com/mozilla/application-services/issues/5436