### PR TITLE
feat: expose API for upgrading from basic to x509 credentials for a conversation WPB-10161

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ crypto-ffi/bindings/android/src/main/kotlin/uniffi/core_crypto/core_crypto.kt
 *.iws
 *.iml
 *.ipr
+local.properties
 out/
 
 # Created by https://www.toptal.com/developers/gitignore/api/node

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1235,14 +1235,13 @@ export class CoreCrypto {
                 custom?.keyRotationSpan,
                 custom?.wirePolicy
             );
-            const ret = await CoreCryptoError.asyncMapErr(
+            return await CoreCryptoError.asyncMapErr(
                 this.#cc.create_conversation(
                     conversationId,
                     creatorCredentialType,
                     config
                 )
             );
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1284,7 +1283,7 @@ export class CoreCrypto {
 
             const identity = mapWireIdentity(ffiDecryptedMessage.identity);
 
-            const ret: DecryptedMessage = {
+            return {
                 message: ffiDecryptedMessage.message,
                 proposals: ffiDecryptedMessage.proposals,
                 isActive: ffiDecryptedMessage.is_active,
@@ -1307,8 +1306,6 @@ export class CoreCrypto {
                 crlNewDistributionPoints:
                     ffiDecryptedMessage.crl_new_distribution_points,
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1357,12 +1354,10 @@ export class CoreCrypto {
                     this.#cc.process_welcome_message(welcomeMessage, config)
                 );
 
-            const ret: WelcomeBundle = {
+            return {
                 id: ffiRet.id,
                 crlNewDistributionPoints: ffiRet.crl_new_distribution_points,
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1460,7 +1455,7 @@ export class CoreCrypto {
 
             const gi = ffiRet.group_info;
 
-            const ret: MemberAddedMessages = {
+            return {
                 welcome: ffiRet.welcome,
                 commit: ffiRet.commit,
                 groupInfo: {
@@ -1470,8 +1465,6 @@ export class CoreCrypto {
                 },
                 crlNewDistributionPoints: ffiRet.crl_new_distribution_points,
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1505,7 +1498,7 @@ export class CoreCrypto {
 
             const gi = ffiRet.group_info;
 
-            const ret: CommitBundle = {
+            return {
                 welcome: ffiRet.welcome,
                 commit: ffiRet.commit,
                 groupInfo: {
@@ -1514,8 +1507,6 @@ export class CoreCrypto {
                     payload: gi.payload,
                 },
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1543,7 +1534,7 @@ export class CoreCrypto {
 
             const gi = ffiRet.group_info;
 
-            const ret: CommitBundle = {
+            return {
                 welcome: ffiRet.welcome,
                 commit: ffiRet.commit,
                 groupInfo: {
@@ -1552,8 +1543,6 @@ export class CoreCrypto {
                     payload: gi.payload,
                 },
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1584,7 +1573,7 @@ export class CoreCrypto {
 
             const gi = ffiRet.group_info;
 
-            const ret: CommitBundle = {
+            return {
                 welcome: ffiRet.welcome,
                 commit: ffiRet.commit,
                 groupInfo: {
@@ -1593,8 +1582,6 @@ export class CoreCrypto {
                     payload: gi.payload,
                 },
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -1752,7 +1739,7 @@ export class CoreCrypto {
 
             const gi = ffiInitMessage.group_info;
 
-            const ret: ConversationInitBundle = {
+            return {
                 conversationId: ffiInitMessage.conversation_id,
                 commit: ffiInitMessage.commit,
                 groupInfo: {
@@ -1763,8 +1750,6 @@ export class CoreCrypto {
                 crlNewDistributionPoints:
                     ffiInitMessage.crl_new_distribution_points,
             };
-
-            return ret;
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }
@@ -2357,14 +2342,12 @@ export class CoreCrypto {
                 newKeyPackageCount
             );
 
-        const ret: RotateBundle = {
+        return {
             commits: ffiRet.commits,
             newKeyPackages: ffiRet.new_key_packages,
             keyPackageRefsToRemove: ffiRet.key_package_refs_to_remove,
             crlNewDistributionPoints: ffiRet.crl_new_distribution_points,
         };
-
-        return ret;
     }
 
     /**

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/MLSClient.kt
@@ -308,6 +308,20 @@ class MLSClient(private val cc: com.wire.crypto.CoreCrypto) {
     suspend fun updateKeyingMaterial(id: MLSGroupId) = cc.updateKeyingMaterial(id.lower()).lift()
 
     /**
+     * Creates an update commit which replaces your leaf containing basic credentials with a leaf node containing x509 credentials in the conversation.
+     *
+     * NOTE: you can only call this after you've completed the enrollment for an end-to-end identity, calling this without
+     * a valid end-to-end identity will result in an error.
+     *
+     * **CAUTION**: [commitAccepted] **HAS TO** be called afterward **ONLY IF** the Delivery Service responds'200 OK' to the [CommitBundle] upload.
+     * It will "merge" the commit locally i.e. increment the local group epoch, use new encryption secrets etc...
+     *
+     * @param id conversation identifier
+     * @return a [CommitBundle] to upload to the backend and if it succeeds call [commitAccepted]
+     */
+    suspend fun e2eiRotate(id: MLSGroupId) = cc.e2eiRotate(id.lower()).lift()
+
+    /**
      * Commits the local pending proposals and returns the {@link CommitBundle} object containing what can result from this operation.
      *
      * *CAUTION**: [commitAccepted] **HAS TO** be called afterward **ONLY IF** the Delivery Service responds'200 OK' to the [CommitBundle] upload.

--- a/crypto-ffi/src/generic.rs
+++ b/crypto-ffi/src/generic.rs
@@ -19,6 +19,7 @@ use std::ops::DerefMut;
 
 use tls_codec::{Deserialize, Serialize};
 
+use crate::UniffiCustomTypeConverter;
 pub use core_crypto::prelude::ConversationId;
 use core_crypto::{
     prelude::{
@@ -32,8 +33,6 @@ use core_crypto::{
 };
 use tracing::{level_filters::LevelFilter, Level};
 use tracing_subscriber::fmt::{self, MakeWriter};
-
-use crate::UniffiCustomTypeConverter;
 
 #[allow(dead_code)]
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -1767,6 +1766,16 @@ impl CoreCrypto {
             )
             .await?
             .into())
+    }
+
+    /// See [core_crypto::mls::MlsCentral::e2ei_rotate]
+    pub async fn e2ei_rotate(&self, conversation_id: Vec<u8>) -> CoreCryptoResult<CommitBundle> {
+        self.central
+            .lock()
+            .await
+            .e2ei_rotate(&conversation_id, None)
+            .await?
+            .try_into()
     }
 
     /// See [core_crypto::mls::MlsCentral::e2ei_rotate_all]

--- a/crypto-ffi/src/wasm.rs
+++ b/crypto-ffi/src/wasm.rs
@@ -2844,6 +2844,26 @@ impl CoreCrypto {
             .err_into(),
         )
     }
+    /// Returns: [`WasmCryptoResult<CommitBundle>`]
+    ///
+    /// see [core_crypto::mls::MlsCentral::e2ei_rotate_all]
+    pub fn e2ei_rotate(&self, conversation_id: ConversationId) -> Promise {
+        let this = self.inner.clone();
+        future_to_promise(
+            async move {
+                let mut central = this.write().await;
+                let commit = central
+                    .e2ei_rotate(&conversation_id, None)
+                    .await
+                    .map_err(CoreCryptoError::from)?;
+
+                let commit: CommitBundle = commit.try_into()?;
+
+                WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&commit)?)
+            }
+            .err_into(),
+        )
+    }
 
     /// see [core_crypto::mls::MlsCentral::e2ei_enrollment_stash]
     pub fn e2ei_enrollment_stash(&self, enrollment: E2eiEnrollment) -> Promise {

--- a/crypto/src/e2e_identity/conversation_state.rs
+++ b/crypto/src/e2e_identity/conversation_state.rs
@@ -356,7 +356,12 @@ mod tests {
                             Some(expiration_time),
                         );
                         let cb = Client::new_x509_credential_bundle(cert.clone()).unwrap();
-                        let commit = alice_central.mls_central.e2ei_rotate(&id, &cb).await.unwrap().commit;
+                        let commit = alice_central
+                            .mls_central
+                            .e2ei_rotate(&id, Some(&cb))
+                            .await
+                            .unwrap()
+                            .commit;
                         alice_central.mls_central.commit_accepted(&id).await.unwrap();
                         bob_central
                             .mls_central
@@ -434,7 +439,7 @@ mod tests {
                     alice_intermediate_ca.update_end_identity(&mut alice_cert.certificate, Some(expiration_time));
 
                     let cb = Client::new_x509_credential_bundle(alice_cert.certificate.clone().into()).unwrap();
-                    alice_central.mls_central.e2ei_rotate(&id, &cb).await.unwrap();
+                    alice_central.mls_central.e2ei_rotate(&id, Some(&cb)).await.unwrap();
                     alice_central.mls_central.commit_accepted(&id).await.unwrap();
 
                     // Needed because 'e2ei_rotate' does not do it directly and it's required for 'get_group_info'

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -170,7 +170,12 @@ mod tests {
                         .await;
 
                     // create a commit. This will also store it in the store
-                    let commit = alice_central.mls_central.e2ei_rotate(&id, &cb).await.unwrap().commit;
+                    let commit = alice_central
+                        .mls_central
+                        .e2ei_rotate(&id, Some(&cb))
+                        .await
+                        .unwrap()
+                        .commit;
                     assert!(alice_central.mls_central.pending_commit(&id).await.is_some());
 
                     // since the pending commit is the same as the incoming one, it should succeed


### PR DESCRIPTION
# What's new in this PR

Expose API for upgrading from basic to x509 credentials for a conversation. This is useful for a clients to address the race condition, which can happen if they got added to a conversation with their basic credentials while upgrading to x509 credentials. 

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
