### PR TITLE
chore: go back to upstream rexie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
+rexie = "0.6.1"
 tls_codec = "0.4.0"
 
 [workspace.dependencies.uniffi]
@@ -27,15 +28,10 @@ version = "0.28"
 [workspace.dependencies.wire-e2e-identity]
 git = "https://github.com/wireapp/rusty-jwt-tools"
 version = "0.9"
-default-features = false
 
 [patch.crates-io.schnellru]
 git = "https://github.com/wireapp/schnellru"
 branch = "feat/try-insert"
-
-[patch.crates-io.rexie]
-git = "https://github.com/wireapp/rexie"
-branch = "feat/api-expansion"
 
 [patch.'https://github.com/wireapp/proteus'.proteus]
 package = "proteus"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -70,7 +70,7 @@ futures-lite = { version = "2.0", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 serde-wasm-bindgen = "0.6"
-rexie = { version = "0.4", optional = true }
+rexie = { workspace = true, optional = true }
 base64 = { version = "0.22", optional = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -79,7 +79,7 @@ default-features = false
 features = ["rusqlite"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-rexie = { version = "0.4", default-features = false, features = ["js"] }
+rexie = { workspace = true }
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
 wasm-bindgen = "0.2"

--- a/keystore/src/connection/platform/wasm/storage.rs
+++ b/keystore/src/connection/platform/wasm/storage.rs
@@ -107,7 +107,7 @@ impl WasmEncryptedStorage {
                 let id = id.as_ref().to_vec();
                 let js_key = js_sys::Uint8Array::from(id.as_slice());
 
-                if let Some(entity_raw) = store.get(&js_key).await? {
+                if let Some(entity_raw) = store.get(js_key.into()).await? {
                     let mut entity: R = serde_wasm_bindgen::from_value(entity_raw)?;
                     entity.decrypt(&self.cipher)?;
 
@@ -143,7 +143,7 @@ impl WasmEncryptedStorage {
 
                 let params = params.unwrap_or_default();
                 let raw_data = store
-                    .get_all(
+                    .scan(
                         None,
                         params.limit,
                         params.offset,
@@ -247,7 +247,7 @@ impl WasmEncryptedStorage {
                 let store = transaction.store(collection)?;
                 for k in ids {
                     let k = Uint8Array::from(k.as_ref());
-                    store.delete(&k.into()).await?;
+                    store.delete(k.into()).await?;
                 }
             }
             WasmStorageWrapper::InMemory(map) => {

--- a/keystore/src/entities/platform/wasm/mls/credential.rs
+++ b/keystore/src/entities/platform/wasm/mls/credential.rs
@@ -106,7 +106,7 @@ impl MlsCredentialExt for MlsCredential {
                 let store = transaction.store(collection)?;
                 let store_index = store.index(index)?;
                 let credential_js: wasm_bindgen::JsValue = js_sys::Uint8Array::from(&credential[..]).into();
-                let Some(entity_raw) = store_index.get(&credential_js).await? else {
+                let Some(entity_raw) = store_index.get(credential_js).await? else {
                     let reason = "'credential' in 'mls_credentials' collection";
                     let value = hex::encode(&credential);
                     return Err(CryptoKeystoreError::NotFound(reason, value));
@@ -116,7 +116,7 @@ impl MlsCredentialExt for MlsCredential {
                 credential.decrypt(&storage.cipher)?;
 
                 let id = js_sys::Uint8Array::from(credential.id.as_slice());
-                store.delete(&id.into()).await?;
+                store.delete(id.into()).await?;
             }
             WasmStorageWrapper::InMemory(_) => {
                 // current table model does not fit in a hashmap (no more primary key)

--- a/keystore/src/mls.rs
+++ b/keystore/src/mls.rs
@@ -146,7 +146,7 @@ impl CryptoKeystoreMls for crate::connection::Connection {
             WasmStorageWrapper::Persistent(rexie) => {
                 let transaction = rexie.transaction(&["mls_keypackages"], rexie::TransactionMode::ReadOnly)?;
                 let store = transaction.store("mls_keypackages")?;
-                let items_fut = store.get_all(None, Some(count), None, Some(rexie::Direction::Next));
+                let items_fut = store.scan(None, Some(count), None, Some(rexie::Direction::Next));
 
                 let items = items_fut.await?;
 


### PR DESCRIPTION
The upstream has just released 0.6.1 that with https://github.com/devashishdxt/rexie/pull/26, 
which we needed, so we can now track upstream.                                                


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
