### PR TITLE
chore: crypto-ffi: remove setup-sample-project task from Makefile.toml

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -280,34 +280,6 @@ dependencies = ["ffi-kotlin", "android-env"]
 [tasks.android]
 dependencies = ["android-armv7", "android-armv8", "android-x86", "android-i686"]
 
-[tasks.setup-sample-project]
-dependencies = ["android"]
-script_runner = "@duckscript"
-script = '''
-handle = map
-map_put ${handle} "i686-linux-android" "x86"
-map_put ${handle} "x86_64-linux-android" "x86_64"
-map_put ${handle} "aarch64-linux-android" "arm64-v8a"
-map_put ${handle} "armv7-linux-androideabi" "armeabi-v7a"
-keys = map_keys ${handle}
-libname = set "libcore_crypto_ffi.${LIBRARY_EXTENSION}"
-for rust_target in ${keys}
-    android_target = map_get ${handle} ${rust_target}
-    println -c bright_blue "cp rust-${rust_target}/${libname} -> android-jniLibs/${android_target}/${libname}"
-    from = canonicalize "../target/${rust_target}/debug/${libname}"
-    to = canonicalize "../sample-projects/android/CoreCryptoTestApp/app/src/main/jniLibs/${android_target}/${libname}"
-    mkdir dirname ${to}
-    cp ${from} ${to}
-end
-
-release ${handle}
-
-println -c bright_blue "cp ./bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt -> ../sample-projects/android/CoreCryptoTestApp/app/src/main/java/com/wire/core/CoreCrypto.kt"
-from = canonicalize "./bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt"
-to = canonicalize "../sample-projects/android/CoreCryptoTestApp/app/src/main/java/com/wire/crypto/CoreCrypto.kt"
-cp ${from} ${to}
-'''
-
 ####################################  JVM  ####################################
 
 [tasks.jvm-x86-darwin]


### PR DESCRIPTION
It's unused and we don't have the sample project anymore.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
