### PR TITLE
chore: remove dependency on a fork of RustCrypto/formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ resolver = "2"
 [workspace.dependencies]
 rexie = "0.6.1"
 tls_codec = "0.4.0"
+x509-cert = "0.2"
 
 [workspace.dependencies.uniffi]
 version = "0.28"
@@ -68,10 +69,6 @@ package = "openmls_x509_credential"
 git = "https://github.com/wireapp/openmls"
 #tag = "v1.0.0-pre.core-crypto-1.0.0"
 branch = "wire/stable"
-
-[patch.crates-io.x509-cert]
-git = "https://github.com/otak/formats"
-branch = "otak/x509-cert-wasm"
 
 # aarch64-apple-ios-sim target support has not yet been released
 [patch.crates-io.openssl-src]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -43,7 +43,7 @@ schnellru = "0.2"
 zeroize = "1.5"
 wire-e2e-identity = { workspace = true }
 indexmap = "2"
-x509-cert = "0.2"
+x509-cert = { workspace = true }
 pem = "3.0"
 async-recursion = "1"
 uniffi = { workspace = true, optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -61,8 +61,6 @@ license-files = [
 allow-git = [
     # ? Needed for our interop runner.
     "https://github.com/otak/fantoccini",
-    # ? Fix for wasm
-    "https://github.com/otak/formats?branch=otak/x509-cert-wasm",
     # ? Needed for rusqlite
     "https://github.com/alexcrichton/openssl-src-rs",
 ]

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -32,7 +32,7 @@ p384 = { version = "0.13", features = ["pkcs8"] }
 p521 = { version = "0.13", features = ["pkcs8"] }
 hkdf = "0.12"
 spki = { version = "0.7", features = ["pem", "fingerprint"] }
-x509-cert = { version = "0.2", features = ["builder", "hazmat"] }
+x509-cert = { workspace = true, features = ["builder", "hazmat"] }
 wire-e2e-identity = { workspace = true }
 fluvio-wasm-timer = "0.2"
 rand = { version = "0.8", features = ["getrandom"] }


### PR DESCRIPTION
Upstream has made a fix and released a new version of der_derive: https://github.com/RustCrypto/formats/pull/1443


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
