### PR TITLE
chore: specify most of the dependencies at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,44 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
+async-lock = "3.4"
+async-recursion = "1"
+async-std = "1.12"
+async-trait = "0.1"
+base64 = "0.22"
+bitflags = "2.6"
+cfg-if = "1.0"
+const_format = "0.2"
+core-crypto-keystore = { version = "^1.0.0-rc.60", path = "keystore" }
+derive_more = { version = "0.99", features = ["from", "into", "deref", "deref_mut"] }
+futures-util = "0.3"
+hex = "0.4"
+indexmap = "2"
+itertools = "0.13"
+openmls = "1"
+openmls_basic_credential = "0.2"
+openmls_x509_credential = "0.2"
+openmls_traits = "0.2"
+log = "0.4"
+mls-crypto-provider = { version = "^1.0.0-rc.60", path = "mls-provider" }
+pem = "3.0"
+rand = { version = "0.8", features = ["getrandom"] }
 rexie = "0.6.1"
 schnellru = "0.2"
+serde = "1.0"
+serde_json = "1.0"
+sha1 = "0.10"
+sha2 = "0.10"
+strum = { version = "0.26", features = ["derive"] }
+thiserror = "1.0"
 tls_codec = "0.4.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json"] }
+uniffi = "0.28"
+url = "2.5"
+uuid = "1.10"
 x509-cert = "0.2"
-
-[workspace.dependencies.uniffi]
-version = "0.28"
-# git = "https://github.com/wireapp/uniffi-rs.git"
-# branch = "wire/uniffi-stable"
+zeroize = "1.8"
 
 [workspace.dependencies.wire-e2e-identity]
 git = "https://github.com/wireapp/rusty-jwt-tools"

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -21,14 +21,14 @@ default = ["proteus"]
 proteus = ["core-crypto/proteus", "core-crypto/cryptobox-migrate"]
 
 [dependencies]
-thiserror = "1.0"
-cfg-if = "1.0"
-futures-util = "0.3"
-async-trait = "0.1"
-tls_codec = { workspace = true }
-async-lock = "3.4"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json"] }
+thiserror.workspace = true
+cfg-if.workspace = true
+futures-util.workspace = true
+async-trait.workspace = true
+tls_codec.workspace = true
+async-lock.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 # see https://github.com/RustCrypto/hashes/issues/404
 [target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")))'.dependencies]
@@ -36,20 +36,19 @@ sha2 = { version = "0.10", features = ["force-soft"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # UniFFI - Android + iOS bindings - Runtime support
-uniffi = { workspace = true }
+uniffi.workspace = true
 core-crypto = { version = "^1.0.0-rc.60", path = "../crypto", features = ["uniffi"] }
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.6"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
 js-sys = "0.3"
 web-sys = "0.3"
-strum = "0.26"
+strum.workspace = true
 core-crypto = { version = "^1.0.0-rc.60", path = "../crypto" }
-
 
 # UniFFI - Android + iOS bindings - Build support
 [target.'cfg(not(target_family = "wasm"))'.build-dependencies.uniffi]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,35 +22,37 @@ bench-in-db = []
 uniffi = ["dep:uniffi"]
 
 [dependencies]
-thiserror = "1.0"
-derive_more = { version = "0.99", features = ["from", "into", "deref", "deref_mut"] }
-strum = { version = "0.26", features = ["derive"] }
-cfg-if = "1.0"
-hex = "0.4"
-futures-util = "0.3"
+derive_more.workspace = true
+thiserror.workspace = true
+strum.workspace = true
+cfg-if.workspace = true
+hex.workspace = true
+futures-util.workspace = true
 
-openmls = { version = "1", features = ["crypto-subtle"] }
-openmls_basic_credential = "0.2"
-openmls_x509_credential = "0.2"
-openmls_traits = "0.2"
-tls_codec = { workspace = true }
-serde = "1.0"
-serde_json = "1.0"
-url = "2.5"
-async-trait = "0.1"
-async-lock = "3.4"
-schnellru = { workspace = true }
-zeroize = "1.8"
-wire-e2e-identity = { workspace = true }
-indexmap = "2"
-x509-cert = { workspace = true }
-pem = "3.0"
-async-recursion = "1"
+openmls = { workspace = true, features = ["crypto-subtle"] }
+openmls_basic_credential.workspace = true
+openmls_x509_credential.workspace = true
+openmls_traits.workspace = true
+mls-crypto-provider.workspace = true
+
+tls_codec.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+url.workspace = true
+async-trait.workspace = true
+async-lock.workspace = true
+schnellru.workspace = true
+zeroize.workspace = true
+wire-e2e-identity.workspace = true
+indexmap.workspace = true
+x509-cert.workspace = true
+pem.workspace = true
+async-recursion.workspace = true
 uniffi = { workspace = true, optional = true }
-itertools = "0.13"
-uuid = { version = "1.10", features = ["v4"] }
-base64 = "0.22"
-tracing = "0.1"
+itertools.workspace = true
+uuid.workspace = true
+base64.workspace = true
+tracing.workspace = true
 
 [dependencies.proteus-wasm]
 version = "2.1"
@@ -71,7 +73,7 @@ futures-lite = { version = "2.3", optional = true }
 [target.'cfg(target_family = "wasm")'.dependencies]
 serde-wasm-bindgen = "0.6"
 rexie = { workspace = true, optional = true }
-base64 = { version = "0.22", optional = true }
+base64 = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 core-crypto-keystore = { version = "^1.0.0-rc.60", path = "../keystore" }
@@ -79,14 +81,10 @@ core-crypto-keystore = { version = "^1.0.0-rc.60", path = "../keystore" }
 [target.'cfg(target_os = "ios")'.dependencies]
 core-crypto-keystore = { version = "^1.0.0-rc.60", path = "../keystore", features = ["ios-wal-compat"] }
 
-[dependencies.mls-crypto-provider]
-version = "^1.0.0-rc.60"
-path = "../mls-provider"
-
 [dev-dependencies]
-itertools = "0.13"
-uuid = { version = "1.10", features = ["v4", "v5"] }
-rand = "0.8"
+itertools.workspace = true
+uuid = { workspace = true, features = ["v4", "v5"] }
+rand.workspace = true
 tempfile = "3.10"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
@@ -95,10 +93,10 @@ js-sys = "0.3"
 rstest = "0.21"
 rstest_reuse = "0.7"
 pretty_env_logger = "0.5"
-async-std = { version = "1.12", features = ["attributes"] }
-futures-util = { version = "0.3", features = ["std", "alloc"] }
+async-std = { workspace = true, features = ["attributes"] }
+futures-util = { workspace = true, features = ["std", "alloc"] }
 proteus-traits = "2.0"
-async-trait = "0.1"
+async-trait.workspace = true
 wire-e2e-identity = { workspace = true, features = ["identity-builder"] }
 fluvio-wasm-timer = "0.2"
 time = { version = "0.3", features = ["wasm-bindgen"] }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -21,19 +21,18 @@ log = "0.4"
 femme = "2.2"
 dirs = "5.0"
 core-crypto = { path = "../crypto" }
-tls_codec = { workspace = true }
-# core-crypto-ffi = { path = "../crypto-ffi" }
+tls_codec.workspace = true
 
 # Utils
-async-trait = "0.1"
-serde_json = "1.0"
-sha2 = "0.10"
-hex = "0.4"
-base64 = "0.22"
-const_format = "0.2"
-rand = "0.8"
-bitflags = "2.6"
-uuid = { version = "1.10", features = ["v4"] }
+async-trait.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+hex.workspace = true
+base64.workspace = true
+const_format.workspace = true
+rand.workspace = true
+bitflags.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 tempfile = { version = "3.10", optional = true }
 # Terminal support
 xshell = "0.2"
@@ -55,6 +54,3 @@ features = ["hazmat"]
 optional = true
 git = "https://github.com/wireapp/proteus"
 branch = "2.x"
-
-
-

--- a/keystore-dump/Cargo.toml
+++ b/keystore-dump/Cargo.toml
@@ -11,22 +11,22 @@ color-eyre = "0.6"
 
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-core-crypto-keystore = { path = "../keystore", features = ["serde"] }
+core-crypto-keystore = { workspace = true, features = ["serde"] }
 core-crypto = { path = "../crypto" }
 
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-serde_json = "1"
-serde = "1"
+serde_json.workspace = true
+serde.workspace = true
 postcard = { version = "1.0", default-features = false, features = ["use-std"] }
-hex = "0.4"
+hex.workspace = true
 serde-transcode = "1"
 
-openmls = { version = "1", features = ["crypto-subtle"] }
-openmls_traits = "0.2"
-openmls_basic_credential = "0.2"
-openmls_x509_credential = "0.2"
-tls_codec = { workspace = true }
+openmls = { workspace = true, features = ["crypto-subtle"] }
+openmls_traits.workspace = true
+openmls_basic_credential.workspace = true
+openmls_x509_credential.workspace = true
+tls_codec.workspace = true
 
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -30,25 +30,25 @@ serde = ["dep:serde"]
 dummy-entity = ["serde"]
 
 [dependencies]
-thiserror = "1.0"
-cfg-if = "1.0"
-hex = "0.4"
-zeroize = { version = "1.8", features = ["zeroize_derive"] }
-async-trait = "0.1"
-async-lock = "3.4"
+thiserror.workspace = true
+cfg-if.workspace = true
+hex.workspace = true
+zeroize = { workspace = true, features = ["zeroize_derive"] }
+async-trait.workspace = true
+async-lock.workspace = true
 postcard = { version = "1.0", default-features = false, features = ["use-std"] }
-sha2 = "0.10"
+sha2.workspace = true
 
 # iOS specific things
 security-framework = { version = "2.11", optional = true }
 security-framework-sys = { version = "2.11", optional = true }
 core-foundation = { version = "0.9", optional = true }
 
-openmls_traits = { version = "0.2", optional = true }
-openmls_basic_credential = { version = "0.2", optional = true }
-openmls_x509_credential = { version = "0.2", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
-log = { version = "0.4", optional = true }
+openmls_traits = { workspace = true, optional = true }
+openmls_basic_credential = { workspace = true, optional = true }
+openmls_x509_credential = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+log = { workspace = true, optional = true }
 
 [dependencies.proteus-traits]
 optional = true
@@ -77,32 +77,32 @@ default-features = false
 features = ["rusqlite"]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-rexie = { workspace = true }
+rexie.workspace = true
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
 wasm-bindgen = "0.2"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde-big-array = "0.5"
 serde-wasm-bindgen = "0.6"
 # Async WASM stuff
 wasm-bindgen-futures = "0.4"
 # Crypto stuff
 aes-gcm = "0.10"
-rand = { version = "0.8", features = ["getrandom"] }
+rand.workspace = true
 getrandom = { version = "0.2", features = ["js"] }
 fluvio-wasm-timer = "0.2"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen-test = "0.3"
-uuid = { version = "1.10", features = ["v4", "js"] }
-rand = { version = "0.8", features = ["getrandom"] }
+uuid = { workspace = true, features = ["v4", "js"] }
+rand = { workspace = true, features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
-openmls = { version = "1", default-features = false, features = ["crypto-subtle"] }
-mls-crypto-provider = { path = "../mls-provider" }
+openmls = { workspace = true, features = ["crypto-subtle"] }
+mls-crypto-provider.workspace = true
 rstest = "0.21"
 rstest_reuse = "0.7"
-async-std = { version = "1.12", features = ["attributes"] }
+async-std = { workspace = true, features = ["attributes"] }
 futures-lite = "2.3"
 core-crypto-keystore = { path = ".", features = ["idb-regression-test", "log-queries"] }
 pretty_env_logger = "0.5"

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -16,12 +16,12 @@ default = []
 raw-rand-access = [] # TESTING ONLY
 
 [dependencies]
-openmls_traits = "0.2"
-async-trait = "0.1"
-tls_codec = { workspace = true }
+openmls_traits.workspace = true
+async-trait.workspace = true
+tls_codec.workspace = true
 aes-gcm = "0.10"
-sha1 = "0.10"
-sha2 = { version = "0.10", features = ["oid"] }
+sha1.workspace = true
+sha2 = { workspace = true, features = ["oid"] }
 chacha20poly1305 = "0.10"
 hmac = "0.12"
 ed25519-dalek = { version = "2.1", features = ["pkcs8"] }
@@ -35,32 +35,32 @@ spki = { version = "0.7", features = ["pem", "fingerprint"] }
 x509-cert = { workspace = true, features = ["builder", "hazmat"] }
 wire-e2e-identity = { workspace = true }
 fluvio-wasm-timer = "0.2"
-rand = { version = "0.8", features = ["getrandom"] }
+rand = { workspace = true, features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
 rand_core = "0.6"
 rand_chacha = "0.3"
-zeroize = "1.8"
-thiserror = "1.0"
-hex = "0.4"
-async-lock = "3.4"
+zeroize.workspace = true
+thiserror.workspace = true
+hex.workspace = true
+async-lock.workspace = true
 
 [dependencies.hpke]
 version = "0.12"
 features = ["x25519", "p256", "p384", "p521"]
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
-core-crypto-keystore = { version = "^1.0.0-rc.60", path = "../keystore" }
+core-crypto-keystore.workspace = true
 
 [target.'cfg(target_os = "ios")'.dependencies]
-core-crypto-keystore = { version = "^1.0.0-rc.60", path = "../keystore", features = ["ios-wal-compat"] }
+core-crypto-keystore = { workspace = true, features = ["ios-wal-compat"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-uuid = { version = "1.10", features = ["v4", "js"] }
-openmls = { version = "1", default-features = false }
+uuid = { workspace = true, features = ["v4", "js"] }
+openmls.workspace = true
 rstest = "0.21"
 rstest_reuse = "0.7"
-async-std = { version = "1.12", features = ["attributes"] }
-cfg-if = "1.0"
+async-std = { workspace = true, features = ["attributes"] }
+cfg-if.workspace = true
 hex-literal = "0.4"
-mls-crypto-provider = { path = ".", features = ["raw-rand-access"] }
+mls-crypto-provider = { workspace = true, features = ["raw-rand-access"] }


### PR DESCRIPTION
This is to consolidate dependency version management and make it easier to handle version changes. Not all dependencies are converted though, as some are not really shared between crates or are not commonly useful dev-dependencies etc.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
