### PR TITLE
test: crypto: bring back external remove proposal tests (WPB-9184)

### DIFF
--- a/keystore/src/mls.rs
+++ b/keystore/src/mls.rs
@@ -361,7 +361,7 @@ impl openmls_traits::key_store::OpenMlsKeyStore for crate::connection::Connectio
                 let concrete_signature_keypair: &SignatureKeyPair = v
                     .downcast()
                     .expect("There's an implementation issue in OpenMLS. This shouln't be happening.");
-                
+
                 // Having an empty credential id seems tolerable, since the SignatureKeyPair type is retrieved from the key store via its public key.
                 let credential_id = vec![];
                 let kp = MlsSignatureKeyPair::new(


### PR DESCRIPTION
The original tests were most likely removed as part of 4e7d907663026b74484b37942c7ac4cfb1ff6cf9 by mistake. So bring them back, and adjust for the API changes done since then.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
