### PR TITLE
chore: remove support/android/libgcc.a

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -47,7 +47,6 @@ runner = [
 ar = "llvm-ar"
 linker = "armv7a-linux-androideabi24-clang"
 rustflags = [
-    "-C", "link-args=-Lsupport/android",
     "-C", "target_feature=+neon",
     "-C", "link-args=-latomic"
 ]
@@ -56,7 +55,6 @@ rustflags = [
 ar = "llvm-ar"
 linker = "aarch64-linux-android24-clang"
 rustflags = [
-    "-C", "link-args=-Lsupport/android",
     "-C", "link-args=-latomic"
 ]
 
@@ -64,7 +62,6 @@ rustflags = [
 ar = "llvm-ar"
 linker = "x86_64-linux-android24-clang"
 rustflags = [
-    "-C", "link-args=-Lsupport/android",
     "-C", "link-args=-latomic"
 ]
 
@@ -72,6 +69,5 @@ rustflags = [
 ar = "llvm-ar"
 linker = "i686-linux-android24-clang"
 rustflags = [
-    "-C", "link-args=-Lsupport/android",
     "-C", "link-args=-latomic"
 ]

--- a/support/android/libgcc.a
+++ b/support/android/libgcc.a
@@ -1,1 +1,0 @@
-INPUT(-lunwind)


### PR DESCRIPTION
It was added in 5eb47aeb9599346bf3f04138fbf7439bcda662fc, however there's no good explanation for it. Let's try to get rid of it.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
