### PR TITLE
build: fix dynamic linker error on i686-linux-android [WPB-10493]

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -273,7 +273,9 @@ args = [
     "--crate-type=staticlib",
     "--release",
     "--",
-    "-C", "strip=symbols"
+    "-C", "strip=symbols",
+    "-l", "static=clang_rt.builtins-i686-android",
+    "-L", "${CLANG_RT_DIR}"
 ]
 dependencies = ["ffi-kotlin", "android-env"]
 


### PR DESCRIPTION
Similar to cb5f5c7f02df17fbeab94801f060fc2e6fb2d165, it turns out that on i686-linux-android the compiler fails to link the runtime library, resulting in errors like

    java.lang.UnsatisfiedLinkError: Unable to load library 'core_crypto_ffi':
    dlopen failed: cannot locate symbol "__atomic_load_8" referenced by ...

So let's do it manually.