### PR TITLE
chore: log a warning when an empty transaction is committed [WPB-11743]

### DIFF
--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -24,7 +24,7 @@ default = ["proteus-keystore"]
 proteus-keystore = ["dep:proteus-traits"]
 ios-wal-compat = ["dep:security-framework", "dep:security-framework-sys", "dep:core-foundation"]
 idb-regression-test = []
-log-queries = ["dep:log", "rusqlite/trace"]
+log-queries = ["rusqlite/trace"]
 serde = ["dep:serde"]
 dummy-entity = ["serde"]
 
@@ -48,7 +48,7 @@ openmls_traits = { workspace = true }
 openmls_basic_credential = { workspace = true }
 openmls_x509_credential = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
-log = { workspace = true, optional = true }
+log = { workspace = true }
 proteus-traits = { workspace = true, optional = true }
 itertools.workspace = true
 

--- a/keystore/src/transaction/mod.rs
+++ b/keystore/src/transaction/mod.rs
@@ -158,7 +158,7 @@ impl KeystoreTransaction {
     /// Identity from the perspective of this function is determined by the output of [crate::entities::Entity::merge_key].
     ///
     /// Further, the output list of records is built with respect to the provided [EntityFindParams]
-    /// and the deleted records cached in this [Self] instance.     
+    /// and the deleted records cached in this [Self] instance.
     async fn merge_records<E: crate::entities::Entity<ConnectionType = KeystoreDatabaseConnection>>(
         &self,
         records_a: Vec<E>,
@@ -250,7 +250,7 @@ impl KeystoreTransaction {
 ///         (identifier_01, MlsCredential),
 ///         (identifier_02, MlsSignatureKeyPair),
 ///     ],
-///     proteus_types: [  
+///     proteus_types: [
 ///         (identifier_03, ProteusPrekey),
 ///         (identifier_04, ProteusIdentity),
 ///         (identifier_05, ProteusSession)
@@ -288,8 +288,7 @@ macro_rules! commit_transaction {
                     }
 
                     if tables.is_empty() {
-                        // If we didn't do this early return, creating the transaction would fail.
-                        // Once logging is available, we should log a warning here though. (WPB-11743)
+                        log::warn!("Empty transaction was committed, this could be an indication of a programming error");
                         return Ok(());
                     }
                     let tx = conn.new_transaction(&tables).await?;


### PR DESCRIPTION
# What's new in this PR

An empty transaction could be an indication that the app consuming core crypto contains a programming error.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
