### PR TITLE
chore: crypto: drop our fork of schnellru

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ resolver = "2"
 
 [workspace.dependencies]
 rexie = "0.6.1"
+schnellru = "0.2"
 tls_codec = "0.4.1"
 x509-cert = "0.2"
 
@@ -29,10 +30,6 @@ version = "0.28"
 [workspace.dependencies.wire-e2e-identity]
 git = "https://github.com/wireapp/rusty-jwt-tools"
 version = "0.9"
-
-[patch.crates-io.schnellru]
-git = "https://github.com/wireapp/schnellru"
-branch = "feat/try-insert"
 
 [patch.'https://github.com/wireapp/proteus'.proteus]
 package = "proteus"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "1.0"
 url = "2.5"
 async-trait = "0.1"
 async-lock = "3.4"
-schnellru = "0.2"
+schnellru = { workspace = true }
 zeroize = "1.8"
 wire-e2e-identity = { workspace = true }
 indexmap = "2"


### PR DESCRIPTION
The fork was originally intended to provide try_insert, which doesn't modify the underlying map, however, the implementation is broken (see https://github.com/koute/schnellru/pull/2) and it doesn't fit the current semantics of schnellru.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
