### PR TITLE
chore: log warning about empty tables also for uniffi targets

### DIFF
--- a/keystore/src/transaction/dynamic_dispatch.rs
+++ b/keystore/src/transaction/dynamic_dispatch.rs
@@ -117,7 +117,6 @@ impl EntityId {
         }
     }
 
-    #[cfg(target_family = "wasm")]
     pub(crate) fn collection_name(&self) -> &'static str {
         match self {
             EntityId::SignatureKeyPair(_) => MlsSignatureKeyPair::COLLECTION_NAME,


### PR DESCRIPTION
Before it was logged only for wasm targets.
Follow-up for [WPB-11743].

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
