### PR TITLE
test: pin future to heap in test with overflowing stack [WPB-9543]

### DIFF
--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -331,7 +331,10 @@ pub mod tests {
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
     async fn should_not_fail_but_degrade_when_basic_joins(case: TestCase) {
-        if case.is_x509() {
+        if !case.is_x509() {
+            return;
+        }
+        Box::pin(async {
             let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
 
             let (alice_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("alice", None);
@@ -412,7 +415,8 @@ pub mod tests {
                 alice_central.e2ei_conversation_state(&id).await.unwrap(),
                 E2eiConversationState::NotVerified
             );
-        }
+        })
+        .await;
     }
 
     #[apply(all_cred_cipher)]


### PR DESCRIPTION
# What's new in this PR
To fix the failing tests in CI, we pin the future to heap in test with overflowing stack

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
