### PR TITLE
chore(interop): use nondeprecated api [WPB-12132]

### DIFF
--- a/crypto-ffi/src/generic/context/mod.rs
+++ b/crypto-ffi/src/generic/context/mod.rs
@@ -3,6 +3,7 @@ use super::{
     ConversationInitBundle, CoreCrypto, CoreCryptoError, CoreCryptoResult, CustomConfiguration, DecryptedMessage,
     MemberAddedMessages, MlsCredentialType, ProposalBundle, WelcomeBundle,
 };
+use async_lock::{Mutex, OnceCell};
 use core_crypto::context::CentralContext;
 use core_crypto::{
     prelude::{
@@ -51,14 +52,114 @@ where
     }
 }
 
+/// Helper to extract data from within a transaction.
+///
+/// The `CoreCryptoCommand` interface requires some kind of interior mutability to extract
+/// any data: it takes an immutable reference to the implementing item, and returns the unit struct
+/// in the success case.
+///
+/// That pattern is relatively arcane and verbose, particularly when we just want to smuggle out
+/// some data from within the transaction. This helper is intended to ease and automate
+/// that process.
+///
+/// Use it like this (pseudocode):
+///
+/// ```ignore
+/// // an extractor is always `Arc`-wrapped
+/// let extractor: Arc<_> = TransactionDataExtractor::new(move |context| async move {
+///     // return whatever you need from the transaction here
+/// });
+/// core_crypto.transaction(extractor.clone()).await?;
+/// let return_value = extractor.into_return_value();
+/// ```
+///
+/// Note that `TransactionDataExtractor` is a one-shot item. Attempting to use the
+/// same extractor in two different transactions will cause a panic.
+pub struct TransactionDataExtractor<T, F> {
+    func: Mutex<Option<F>>,
+    return_value: OnceCell<T>,
+}
+
+impl<T, F, Fut> TransactionDataExtractor<T, F>
+where
+    F: FnOnce(Arc<CoreCryptoContext>) -> Fut + Send + Sync,
+    Fut: Future<Output = CoreCryptoResult<T>> + Send,
+    T: Send + Sync,
+{
+    pub fn new(func: F) -> Arc<Self> {
+        Arc::new(Self {
+            func: Mutex::new(Some(func)),
+            return_value: OnceCell::new(),
+        })
+    }
+
+    /// Get the return value from the internal function.
+    ///
+    /// ## Panics
+    ///
+    /// - If there exists more than one strong reference to this extractor
+    /// - If the inner function was never called
+    /// - If the inner function returned an `Err` variant
+    ///
+    /// In general if you call this after a call like
+    ///
+    /// ```ignore
+    /// core_crypto.transaction(extractor.clone())?;
+    /// ```
+    ///
+    /// then this will be fine.
+    pub fn into_return_value(self: Arc<Self>) -> T {
+        Arc::into_inner(self)
+            .expect("there should exist exactly one strong ref right now")
+            .return_value
+            .into_inner()
+            .expect("return value should be initialized")
+    }
+
+    /// Safely get the return value from the internal function.
+    ///
+    /// If there exists more than one strong reference to this item, or
+    /// the inner function was never called or returned an `Err` variant,
+    /// this will return `None`.
+    pub fn try_into_return_value(self: Arc<Self>) -> Option<T> {
+        Arc::into_inner(self)?.return_value.into_inner()
+    }
+}
+
+#[async_trait::async_trait]
+impl<T, F, Fut> CoreCryptoCommand for TransactionDataExtractor<T, F>
+where
+    F: FnOnce(Arc<CoreCryptoContext>) -> Fut + Send + Sync,
+    Fut: Future<Output = CoreCryptoResult<T>> + Send,
+    T: Send + Sync,
+{
+    async fn execute(&self, context: Arc<CoreCryptoContext>) -> CoreCryptoResult<()> {
+        let func = self
+            .func
+            .lock()
+            .await
+            .take()
+            .expect("inner function must only be called once");
+        let return_value = func(context).await?;
+        let set_result = self.return_value.set(return_value).await;
+        if set_result.is_err() {
+            // can't just `.expect()` here because `T` is not `Debug`
+            // though TBH this would be a really weird case; we should already have
+            // paniced getting `func` above
+            panic!("return value was previously set");
+        }
+        Ok(())
+    }
+}
+
 #[uniffi::export]
 impl CoreCrypto {
     /// Starts a new transaction in Core Crypto. If the callback succeeds, it will be committed,
     /// otherwise, every operation performed with the context will be discarded.
-    /// 
-    /// When calling this function from within Rust, async functions accepting a context 
+    ///
+    /// When calling this function from within Rust, async functions accepting a context
     /// implement `CoreCryptoCommand`, so operations can be defined inline as follows:
-    /// 
+    ///
     /// ```ignore
     /// core_crypto.transaction(Arc::new(|context| async {
     ///     // your implementation here

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -217,12 +217,14 @@ impl crate::clients::EmulatedProteusClient for CoreCryptoFfiClient {
         Ok(extractor.into_return_value())
     }
 
-    #[allow(deprecated)]
     async fn encrypt(&mut self, session_id: &str, plaintext: &[u8]) -> Result<Vec<u8>> {
-        self.cc
-            .proteus_encrypt(session_id.to_string(), plaintext.to_vec())
-            .await
-            .map_err(Into::into)
+        let session_id = session_id.to_string();
+        let plaintext = plaintext.to_vec();
+        let extractor = TransactionDataExtractor::new(move |context| async move {
+            context.proteus_encrypt(session_id, plaintext).await
+        });
+        self.cc.transaction(extractor.clone()).await?;
+        Ok(extractor.into_return_value())
     }
 
     #[allow(deprecated)]

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -196,11 +196,13 @@ impl crate::clients::EmulatedProteusClient for CoreCryptoFfiClient {
         Ok(extractor.into_return_value())
     }
 
-    #[allow(deprecated)]
     async fn session_from_prekey(&mut self, session_id: &str, prekey: &[u8]) -> Result<()> {
-        let _ = self
-            .cc
-            .proteus_session_from_prekey(session_id.to_string(), prekey.to_vec())
+        let session_id = session_id.to_string();
+        let prekey = prekey.to_vec();
+        self.cc
+            .transaction(TransactionDataExtractor::new(move |context| async move {
+                context.proteus_session_from_prekey(session_id, prekey).await
+            }))
             .await?;
         Ok(())
     }

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -157,12 +157,14 @@ impl EmulatedMlsClient for CoreCryptoFfiClient {
         Ok(extractor.into_return_value().id)
     }
 
-    #[allow(deprecated)]
     async fn encrypt_message(&mut self, conversation_id: &[u8], message: &[u8]) -> Result<Vec<u8>> {
-        self.cc
-            .encrypt_message(conversation_id.to_vec(), message.to_vec())
-            .await
-            .map_err(Into::into)
+        let conversation_id = conversation_id.to_vec();
+        let message = message.to_vec();
+        let extractor = TransactionDataExtractor::new(move |context| async move {
+            context.encrypt_message(conversation_id, message).await
+        });
+        self.cc.transaction(extractor.clone()).await?;
+        Ok(extractor.into_return_value())
     }
 
     #[allow(deprecated)]


### PR DESCRIPTION
# What's new in this PR

- Create a `TransactionHelper` which eases the process of dealing with transactions in Rust
- Adjusts the interop functions to use transactions instead of the old deprecated functions.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
