### PR TITLE
refactor: keep client initialization state internal [WPB-12004]

### DIFF
--- a/crypto/benches/utils/mls.rs
+++ b/crypto/benches/utils/mls.rs
@@ -123,7 +123,7 @@ pub(crate) async fn setup_mls(
     in_memory: bool,
 ) -> (CoreCrypto, ConversationId) {
     let (central, _) = new_central(ciphersuite, credential, in_memory).await;
-    let core_crypto = CoreCrypto::from(central);
+    let core_crypto = central;
     let context = core_crypto.new_transaction().await.unwrap();
     let id = conversation_id();
     context

--- a/crypto/src/context.rs
+++ b/crypto/src/context.rs
@@ -33,7 +33,7 @@ enum ContextState {
     Valid {
         provider: MlsCryptoProvider,
         callbacks: Arc<RwLock<Option<std::sync::Arc<dyn CoreCryptoCallbacks + 'static>>>>,
-        mls_client: Arc<RwLock<Option<Client>>>,
+        mls_client: Client,
         mls_groups: Arc<RwLock<GroupStore<MlsConversation>>>,
         #[cfg(feature = "proteus")]
         proteus_central: Arc<Mutex<Option<ProteusCentral>>>,
@@ -79,16 +79,9 @@ impl CentralContext {
         })
     }
 
-    pub(crate) async fn mls_client(&self) -> CryptoResult<RwLockReadGuardArc<Option<Client>>> {
+    pub(crate) async fn mls_client(&self) -> CryptoResult<Client> {
         match self.state.read().await.deref() {
-            ContextState::Valid { mls_client, .. } => Ok(mls_client.read_arc().await),
-            ContextState::Invalid => Err(CryptoError::InvalidContext),
-        }
-    }
-
-    pub(crate) async fn mls_client_mut(&self) -> CryptoResult<RwLockWriteGuardArc<Option<Client>>> {
-        match self.state.read().await.deref() {
-            ContextState::Valid { mls_client, .. } => Ok(mls_client.write_arc().await),
+            ContextState::Valid { mls_client, .. } => Ok(mls_client.clone()),
             ContextState::Invalid => Err(CryptoError::InvalidContext),
         }
     }

--- a/crypto/src/e2e_identity/conversation_state.rs
+++ b/crypto/src/e2e_identity/conversation_state.rs
@@ -301,13 +301,13 @@ mod tests {
                     let x509_test_chain = x509_test_chain_arc.as_ref().as_ref().unwrap();
 
                     // That way the conversation creator (Alice) will have a different credential type than Bob
-                    let mut alice_client_guard = alice_central.context.mls_client_mut().await.unwrap();
-                    let alice_client = alice_client_guard.as_mut().unwrap();
+                    let alice_client = alice_central.context.mls_client().await.unwrap();
                     let alice_provider = alice_central.context.mls_provider().await.unwrap();
                     let creator_ct = match case.credential_type {
                         MlsCredentialType::Basic => {
                             let intermediate_ca = x509_test_chain.find_local_intermediate_ca();
-                            let cert_bundle = CertificateBundle::rand(alice_client.id(), intermediate_ca);
+                            let cert_bundle =
+                                CertificateBundle::rand(&alice_client.id().await.unwrap(), intermediate_ca);
                             alice_client
                                 .init_x509_credential_bundle_if_missing(
                                     &alice_provider,
@@ -326,7 +326,6 @@ mod tests {
                             MlsCredentialType::Basic
                         }
                     };
-                    drop(alice_client_guard);
 
                     alice_central
                         .context
@@ -392,8 +391,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let mut alice_client_guard = alice_central.context.mls_client_mut().await.unwrap();
-                let alice_client = alice_client_guard.as_mut().unwrap();
+                let alice_client = alice_central.context.mls_client().await.unwrap();
                 let alice_provider = alice_central.context.mls_provider().await.unwrap();
                 // Needed because 'e2ei_rotate' does not do it directly and it's required for 'get_group_info'
                 alice_client
@@ -401,7 +399,6 @@ mod tests {
                     .await
                     .unwrap();
 
-                drop(alice_client_guard);
                 // Need to fetch it before it becomes invalid & expires
                 let gi = alice_central.get_group_info(&id).await;
 
@@ -458,7 +455,7 @@ mod tests {
                     alice_central.context.e2ei_rotate(&id, Some(&cb)).await.unwrap();
                     alice_central.context.commit_accepted(&id).await.unwrap();
 
-                    let mut alice_client = alice_central.client().await;
+                    let alice_client = alice_central.client().await;
                     let alice_provider = alice_central.context.mls_provider().await.unwrap();
 
                     // Needed because 'e2ei_rotate' does not do it directly and it's required for 'get_group_info'

--- a/crypto/src/e2e_identity/mod.rs
+++ b/crypto/src/e2e_identity/mod.rs
@@ -588,7 +588,7 @@ pub(crate) mod tests {
     use crate::{
         e2e_identity::{id::QualifiedE2eiClientId, tests::x509::X509TestChain},
         prelude::*,
-        test_utils::{central::TEAM, *},
+        test_utils::{context::TEAM, *},
         CryptoResult,
     };
 

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -47,8 +47,7 @@ impl CentralContext {
         };
         let guard = self.callbacks().await?;
         let callbacks = guard.as_ref().map(|boxed| boxed.as_ref());
-        let client_guard = self.mls_client().await?;
-        let client = client_guard.as_ref().ok_or(CryptoError::MlsNotInitialized)?;
+        let client = &self.mls_client().await?;
         let mls_provider = self.mls_provider().await?;
         conversation
             .restore_pending_messages(

--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -350,8 +350,7 @@ mod tests {
                 };
 
                 let jwk = wire_e2e_identity::prelude::generate_jwk(alg);
-                let _ = cc
-                    .context
+                cc.context
                     .set_raw_external_senders(&mut case.cfg.clone(), vec![jwk])
                     .await
                     .unwrap();

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -392,8 +392,7 @@ impl CentralContext {
         let parent_conversation = self.get_parent_conversation(&conversation).await?;
         let guard = self.callbacks().await?;
         let callbacks = guard.as_ref().map(|boxed| boxed.as_ref());
-        let client_guard = self.mls_client().await?;
-        let client = client_guard.as_ref().ok_or(CryptoError::MlsNotInitialized)?;
+        let client = &self.mls_client().await?;
         let decrypt_message = conversation
             .write()
             .await

--- a/crypto/src/mls/conversation/encrypt.rs
+++ b/crypto/src/mls/conversation/encrypt.rs
@@ -28,8 +28,8 @@ impl MlsConversation {
     ) -> CryptoResult<Vec<u8>> {
         let signer = &self
             .find_current_credential_bundle(client)
-            .await?
-            .ok_or(CryptoError::IdentityInitializationError)?
+            .await
+            .map_err(|_| CryptoError::IdentityInitializationError)?
             .signature_key;
         let encrypted = self
             .group

--- a/crypto/src/mls/conversation/encrypt.rs
+++ b/crypto/src/mls/conversation/encrypt.rs
@@ -65,13 +65,12 @@ impl CentralContext {
         conversation: &ConversationId,
         message: impl AsRef<[u8]>,
     ) -> CryptoResult<Vec<u8>> {
-        let client_guard = self.mls_client().await?;
-        let client = client_guard.as_ref().ok_or(CryptoError::MlsNotInitialized)?;
+        let client = self.mls_client().await?;
         self.get_conversation(conversation)
             .await?
             .write()
             .await
-            .encrypt_message(client, message, &self.mls_provider().await?)
+            .encrypt_message(&client, message, &self.mls_provider().await?)
             .await
     }
 }

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -99,7 +99,7 @@ impl MlsConversation {
     /// Errors can happen from OpenMls or from the KeyStore
     pub async fn create(
         id: ConversationId,
-        author_client: &mut Client,
+        author_client: &Client,
         creator_credential_type: MlsCredentialType,
         configuration: MlsConversationConfiguration,
         backend: &MlsCryptoProvider,

--- a/crypto/src/mls/conversation/proposal.rs
+++ b/crypto/src/mls/conversation/proposal.rs
@@ -102,11 +102,7 @@ impl MlsConversation {
             .signature_key;
 
         let proposal = if let Some(leaf_node) = leaf_node {
-            let leaf_node_signer = &self
-                .find_most_recent_credential_bundle(client)
-                .await?
-                .ok_or(CryptoError::IdentityInitializationError)?
-                .signature_key;
+            let leaf_node_signer = &self.find_most_recent_credential_bundle(client).await?.signature_key;
 
             self.group
                 .propose_explicit_self_update(backend, msg_signer, leaf_node, leaf_node_signer)

--- a/crypto/src/mls/conversation/proposal.rs
+++ b/crypto/src/mls/conversation/proposal.rs
@@ -30,8 +30,8 @@ impl MlsConversation {
     ) -> CryptoResult<MlsProposalBundle> {
         let signer = &self
             .find_current_credential_bundle(client)
-            .await?
-            .ok_or(CryptoError::IdentityInitializationError)?
+            .await
+            .map_err(|_| CryptoError::IdentityInitializationError)?
             .signature_key;
 
         let crl_new_distribution_points = get_new_crl_distribution_points(
@@ -64,8 +64,8 @@ impl MlsConversation {
     ) -> CryptoResult<MlsProposalBundle> {
         let signer = &self
             .find_current_credential_bundle(client)
-            .await?
-            .ok_or(CryptoError::IdentityInitializationError)?
+            .await
+            .map_err(|_| CryptoError::IdentityInitializationError)?
             .signature_key;
         let proposal = self
             .group
@@ -97,8 +97,8 @@ impl MlsConversation {
     ) -> CryptoResult<MlsProposalBundle> {
         let msg_signer = &self
             .find_current_credential_bundle(client)
-            .await?
-            .ok_or(CryptoError::IdentityInitializationError)?
+            .await
+            .map_err(|_| CryptoError::IdentityInitializationError)?
             .signature_key;
 
         let proposal = if let Some(leaf_node) = leaf_node {

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -146,10 +146,7 @@ impl MlsConversation {
 
         let sc = self.signature_scheme();
         let ct = self.own_credential_type()?;
-        let cb = client
-            .find_most_recent_credential_bundle(sc, ct)
-            .await
-            .ok_or(CryptoError::MlsNotInitialized)?;
+        let cb = client.find_most_recent_credential_bundle(sc, ct).await?;
 
         leaf_node.set_credential_with_key(cb.to_mls_credential_with_key());
 

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -97,8 +97,7 @@ impl CentralContext {
         custom_cfg: MlsCustomConfiguration,
         credential_type: MlsCredentialType,
     ) -> CryptoResult<MlsConversationInitBundle> {
-        let mut client_guard = self.mls_client_mut().await?;
-        let client = client_guard.as_mut().ok_or(CryptoError::MlsNotInitialized)?;
+        let client = &self.mls_client().await?;
 
         let cs: MlsCiphersuite = group_info.ciphersuite().into();
         let mls_provider = self.mls_provider().await?;

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -245,8 +245,7 @@ impl MlsCentral {
         let cb = self
             .mls_client
             .find_most_recent_credential_bundle(ciphersuite.signature_algorithm(), credential_type)
-            .await?
-            .ok_or(CryptoError::ClientSignatureNotFound)?;
+            .await?;
         Ok(cb.signature_key.to_public_vec())
     }
 
@@ -336,7 +335,8 @@ impl CentralContext {
             .await?;
 
         if mls_client.is_e2ei_capable().await {
-            trace!(client_id:% = mls_client.id().await?; "Initializing PKI environment");
+            let client_id = mls_client.id().await?;
+            trace!(client_id:% = client_id; "Initializing PKI environment");
             self.init_pki_env().await?;
         }
 
@@ -381,8 +381,7 @@ impl CentralContext {
             .mls_client()
             .await?
             .find_most_recent_credential_bundle(ciphersuite.signature_algorithm(), credential_type)
-            .await?
-            .ok_or(CryptoError::ClientSignatureNotFound)?;
+            .await?;
         Ok(cb.signature_key.to_public_vec())
     }
 

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -138,8 +138,7 @@ impl CentralContext {
     /// returned as well, when for example there's a commit pending to be merged
     async fn new_proposal(&self, id: &ConversationId, proposal: MlsProposal) -> CryptoResult<MlsProposalBundle> {
         let conversation = self.get_conversation(id).await?;
-        let client_guard = self.mls_client().await?;
-        let client = client_guard.as_ref().ok_or(CryptoError::MlsNotInitialized)?;
+        let client = &self.mls_client().await?;
         proposal
             .create(client, &self.mls_provider().await?, conversation.write().await)
             .await

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -25,7 +25,7 @@ pub use rstest_reuse::{self, *};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub mod central;
+pub mod context;
 pub mod fixtures;
 pub mod message;
 pub mod x509;
@@ -62,12 +62,11 @@ impl ClientContext {
     }
 
     pub async fn client(&self) -> Client {
-        let client_guard = self.context.mls_client().await.unwrap();
-        client_guard.as_ref().unwrap().clone()
+        self.context.mls_client().await.unwrap()
     }
 
     pub async fn get_client_id(&self) -> ClientId {
-        self.client().await.id().clone()
+        self.client().await.id().await.unwrap()
     }
 }
 


### PR DESCRIPTION
# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
