### PR TITLE
fix: improve errors when hitting an indexdb error during cryptobox migration

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -118,9 +118,9 @@ jobs:
       - name: Setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: taiki-e/install-action@v2
         with:
-          version: "latest"
+          tool: wasm-pack
       - name: Build & test WASM / JS package
         run: |
           cd crypto-ffi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
 
-    steps: 
+    steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -36,9 +36,9 @@ jobs:
       uses: davidB/rust-cargo-make@v1
 
     - name: Install wasm-pack
-      uses: jetli/wasm-pack-action@v0.4.0
+      uses: taiki-e/install-action@v2
       with:
-        version: 'latest'
+        tool: wasm-pack
 
     - name: Build Rust documentation
       run: cargo doc --all --no-deps

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -41,9 +41,9 @@ jobs:
         uses: davidB/rust-cargo-make@v1
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: taiki-e/install-action@v2
         with:
-          version: "latest"
+          tool: wasm-pack
 
       - name: Build WASM package
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "hex",
+ "idb",
  "indexmap 2.6.0",
  "itertools 0.13.0",
  "js-sys",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["lib", "cdylib"]
 [features]
 default = ["proteus", "cryptobox-migrate"]
 proteus = ["dep:proteus-wasm", "dep:proteus-traits", "core-crypto-keystore/proteus-keystore"]
-cryptobox-migrate = ["proteus", "proteus-wasm?/cryptobox-identity", "dep:async-fs", "dep:futures-lite", "dep:rexie", "dep:base64"]
+cryptobox-migrate = ["proteus", "proteus-wasm?/cryptobox-identity", "dep:async-fs", "dep:futures-lite", "dep:rexie", "dep:idb", "dep:base64"]
 # for test/bench all ciphersuites
 test-all-cipher = []
 # execute benches with also real db to better see overhead
@@ -65,6 +65,7 @@ futures-lite = { version = "2.3", optional = true }
 [target.'cfg(target_family = "wasm")'.dependencies]
 serde-wasm-bindgen = "0.6"
 rexie = { workspace = true, optional = true }
+idb = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -17,6 +17,9 @@
 use crate::mls::conversation::config::MAX_PAST_EPOCHS;
 use crate::prelude::{E2eIdentityError, MlsCredentialType};
 
+#[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
+use rexie;
+
 /// CoreCrypto errors
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
@@ -447,8 +450,12 @@ impl ProteusError {
 pub enum CryptoboxMigrationError {
     #[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
     #[error(transparent)]
+    /// Rexie Error
+    RexieError(rexie::Error),
+    #[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
+    #[error(transparent)]
     /// IndexedDB Error
-    RexieError(#[from] rexie::Error),
+    IdbError(idb::Error),
     #[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
     #[error(transparent)]
     /// Error when parsing/serializing JSON payloads from the WASM boundary
@@ -473,4 +480,14 @@ pub enum CryptoboxMigrationError {
     #[error("The Cryptobox identity at path [{0}] could not be found.")]
     /// Error when inspecting a Cryptobox store that doesn't contain an Identity
     IdentityNotFound(String),
+}
+
+#[cfg(all(feature = "cryptobox-migrate", target_family = "wasm"))]
+impl From<rexie::Error> for CryptoboxMigrationError {
+    fn from(e: rexie::Error) -> Self {
+        match e {
+            rexie::Error::IdbError(e) => Self::IdbError(e),
+            _ => Self::RexieError(e),
+        }
+    }
 }


### PR DESCRIPTION
# What's new in this PR

The old error swallowed the underlaying indexdb error.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
