### PR TITLE
feat: support changing loggers at runtime WPB-11541

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ dependencies = [
  "futures-util",
  "js-sys",
  "log",
+ "log-reload",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -2668,6 +2669,16 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "serde",
  "value-bag",
+]
+
+[[package]]
+name = "log-reload"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99df759bfe829042ac9ad2d576ad0b3ffb3bad3c1f124dc0094b54441e89999"
+dependencies = [
+ "log",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ idb = "0.6"
 indexmap = "2"
 itertools = "0.13"
 log = { version = "0.4", features = ["kv"] }
+log-reload = "0.1.0"
 mls-crypto-provider = { path = "mls-provider" }
 pem = "3.0"
 rand = { version = "0.8", features = ["getrandom"] }

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -28,6 +28,7 @@ async-trait.workspace = true
 tls_codec.workspace = true
 async-lock.workspace = true
 log.workspace = true
+log-reload.workspace = true
 
 # see https://github.com/RustCrypto/hashes/issues/404
 [target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")))'.dependencies]

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -898,11 +898,14 @@ export enum CoreCryptoLogLevel {
 }
 
 /**
- * Initializes the global logger for Core Crypto and registers the callback. Can be called only once
+ * Initializes the global logger for Core Crypto and registers the callback.
+ *
+ * **NOTE:** you must call this after `await CoreCrypto.init(params)` or `await CoreCrypto.deferredInit(params)`.
+ *
+ * @deprecated use {@link CoreCrypto.setLogger} instead.
+ *
  * @param logger - the interface to be called when something is going to be logged
  * @param level - the max level that should be logged
- *
- * NOTE: you must call this after `await CoreCrypto.init(params)` or `await CoreCrypto.deferredInit(params)`.
  **/
 export function initLogger(
     logger: CoreCryptoLogger,
@@ -910,7 +913,29 @@ export function initLogger(
     ctx: unknown = null
 ): void {
     const wasmLogger = new CoreCryptoWasmLogger(logger.log, ctx);
-    CoreCrypto.setLogger(wasmLogger, level);
+    CoreCrypto.setLogger(wasmLogger);
+    CoreCrypto.setMaxLogLevel(level);
+}
+
+/**
+ * Initializes the global logger for Core Crypto and registers the callback.
+ *
+ * **NOTE:** you must call this after `await CoreCrypto.init(params)` or `await CoreCrypto.deferredInit(params)`.
+ *
+ * @param logger - the interface to be called when something is going to be logged
+ **/
+export function setLogger(logger: CoreCryptoLogger, ctx: unknown = null): void {
+    const wasmLogger = new CoreCryptoWasmLogger(logger.log, ctx);
+    CoreCrypto.setLogger(wasmLogger);
+}
+
+/**
+ * Sets maximum log level for logs forwarded to the logger, defaults to `Warn`.
+ *
+ * @param level - the max level that should be logged
+ */
+export function setMaxLogLevel(level: CoreCryptoLogLevel): void {
+    CoreCrypto.setMaxLogLevel(level);
 }
 
 /**
@@ -947,9 +972,14 @@ export class CoreCrypto {
         }
     }
 
-    static setLogger(logger: CoreCryptoWasmLogger, level: CoreCryptoLogLevel) {
+    static setLogger(logger: CoreCryptoWasmLogger) {
         this.#assertModuleLoaded();
-        CoreCryptoFfi.set_logger(logger, level);
+        CoreCryptoFfi.set_logger(logger);
+    }
+
+    static setMaxLogLevel(level: CoreCryptoLogLevel) {
+        this.#assertModuleLoaded();
+        CoreCryptoFfi.set_max_log_level(level);
     }
 
     /**

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -1582,7 +1582,8 @@ test("logs are forwarded when logger is registered", async () => {
             Ciphersuite,
             CredentialType,
             CoreCryptoLogLevel,
-            initLogger,
+            setLogger,
+            setMaxLogLevel,
         } = await import("./corecrypto.js");
 
         const ciphersuite =
@@ -1596,14 +1597,12 @@ test("logs are forwarded when logger is registered", async () => {
         });
 
         const logs = [];
-        initLogger(
-            {
-                log: (level, json_msg) => {
-                    logs.push(json_msg);
-                },
+        setLogger({
+            log: (level, json_msg) => {
+                logs.push(json_msg);
             },
-            CoreCryptoLogLevel.Debug
-        );
+        });
+        setMaxLogLevel(CoreCryptoLogLevel.Debug);
 
         const encoder = new TextEncoder();
         const conversationId = encoder.encode("invalidConversation");
@@ -1628,7 +1627,8 @@ test("logs are not forwarded when logger is registered, but log level is too hig
             Ciphersuite,
             CredentialType,
             CoreCryptoLogLevel,
-            initLogger,
+            setLogger,
+            setMaxLogLevel,
         } = await import("./corecrypto.js");
 
         const ciphersuite =
@@ -1642,14 +1642,12 @@ test("logs are not forwarded when logger is registered, but log level is too hig
         });
 
         const logs = [];
-        initLogger(
-            {
-                log: (level, json_msg) => {
-                    logs.push(json_msg);
-                },
+        setLogger({
+            log: (level, json_msg) => {
+                logs.push(json_msg);
             },
-            CoreCryptoLogLevel.Warn
-        );
+        });
+        setMaxLogLevel(CoreCryptoLogLevel.Warn);
 
         const encoder = new TextEncoder();
         const conversationId = encoder.encode("invalidConversation");
@@ -1681,7 +1679,8 @@ test("errors thrown by logger are reported as errors", async () => {
             Ciphersuite,
             CredentialType,
             CoreCryptoLogLevel,
-            initLogger,
+            setLogger,
+            setMaxLogLevel,
         } = await import("./corecrypto.js");
 
         const ciphersuite =
@@ -1694,14 +1693,12 @@ test("errors thrown by logger are reported as errors", async () => {
             clientId: "test",
         });
 
-        initLogger(
-            {
-                log: () => {
-                    throw Error("test error");
-                },
+        setLogger({
+            log: () => {
+                throw Error("test error");
             },
-            CoreCryptoLogLevel.Debug
-        );
+        });
+        setMaxLogLevel(CoreCryptoLogLevel.Debug);
 
         const encoder = new TextEncoder();
         const conversationId = encoder.encode("invalidConversation");

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
@@ -58,13 +58,32 @@ suspend fun <R> CoreCryptoCentral.transaction(block: suspend (context: CoreCrypt
 
 /**
  * Initializes the logging inside Core Crypto. Not required to be called and by default there will be no logging.
- * Can only be called once, otherwise errors will be thrown.
  *
  * @param logger a callback to implement the platform specific logging. It will receive the string with the log text from Core Crypto
- * @param  level the max level that should be logged. By default it will be OFF
+ * @param  level the max level that should be logged
  **/
-fun initLogger(logger: CoreCryptoLogger, level: CoreCryptoLogLevel = CoreCryptoLogLevel.OFF) {
-    setLogger(logger, level)
+@Deprecated("Use setLogger and setMaxLogLevel instead")
+fun initLogger(logger: CoreCryptoLogger, level: CoreCryptoLogLevel) {
+    com.wire.crypto.setLoggerOnly(logger)
+    com.wire.crypto.setMaxLogLevel(level)
+}
+
+/**
+ * Initializes the logging inside Core Crypto. Not required to be called and by default there will be no logging.
+ *
+ * @param logger a callback to implement the platform specific logging. It will receive the string with the log text from Core Crypto
+ **/
+fun setLogger(logger: CoreCryptoLogger) {
+    com.wire.crypto.setLoggerOnly(logger)
+}
+
+/**
+ * Set maximum log level of logs which are forwarded to the [CoreCryptoLogger].
+ *
+ * @param  level the max level that should be logged, by default it will be WARN
+ */
+fun setMaxLogLevel(level: CoreCryptoLogLevel) {
+    com.wire.crypto.setMaxLogLevel(level)
 }
 
 


### PR DESCRIPTION
# What's new in this PR

Support changing loggers and max log level at runtime.

also renamed `initLogger` in the bindings to `setLogger` since IMO init is not suitable anymore
when we allow replacing a logger.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
