### PR TITLE
feat: disambiguate `WrongEpoch` [WPB-14351]

### DIFF
--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -128,8 +128,11 @@ pub enum CryptoError {
     /// Tried to decrypt a message in the wrong epoch
     #[error("Decrypted an application message from the wrong epoch")]
     DecryptionError,
-    /// Incoming message is for the wrong epoch
-    #[error("Incoming message is for the wrong epoch")]
+    /// Incoming message is from a prior epoch
+    #[error("Incoming message is from a prior epoch")]
+    StaleMessage,
+    /// Incoming message is from an epoch too far in the future to buffer.
+    #[error("Incoming message is from an epoch too far in the future to buffer.")]
     WrongEpoch,
     /// Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives
     #[error("Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives")]

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -316,7 +316,7 @@ impl MlsConversation {
                         CryptoError::BufferedFutureMessage
                     } else if msg_epoch < group_epoch {
                         match content_type {
-                            ContentType::Application => CryptoError::WrongEpoch,
+                            ContentType::Application => CryptoError::StaleMessage,
                             ContentType::Commit => CryptoError::StaleCommit,
                             ContentType::Proposal => CryptoError::StaleProposal,
                         }


### PR DESCRIPTION
`WrongEpoch` used to be emitted both when the message epoch was too old to handle, and when it was too far in the future to handle. That could lead to client inefficiencies when handling this error.

Split it into `StaleMessage` and `UnbufferedFutureMessage` to distinguish these cases.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
