### PR TITLE
ci: enable commit sha reference for PR benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,12 +22,11 @@ jobs:
         uses: bencherdev/bencher@main
       - name: Run benchmarks on PR
         if: github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'
-        #  Not using this right now as a parameter, as we don't have any runs on the base branch yet. Add it once we do.
-        # --branch-start-point-hash '${{ github.event.pull_request.base.sha }}' \
         run: |
           bencher run \
           --branch '${{ github.head_ref }}' \
           --branch-start-point '${{ github.base_ref }}' \
+          --branch-start-point-hash '${{ github.event.pull_request.base.sha }}' \
           --testbed ubuntu-latest \
           --err \
           --github-actions '${{ secrets.GITHUB_TOKEN }}' \


### PR DESCRIPTION
# What's new in this PR
See title

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
