### PR TITLE
build: drop i686-linux-android target [WPB-10568]

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,10 +13,6 @@ CC_x86_64-linux-android = "x86_64-linux-android24-clang"
 CXX_x86_64-linux-android = "x86_64-linux-android24-clang++"
 AR_x86_64-linux-android = "llvm-ar"
 RANLIB_x86_64-linux-android = "llvm-ranlib"
-CC_i686-linux-android = "i686-linux-android24-clang"
-CXX_i686-linux-android = "i686-linux-android24-clang++"
-AR_i686-linux-android = "llvm-ar"
-RANLIB_i686-linux-android = "llvm-ranlib"
 # ? Ring treats warnings as errors during local development by detecting
 # ? the presence of a `.git` folder
 # ? With us having a git dependency to ring, this triggers this local development behavior, preventing
@@ -43,13 +39,6 @@ rustflags = [
 [target.x86_64-linux-android]
 ar = "llvm-ar"
 linker = "x86_64-linux-android24-clang"
-rustflags = [
-    "-C", "link-args=-latomic"
-]
-
-[target.i686-linux-android]
-ar = "llvm-ar"
-linker = "i686-linux-android24-clang"
 rustflags = [
     "-C", "link-args=-latomic"
 ]

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android,i686-linux-android"
+          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
       - name: Setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - name: Setup Android SDK

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android,i686-linux-android"
+          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
       - name: Setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - name: Setup Android SDK

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Install Android SDK and Build-Tools for API level 30+
 
 Install android rust targets:
 ```ignore
-rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android
+rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
 ```
 Build:
 ```ignore

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -298,24 +298,8 @@ args = [
 ]
 dependencies = ["ffi-kotlin-android", "android-env"]
 
-[tasks.android-i686]
-command = "cargo"
-args = [
-    "rustc",
-    "--locked",
-    "--target", "i686-linux-android",
-    "--crate-type=cdylib",
-    "--crate-type=staticlib",
-    "--release",
-    "--",
-    "-C", "strip=symbols",
-    "-l", "static=clang_rt.builtins-i686-android",
-    "-L", "${CLANG_RT_DIR}"
-]
-dependencies = ["ffi-kotlin-android", "android-env"]
-
 [tasks.android]
-dependencies = ["android-armv7", "android-armv8", "android-x86", "android-i686"]
+dependencies = ["android-armv7", "android-armv8", "android-x86"]
 
 ####################################  JVM  ####################################
 

--- a/crypto-ffi/bindings/android/build.gradle.kts
+++ b/crypto-ffi/bindings/android/build.gradle.kts
@@ -72,7 +72,6 @@ fun registerCopyJvmBinaryTask(target: String, jniTarget: String, include: String
 val copyBinariesTasks = listOf(
     registerCopyJvmBinaryTask("aarch64-linux-android", "arm64-v8a"),
     registerCopyJvmBinaryTask("armv7-linux-androideabi", "armeabi-v7a"),
-    registerCopyJvmBinaryTask("i686-linux-android", "x86"),
     registerCopyJvmBinaryTask("x86_64-linux-android", "x86_64")
 )
 


### PR DESCRIPTION
Drop support for `i686-linux-android` target

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
