### PR TITLE
refactor: move proteus errors to it's own top level error

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -162,6 +162,7 @@ script = '''
     perl -i \
         -pe 's/\bCryptoException\b/CryptoError/g;' \
         -pe 's/\bE2eIdentityException\b/E2eIdentityError/g;' \
+        -pe 's/\bProteusException\b/ProteusError/g;' \
         ./bindings/android/src/main/kotlin/uniffi/core_crypto/core_crypto.kt
 '''
 
@@ -187,6 +188,7 @@ script = '''
     perl -i \
         -pe 's/\bCryptoException\b/CryptoError/g;' \
         -pe 's/\bE2eIdentityException\b/E2eIdentityError/g;' \
+        -pe 's/\bProteusException\b/ProteusError/g;' \
         ./bindings/jvm/src/main/kotlin/uniffi/core_crypto/core_crypto.kt
 '''
 

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -313,7 +313,9 @@ test("Using invalid context throws error", async () => {
         return error;
     });
 
-    expect(error.rustStackTrace).toBe("CryptoError(InvalidContext)");
+    expect(error.rustStackTrace).toBe(
+        "CryptoError(ContextError(InvalidContext))"
+    );
 
     await page.close();
     await ctx.close();

--- a/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/client/MLSTest.kt
+++ b/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/client/MLSTest.kt
@@ -76,7 +76,7 @@ class MLSTest {
             context!!.mlsInit(aliceId.toClientId())
         }
 
-        assertIs<CryptoError.InvalidContext>(expectedException.error)
+        assertIs<CryptoError.ContextException>(expectedException.error)
     }
 
     @Test

--- a/crypto-ffi/src/lib.rs
+++ b/crypto-ffi/src/lib.rs
@@ -24,8 +24,8 @@ macro_rules! proteus_impl {
 
                 cfg_if::cfg_if! {
                     if #[cfg(target_family = "wasm")] {
-                        if let Err(CoreCryptoError(WasmError::CryptoError(e))) = &result {
-                            let errcode = e.proteus_error_code();
+                        if let Err(CoreCryptoError(WasmError::ProteusError(e))) = &result {
+                            let errcode = e.error_code();
                             if errcode > 0 {
                                 let mut ec = $errcode_dest.write().await;
                                 *ec = errcode;
@@ -34,8 +34,8 @@ macro_rules! proteus_impl {
 
                         result
                     } else {
-                        if let Err(CoreCryptoError::CryptoError { error: e }) = &result {
-                            let errcode = e.proteus_error_code();
+                        if let Err(CoreCryptoError::ProteusError { error: e }) = &result {
+                            let errcode = e.error_code();
                             if errcode > 0 {
                                 $errcode_dest.store(errcode, std::sync::atomic::Ordering::SeqCst);
                             }

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+use crate::context;
 use crate::mls::conversation::config::MAX_PAST_EPOCHS;
 use crate::prelude::{E2eIdentityError, MlsCredentialType};
 
@@ -134,12 +135,6 @@ pub enum CryptoError {
     /// Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives
     #[error("Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives")]
     BufferedFutureMessage,
-    /// Proteus Error Wrapper
-    #[error(transparent)]
-    ProteusError(#[from] ProteusError),
-    /// Cryptobox migration error wrapper
-    #[error(transparent)]
-    CryptoboxMigrationError(#[from] CryptoboxMigrationError),
     /// The proteus client has been called but has not been initialized yet
     #[error("Proteus client hasn't been initialized")]
     ProteusNotInitialized,
@@ -249,9 +244,9 @@ pub enum CryptoError {
     /// Not supported for the moment
     #[error("Not supported for the moment")]
     Unsupported,
-    /// Invalid Context. This context has been finished and can no longer be used.
-    #[error("This context has already been finished and can no longer be used.")]
-    InvalidContext,
+    /// Error occurred while performing operations in a context
+    #[error(transparent)]
+    ContextError(#[from] context::ContextError),
 }
 
 impl From<MlsError> for CryptoError {
@@ -273,16 +268,6 @@ impl From<MlsError> for CryptoError {
 
 /// A simpler definition for Result types that the Error is a [CryptoError]
 pub type CryptoResult<T> = Result<T, CryptoError>;
-
-impl CryptoError {
-    /// Returns the proteus error code
-    pub fn proteus_error_code(&self) -> u32 {
-        let Self::ProteusError(e) = self else {
-            return 0;
-        };
-        e.error_code()
-    }
-}
 
 /// MLS-specific error wrapper - see github.com/openmls/openmls for details
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
@@ -395,77 +380,4 @@ pub enum MlsError {
     /// OpenMLS GroupInfo error
     #[error(transparent)]
     GroupInfoError(#[from] openmls::messages::group_info::GroupInfoError),
-}
-
-#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
-/// Wrapper for Proteus-related errors
-pub enum ProteusError {
-    #[cfg(feature = "proteus")]
-    #[error(transparent)]
-    /// Error when decoding CBOR and/or decrypting Proteus messages
-    ProteusDecodeError(#[from] proteus_wasm::DecodeError),
-    #[cfg(feature = "proteus")]
-    #[error(transparent)]
-    /// Error when encoding CBOR and/or decrypting Proteus messages
-    ProteusEncodeError(#[from] proteus_wasm::EncodeError),
-    #[cfg(feature = "proteus")]
-    #[error(transparent)]
-    /// Various internal Proteus errors
-    ProteusInternalError(#[from] proteus_wasm::error::ProteusError),
-    #[cfg(feature = "proteus")]
-    #[error(transparent)]
-    /// Error when there's a critical error within a proteus Session
-    ProteusSessionError(#[from] proteus_wasm::session::Error<core_crypto_keystore::CryptoKeystoreError>),
-}
-
-impl ProteusError {
-    /// Returns the proteus error code
-    pub fn error_code(&self) -> u32 {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "proteus")] {
-                use proteus_traits::ProteusErrorCode as _;
-                match self {
-                    ProteusError::ProteusDecodeError(e) => e.code() as u32,
-                    ProteusError::ProteusEncodeError(e) => e.code() as u32,
-                    ProteusError::ProteusSessionError(e) => e.code() as u32,
-                    ProteusError::ProteusInternalError(e) => e.code() as u32,
-                }
-            } else {
-                0
-            }
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
-/// Wrapper for errors that can happen during a Cryptobox migration
-pub enum CryptoboxMigrationError {
-    #[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
-    #[error(transparent)]
-    /// IndexedDB Error
-    RexieError(#[from] rexie::Error),
-    #[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
-    #[error(transparent)]
-    /// Error when parsing/serializing JSON payloads from the WASM boundary
-    JsonParseError(#[from] serde_wasm_bindgen::Error),
-    #[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
-    #[error(transparent)]
-    /// Error when decoding base64
-    Base64DecodeError(#[from] base64::DecodeError),
-    #[error("The targeted value does not possess the targeted key ({0})")]
-    /// Error when trying to fetch a certain key from a structured value
-    MissingKeyInValue(String),
-    #[error("The value cannot be coerced to the {0} type")]
-    /// Error when trying to coerce a certain value to a certain type
-    WrongValueType(String),
-    #[cfg_attr(target_family = "wasm", error("The provided path [{0}] could not be found."))]
-    #[cfg_attr(
-        not(target_family = "wasm"),
-        error("The provided path store [{0}] is either non-existent or has an incorrect shape.")
-    )]
-    /// Error when trying to open a Cryptobox store that doesn't exist
-    ProvidedPathDoesNotExist(String),
-    #[error("The Cryptobox identity at path [{0}] could not be found.")]
-    /// Error when inspecting a Cryptobox store that doesn't contain an Identity
-    IdentityNotFound(String),
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -72,7 +72,7 @@ pub mod prelude {
             types::{E2eiAcmeChallenge, E2eiAcmeDirectory, E2eiNewAcmeAuthz, E2eiNewAcmeOrder},
             E2eiEnrollment,
         },
-        error::{CryptoError, CryptoResult, CryptoboxMigrationError, MlsError, ProteusError},
+        error::{CryptoError, CryptoResult, MlsError},
         mls::{
             ciphersuite::MlsCiphersuite,
             client::id::ClientId,


### PR DESCRIPTION
# What's new in this PR

Moving proteus errors to it's own error struct lets us create more detailed proteus errors, which in turn will allow us to remove the `proteus_code` hack.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
