### PR TITLE
chore: .github: simplify the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# What's new in this PR
+
+
+----
+##### PR Submission Checklist for internal contributors
+
+- The **PR Title**
+  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
+  - [ ] contains a reference JIRA issue number like `SQPIT-764`
+  - [ ] answers the question: _If merged, this PR will: ..._ ³
+
+1. https://sparkbox.com/foundry/semantic_commit_messages
+1. https://github.com/wireapp/.github#usage
+1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


### PR DESCRIPTION
Just a much smaller, more readable PR template.