### PR TITLE
chore: update rusty-jwt-tools to latest release, 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,8 +3930,8 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rusty-acme"
-version = "0.9.0"
-source = "git+https://github.com/wireapp/rusty-jwt-tools?rev=751f281ec75a6ae113584659b4b48940407c50f8#751f281ec75a6ae113584659b4b48940407c50f8"
+version = "0.11.0"
+source = "git+https://github.com/wireapp/rusty-jwt-tools?tag=v0.11.0#8e95b38867ef631925cb34aabee0b4e6a42f6ace"
 dependencies = [
  "base64 0.22.1",
  "const-oid",
@@ -3958,8 +3958,8 @@ dependencies = [
 
 [[package]]
 name = "rusty-jwt-tools"
-version = "0.9.0"
-source = "git+https://github.com/wireapp/rusty-jwt-tools?rev=751f281ec75a6ae113584659b4b48940407c50f8#751f281ec75a6ae113584659b4b48940407c50f8"
+version = "0.11.0"
+source = "git+https://github.com/wireapp/rusty-jwt-tools?tag=v0.11.0#8e95b38867ef631925cb34aabee0b4e6a42f6ace"
 dependencies = [
  "base64 0.22.1",
  "const_format",
@@ -3986,8 +3986,8 @@ dependencies = [
 
 [[package]]
 name = "rusty-x509-check"
-version = "0.9.0"
-source = "git+https://github.com/wireapp/rusty-jwt-tools?rev=751f281ec75a6ae113584659b4b48940407c50f8#751f281ec75a6ae113584659b4b48940407c50f8"
+version = "0.11.0"
+source = "git+https://github.com/wireapp/rusty-jwt-tools?tag=v0.11.0#8e95b38867ef631925cb34aabee0b4e6a42f6ace"
 dependencies = [
  "certval",
  "const-oid",
@@ -5926,8 +5926,8 @@ dependencies = [
 
 [[package]]
 name = "wire-e2e-identity"
-version = "0.9.0"
-source = "git+https://github.com/wireapp/rusty-jwt-tools?rev=751f281ec75a6ae113584659b4b48940407c50f8#751f281ec75a6ae113584659b4b48940407c50f8"
+version = "0.11.0"
+source = "git+https://github.com/wireapp/rusty-jwt-tools?tag=v0.11.0#8e95b38867ef631925cb34aabee0b4e6a42f6ace"
 dependencies = [
  "derive_more",
  "jwt-simple",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ openmls_x509_credential = { git = "https://github.com/wireapp/openmls", rev = "6
 proteus-traits = { git = "https://github.com/wireapp/proteus", tag = "v2.1.1" }
 proteus-wasm = { git = "https://github.com/wireapp/proteus", tag = "v2.1.1" }
 
-wire-e2e-identity = { git = "https://github.com/wireapp/rusty-jwt-tools", rev = "751f281ec75a6ae113584659b4b48940407c50f8", version = "0.9" }
+wire-e2e-identity = { git = "https://github.com/wireapp/rusty-jwt-tools", tag = "v0.11.0" }
 
 [profile.release]
 lto = true

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -250,7 +250,8 @@ mod tests {
                 .unwrap();
             let mut alice_cert = alice_cert.clone();
             alice_cert.certificate = new_cert;
-            let alice_identifier = ClientIdentifier::X509([(case.signature_scheme(), alice_cert.into())].into());
+            let cb = CertificateBundle::from_self_signed_certificate(&alice_cert);
+            let alice_identifier = ClientIdentifier::X509([(case.signature_scheme(), cb)].into());
 
             let (bob_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("bob", None);
             assert!(matches!(
@@ -457,7 +458,7 @@ mod tests {
                     ..Default::default()
                 })
             };
-            let cb = alice_cert.into();
+            let cb = CertificateBundle::from_certificate_and_issuer(&alice_cert, &local_ca);
             let alice_identifier = ClientIdentifier::X509(HashMap::from([(case.signature_scheme(), cb)]));
 
             let (bob_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("bob", None);

--- a/crypto/src/test_utils/x509.rs
+++ b/crypto/src/test_utils/x509.rs
@@ -403,7 +403,7 @@ impl X509TestChain {
 
         let common_name = format!("{name} Smith");
         let handle = format!("{}_wire", name.to_lowercase());
-        let client_id: String = QualifiedE2eiClientId::generate_with_domain("wire.com")
+        let client_id: String = QualifiedE2eiClientId::generate_with_domain("world.com")
             .try_into()
             .unwrap();
         let mut cert_params = CertificateParams {

--- a/crypto/src/test_utils/x509.rs
+++ b/crypto/src/test_utils/x509.rs
@@ -1,6 +1,6 @@
 use crate::{
-    e2e_identity::id::QualifiedE2eiClientId, mls::client::identifier::ClientIdentifier, prelude::E2eIdentityError,
-    CryptoError,
+    e2e_identity::id::QualifiedE2eiClientId, mls::client::identifier::ClientIdentifier, prelude::CertificateBundle,
+    prelude::E2eIdentityError, CryptoError,
 };
 use std::{fmt::Display, time::Duration};
 
@@ -420,6 +420,7 @@ impl X509TestChain {
         let certificate = intermediate.create_and_sign_end_identity(cert_params);
 
         let sc = intermediate.signature_scheme;
+        let cert_bundle = CertificateBundle::from_certificate_and_issuer(&certificate, &intermediate);
 
         self.actors.push(X509TestChainActor {
             name: common_name,
@@ -431,7 +432,7 @@ impl X509TestChain {
 
         let cert = &self.actors.last().unwrap().certificate;
 
-        (ClientIdentifier::X509([(sc, cert.into())].into()), cert)
+        (ClientIdentifier::X509([(sc, cert_bundle)].into()), cert)
     }
 }
 


### PR DESCRIPTION
While updating to rusty-jwt-tools 0.11., we encountered failings tests due to
- version 0.11 correctly doing certificate validation (this was not the case before)
- incorrect construction of `CertificateBundle` instances, which were missing intermediate CA's certificate

This PR fixes the latter.