### PR TITLE
refactor: change test for build meta data

### DIFF
--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -875,6 +875,6 @@ describe("build", () => {
             browser.execute(async () =>
                 window.ccModule.CoreCrypto.buildMetadata().toJSON()
             )
-        ).resolves.toMatchObject({ cargo_features: expect.anything() });
+        ).resolves.toMatchObject({ gitDescribe: expect.anything() });
     });
 });

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -46,28 +46,28 @@ pub struct BuildMetadata {
     #[wasm_bindgen(readonly)]
     pub timestamp: &'static str,
     /// Whether this build was in Debug mode (true) or Release mode (false)
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "cargoDebug")]
     pub cargo_debug: &'static str,
     /// Features enabled for this build
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "cargoFeatures")]
     pub cargo_features: &'static str,
     /// Optimization level
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "optLevel")]
     pub opt_level: &'static str,
     /// Build target triple
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "targetTriple")]
     pub target_triple: &'static str,
     /// Git branch
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "gitBranch")]
     pub git_branch: &'static str,
     /// Output of `git describe`
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "gitDescribe")]
     pub git_describe: &'static str,
     /// Hash of current git commit
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "gitSha")]
     pub git_sha: &'static str,
     /// `true` when the source code differed from the commit at the most recent git hash
-    #[wasm_bindgen(readonly)]
+    #[wasm_bindgen(readonly, js_name = "gitDirty")]
     pub git_dirty: &'static str,
 }
 


### PR DESCRIPTION
# What's new in this PR
- change test for build metadata to achieve closer parity with the kotlin test.

- change fields of BuildMetadata to camelCase.
- To comply to javascript conventions.
- This is desirable because we expose this struct beyond our typescript wrapper.
- It has to be this tedious way of renaming each field separately, until rustwasm/wasm-bindgen#1818 is solved.



----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
