### PR TITLE
chore: run ci on pushes to dev as well

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -4,7 +4,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -4,7 +4,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
# What's new in this PR

To guarantee we always have the CI run on the latest state on develop, we want to run the CI on pushes to develop, not just on PRs.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
