### PR TITLE
chore: fix ci test runs by temporarily increasing stack size for test [WPB-9543]

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -103,6 +103,7 @@ async-trait = "0.1"
 wire-e2e-identity = { version = "0.9", features = ["identity-builder"] }
 fluvio-wasm-timer = "0.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }
+stacker = "0.1.15"
 
 [dev-dependencies.core-crypto-keystore]
 version = "^1.0.0-rc.60"

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -332,86 +332,89 @@ pub mod tests {
     #[wasm_bindgen_test]
     async fn should_not_fail_but_degrade_when_basic_joins(case: TestCase) {
         if case.is_x509() {
-            let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
+            // TODO: investigate why the stack grows so much here. Tracking issue: WPB-9543
+            stacker::maybe_grow(32 * 1024, 1024 * 1024, || async {  
+                let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
 
-            let (alice_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("alice", None);
-            let (bob_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("bob", None);
+                let (alice_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("alice", None);
+                let (bob_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("bob", None);
 
-            // this should work since the certificate is not yet expired
-            let (mut alice_central, mut bob_central, id) =
-                try_talk(&case, Some(&x509_test_chain), alice_identifier, bob_identifier)
+                // this should work since the certificate is not yet expired
+                let (mut alice_central, mut bob_central, id) =
+                    try_talk(&case, Some(&x509_test_chain), alice_identifier, bob_identifier)
+                        .await
+                        .unwrap();
+
+                assert_eq!(
+                    alice_central.e2ei_conversation_state(&id).await.unwrap(),
+                    E2eiConversationState::Verified
+                );
+
+                assert_eq!(
+                    bob_central.e2ei_conversation_state(&id).await.unwrap(),
+                    E2eiConversationState::Verified
+                );
+
+                alice_central.try_talk_to(&id, &mut bob_central).await.unwrap();
+                assert_eq!(
+                    alice_central.e2ei_conversation_state(&id).await.unwrap(),
+                    E2eiConversationState::Verified
+                );
+
+                assert_eq!(
+                    bob_central.e2ei_conversation_state(&id).await.unwrap(),
+                    E2eiConversationState::Verified
+                );
+
+                // Charlie is a basic client that tries to join (i.e. emulates guest links in Wire)
+                let charlie_identifier = ClientIdentifier::Basic("charlie".into());
+                let charlie_path = tmp_db_file();
+
+                let ciphersuites = vec![case.ciphersuite()];
+
+                let mut charlie_central = MlsCentral::try_new(
+                    MlsCentralConfiguration::try_new(
+                        charlie_path.0,
+                        "charlie".into(),
+                        None,
+                        ciphersuites.clone(),
+                        None,
+                        Some(INITIAL_KEYING_MATERIAL_COUNT),
+                    )
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+                charlie_central
+                    .mls_init(
+                        charlie_identifier,
+                        ciphersuites.clone(),
+                        Some(INITIAL_KEYING_MATERIAL_COUNT),
+                    )
                     .await
                     .unwrap();
 
-            assert_eq!(
-                alice_central.e2ei_conversation_state(&id).await.unwrap(),
-                E2eiConversationState::Verified
-            );
+                let charlie_kp = charlie_central
+                    .rand_key_package_of_type(&case, MlsCredentialType::Basic)
+                    .await;
 
-            assert_eq!(
-                bob_central.e2ei_conversation_state(&id).await.unwrap(),
-                E2eiConversationState::Verified
-            );
+                alice_central
+                    .invite_all_members(&case, &id, [(&mut charlie_central, charlie_kp)])
+                    .await
+                    .unwrap();
 
-            alice_central.try_talk_to(&id, &mut bob_central).await.unwrap();
-            assert_eq!(
-                alice_central.e2ei_conversation_state(&id).await.unwrap(),
-                E2eiConversationState::Verified
-            );
+                assert_eq!(
+                    alice_central.e2ei_conversation_state(&id).await.unwrap(),
+                    E2eiConversationState::NotVerified
+                );
 
-            assert_eq!(
-                bob_central.e2ei_conversation_state(&id).await.unwrap(),
-                E2eiConversationState::Verified
-            );
+                alice_central.try_talk_to(&id, &mut charlie_central).await.unwrap();
 
-            // Charlie is a basic client that tries to join (i.e. emulates guest links in Wire)
-            let charlie_identifier = ClientIdentifier::Basic("charlie".into());
-            let charlie_path = tmp_db_file();
-
-            let ciphersuites = vec![case.ciphersuite()];
-
-            let mut charlie_central = MlsCentral::try_new(
-                MlsCentralConfiguration::try_new(
-                    charlie_path.0,
-                    "charlie".into(),
-                    None,
-                    ciphersuites.clone(),
-                    None,
-                    Some(INITIAL_KEYING_MATERIAL_COUNT),
-                )
-                .unwrap(),
-            )
-            .await
-            .unwrap();
-            charlie_central
-                .mls_init(
-                    charlie_identifier,
-                    ciphersuites.clone(),
-                    Some(INITIAL_KEYING_MATERIAL_COUNT),
-                )
-                .await
-                .unwrap();
-
-            let charlie_kp = charlie_central
-                .rand_key_package_of_type(&case, MlsCredentialType::Basic)
-                .await;
-
-            alice_central
-                .invite_all_members(&case, &id, [(&mut charlie_central, charlie_kp)])
-                .await
-                .unwrap();
-
-            assert_eq!(
-                alice_central.e2ei_conversation_state(&id).await.unwrap(),
-                E2eiConversationState::NotVerified
-            );
-
-            alice_central.try_talk_to(&id, &mut charlie_central).await.unwrap();
-
-            assert_eq!(
-                alice_central.e2ei_conversation_state(&id).await.unwrap(),
-                E2eiConversationState::NotVerified
-            );
+                assert_eq!(
+                    alice_central.e2ei_conversation_state(&id).await.unwrap(),
+                    E2eiConversationState::NotVerified
+                );
+            });
         }
     }
 

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -333,7 +333,7 @@ pub mod tests {
     async fn should_not_fail_but_degrade_when_basic_joins(case: TestCase) {
         if case.is_x509() {
             // TODO: investigate why the stack grows so much here. Tracking issue: WPB-9543
-            stacker::maybe_grow(32 * 1024, 1024 * 1024, || async {  
+            stacker::maybe_grow(32 * 1024, 1024 * 1024, || async {
                 let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
 
                 let (alice_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("alice", None);

--- a/keystore/src/mls.rs
+++ b/keystore/src/mls.rs
@@ -361,7 +361,7 @@ impl openmls_traits::key_store::OpenMlsKeyStore for crate::connection::Connectio
                 let concrete_signature_keypair: &SignatureKeyPair = v
                     .downcast()
                     .expect("There's an implementation issue in OpenMLS. This shouln't be happening.");
-                
+
                 // Having an empty credential id seems tolerable, since the SignatureKeyPair type is retrieved from the key store via its public key.
                 let credential_id = vec![];
                 let kp = MlsSignatureKeyPair::new(


### PR DESCRIPTION
# What's new in this PR
As a temporary workaround, we increase the stack size of the failing unit tests.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
