### PR TITLE
style: fix new clippy lint

### DIFF
--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -934,12 +934,11 @@ impl CoreCrypto {
         central.restore_from_disk().await?;
         cfg_if::cfg_if! {
             if #[cfg(feature = "proteus")] {
-                central.proteus_reload_sessions().await.map_err(|e|{
+                central.proteus_reload_sessions().await.inspect_err(|e|{
                     let errcode = e.proteus_error_code();
                     if errcode > 0 {
                         self.proteus_last_error_code.store(errcode, std::sync::atomic::Ordering::SeqCst);
                     }
-                    e
                 })?;
             }
         }


### PR DESCRIPTION
"Use of map over inspect", which came up with the release of Rust 1.81.

# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
