### PR TITLE
chore: .github: use gradle/actions/wrapper-validation instead of gradle/wrapper-validation-action

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Gradle Setup
         uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
       - name: "Setup rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Gradle Setup
         uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
       - name: "Setup rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Gradle Setup
         uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v3
       - name: Download x86_64 Linux Artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This PR moves moves away from the obsoleted wrapper validation and gradle setup actions.
Additionally, it updates to the latest versions of those actions.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
