### PR TITLE
ci: fix doc generation

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -124,7 +124,6 @@ jobs:
       - name: Build & test WASM / JS package
         run: |
           cd crypto-ffi
-          npm install
           bun install
           cargo make wasm
           bun run wdio

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,12 @@ jobs:
     - name: Build Rust documentation
       run: cargo doc --all --no-deps
 
-    - name: Build TypeScript docs
+    - name: Setup bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - name: Build TypeScript and Kotlin docs
       run: |
         cd crypto-ffi
         cargo make wasm-build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,9 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
       with:
         rustflags: ''
-        target: wasm32-unknown-unknown
+        target: |
+          wasm32-unknown-unknown
+          x86_64-unknown-linux-gnu
 
     - name: Setup cargo-make
       uses: davidB/rust-cargo-make@v1
@@ -49,7 +51,6 @@ jobs:
     - name: Build TypeScript and Kotlin docs
       run: |
         cd crypto-ffi
-        cargo make wasm-build
         cargo make docs-ts
         cargo make docs-kotlin
 

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ cd crypto-ffi/bindings/android
 Publishing JS / WASM bindings happens automatically by a github workflow when a release tag is pushed.
 
 If you would like to publish to `@wireapp/core-crypto` manually, log into NPM and
-just run `npm publish`.
+just run `bun publish`.

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -77,15 +77,15 @@ args = [
 command = "cargo"
 args = ["doc", "--no-deps", "--target=wasm32-unknown-unknown"]
 
-[tasks.npm-deps]
-command = "npm"
+[tasks.bun-deps]
+command = "bun"
 args = ["install"]
 
 [tasks.docs-ts]
-dependencies = ["npm-deps"]
-command = "npx"
+dependencies = ["bun-deps"]
+command = "bunx"
 args = [
-    "-y", "typedoc",
+    "typedoc",
     "--basePath", "./bindings/js",
     "--entryPoints", "./bindings/js/CoreCrypto.ts",
     "--tsconfig", "./bindings/js/tsconfig.json",

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -62,7 +62,11 @@ script = '''
 '''
 
 [tasks.docs-kotlin]
-dependencies = ["docs-kotlin-install-deps"]
+dependencies = [
+    "docs-kotlin-install-deps",
+    { name = "jvm-darwin", condition = { platforms = ["mac"] } },
+    { name = "jvm-linux", condition = { platforms = ["linux"] } }
+]
 command = "java"
 args = [
     "-jar", "../target/_kotlin_docs_tmp/dokka-cli-${DOKKA_VERSION}.jar",
@@ -82,7 +86,7 @@ command = "bun"
 args = ["install"]
 
 [tasks.docs-ts]
-dependencies = ["bun-deps"]
+dependencies = ["wasm", "bun-deps"]
 command = "bunx"
 args = [
     "typedoc",
@@ -112,11 +116,9 @@ args = [
 script = "cargo make wasm-build --dev"
 
 [tasks.wasm]
-dependencies = ["wasm-build"]
-script = [
-    "bun install",
-    "bun run build_ts.ts"
-]
+dependencies = ["wasm-build", "bun-deps"]
+command = "bun"
+args = ["run", "build_ts.ts"]
 
 ##################################### FFI #####################################
 

--- a/interop/src/build/web/wasm.rs
+++ b/interop/src/build/web/wasm.rs
@@ -52,7 +52,7 @@ pub(crate) async fn build_wasm() -> Result<()> {
     if cfg!(feature = "proteus") {
         let spinner = RunningProcess::new("Building Cryptobox ESM bundle...", false);
 
-        Command::new("npm")
+        Command::new("bun")
             .args(["install"])
             .current_dir(cwd.join("interop/src/build/web/cryptobox-esm"))
             .stdout(std::process::Stdio::null())
@@ -60,7 +60,7 @@ pub(crate) async fn build_wasm() -> Result<()> {
             .status()
             .await?;
 
-        Command::new("npm")
+        Command::new("bun")
             .args(["run", "build"])
             .current_dir(cwd.join("interop/src/build/web/cryptobox-esm"))
             .stdout(std::process::Stdio::null())
@@ -113,15 +113,15 @@ pub(crate) async fn build_wasm() -> Result<()> {
     }
 
     let mut cargo_args = vec!["make", "wasm"];
-    let mut npm_env = vec![];
+    let mut bun_env = vec![];
 
     if cfg!(feature = "proteus") {
         spinner.update(
-            "`proteus` feature enabled. Building `core-crypto` with proteus support & enabling npm env BUILD_PROTEUS=1; Also building ESM bundle for Cryptobox",
+            "`proteus` feature enabled. Building `core-crypto` with proteus support & enabling bun env BUILD_PROTEUS=1; Also building ESM bundle for Cryptobox",
         );
         cargo_args.push("--features");
         cargo_args.push("proteus");
-        npm_env.push(("BUILD_PROTEUS", "1"));
+        bun_env.push(("BUILD_PROTEUS", "1"));
     }
 
     Command::new("cargo")
@@ -133,7 +133,7 @@ pub(crate) async fn build_wasm() -> Result<()> {
 
     Command::new("bun")
         .args(["run", "wdio"])
-        .envs(npm_env.clone())
+        .envs(bun_env.clone())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()


### PR DESCRIPTION
# What's new in this PR
- ci: use bun instead of npm when building
- ci: make sure targets are built before building docs

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
