### PR TITLE
fix: handle own commit after mls error [WPB-10105]

### DIFF
--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -61,9 +61,9 @@ pub(crate) mod group_info;
 mod leaf_node_validation;
 pub(crate) mod merge;
 mod orphan_welcome;
+mod own_commit;
 pub(crate) mod proposal;
 mod renew;
-mod self_commit;
 pub(crate) mod welcome;
 mod wipe;
 /// A unique identifier for a group/conversation. The identifier must be unique within a client.


### PR DESCRIPTION
# What's new in this PR
See corresponing jira item

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
