### PR TITLE
chore: Cargo.toml: convert wire-e2e-identity to a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ version = "0.28"
 # git = "https://github.com/wireapp/uniffi-rs.git"
 # branch = "wire/uniffi-stable"
 
+[workspace.dependencies.wire-e2e-identity]
+git = "https://github.com/wireapp/rusty-jwt-tools"
+version = "0.9"
+default-features = false
+
 [patch.crates-io.schnellru]
 git = "https://github.com/wireapp/schnellru"
 branch = "feat/try-insert"
@@ -71,11 +76,6 @@ branch = "wire/stable"
 [patch.crates-io.hpke]
 git = "https://github.com/wireapp/rust-hpke.git"
 branch = "wire/unstable-pq-xyber-p521"
-
-[patch.crates-io.wire-e2e-identity]
-package = "wire-e2e-identity"
-git = "https://github.com/wireapp/rusty-jwt-tools"
-branch = "main"
 
 [patch.crates-io.x509-cert]
 git = "https://github.com/otak/formats"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -42,7 +42,7 @@ async-trait = "0.1"
 async-lock = "3.3"
 schnellru = "0.2"
 zeroize = "1.5"
-wire-e2e-identity = { version = "0.9", default-features = false }
+wire-e2e-identity = { workspace = true }
 indexmap = "2"
 x509-cert = "0.2"
 pem = "3.0"
@@ -100,7 +100,7 @@ async-std = { version = "1.12", features = ["attributes"] }
 futures-util = { version = "0.3", features = ["std", "alloc"] }
 proteus-traits = "2.0"
 async-trait = "0.1"
-wire-e2e-identity = { version = "0.9", features = ["identity-builder"] }
+wire-e2e-identity = { workspace = true, features = ["identity-builder"] }
 fluvio-wasm-timer = "0.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }
 

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -33,7 +33,7 @@ p521 = { version = "0.13", features = ["pkcs8"] }
 hkdf = "0.12"
 spki = { version = "0.7", features = ["pem", "fingerprint"] }
 x509-cert = { version = "0.2", features = ["builder", "hazmat"] }
-wire-e2e-identity = { version = "0.9", default-features = false }
+wire-e2e-identity = { workspace = true }
 fluvio-wasm-timer = "0.2"
 rand = { version = "0.8", features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
No need to use a patch.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
