### PR TITLE
fix: stop exposing wipe() and unload() since they are broken in Kotlin [WPB-14514]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,6 +2593,7 @@ dependencies = [
 name = "interop"
 version = "2.0.0"
 dependencies = [
+ "async-fs",
  "async-trait",
  "base64 0.22.1",
  "bitflags 2.6.0",

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1138,15 +1138,6 @@ export class CoreCrypto {
     }
 
     /**
-     * Wipes the {@link CoreCrypto} backing storage (i.e. {@link https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API | IndexedDB} database)
-     *
-     * **CAUTION**: This {@link CoreCrypto} instance won't be useable after a call to this method, but there's no way to express this requirement in TypeScript so you'll get errors instead!
-     */
-    async wipe() {
-        await CoreCryptoError.asyncMapErr(this.#cc.wipe());
-    }
-
-    /**
      * Closes this {@link CoreCrypto} instance and deallocates all loaded resources
      *
      * **CAUTION**: This {@link CoreCrypto} instance won't be usable after a call to this method, but there's no way to express this requirement in TypeScript, so you'll get errors instead!

--- a/crypto-ffi/bindings/js/test/utils.ts
+++ b/crypto-ffi/bindings/js/test/utils.ts
@@ -58,10 +58,18 @@ export async function setup() {
 
 export async function teardown() {
     await browser.execute(async () => {
+        function promiseForIDBRequest(tx: IDBRequest) {
+            return new Promise<void>((resolve, reject) => {
+                tx.onsuccess = () => resolve();
+                tx.onerror = () => reject(tx.error);
+            });
+        }
+
         // Delete all core crypto instances.
         for (const ccKey in window.cc) {
             const cc = window.ensureCcDefined(ccKey);
-            await cc.wipe();
+            await cc.close();
+            await promiseForIDBRequest(window.indexedDB.deleteDatabase(ccKey));
             delete window.cc[ccKey];
         }
     });

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
@@ -126,14 +126,6 @@ class CoreCrypto(private val cc: com.wire.crypto.uniffi.CoreCrypto) {
         cc.close()
     }
 
-    /**
-     * Wipes all in-memory and persisted data associated with this [CoreCrypto] instance.
-     *
-     * * **CAUTION**: This {@link CoreCrypto} instance won't be usable after a call to this method, but there's no way to express this requirement in Kotlin, so you'll get errors instead!
-     */
-    suspend fun wipe() {
-        cc.wipe()
-    }
 }
 
 

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -1142,26 +1142,6 @@ impl CoreCrypto {
         Ok(())
     }
 
-    /// See [core_crypto::mls::MlsCentral::close]
-    pub async fn unload(self: std::sync::Arc<Self>) -> CoreCryptoResult<()> {
-        if let Some(cc) = std::sync::Arc::into_inner(self) {
-            cc.central.take().close().await?;
-            Ok(())
-        } else {
-            Err(CryptoError::LockPoisonError.into())
-        }
-    }
-
-    /// See [core_crypto::mls::MlsCentral::wipe]
-    pub async fn wipe(self: std::sync::Arc<Self>) -> CoreCryptoResult<()> {
-        if let Some(cc) = std::sync::Arc::into_inner(self) {
-            cc.central.take().wipe().await?;
-            Ok(())
-        } else {
-            Err(CryptoError::LockPoisonError.into())
-        }
-    }
-
     /// See [core_crypto::mls::MlsCentral::provide_transport]
     pub async fn provide_transport(&self, callbacks: Arc<dyn MlsTransport>) -> CoreCryptoResult<()> {
         self.central

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1582,27 +1582,6 @@ impl CoreCrypto {
         }
     }
 
-    /// Returns: [`WasmCryptoResult<()>`]
-    ///
-    /// see [core_crypto::mls::MlsCentral::wipe]
-    pub fn wipe(self) -> Promise {
-        let error_message: &JsValue = &format!(
-            "There are other outstanding references to this CoreCrypto instance [strong refs = {}]",
-            Arc::strong_count(&self.inner)
-        )
-        .into();
-        match Arc::into_inner(self.inner) {
-            Some(central) => future_to_promise(
-                async move {
-                    central.take().wipe().await.map_err(CoreCryptoError::from)?;
-                    WasmCryptoResult::Ok(JsValue::UNDEFINED)
-                }
-                .err_into(),
-            ),
-            None => Promise::reject(error_message),
-        }
-    }
-
     pub fn set_logger(logger: CoreCryptoWasmLogger) {
         // unwrapping poisoned lock error which shouldn't happen since we don't panic while replacing the logger
         LOGGER.handle().replace(logger).unwrap();

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -300,15 +300,6 @@ impl MlsCentral {
         Ok(())
     }
 
-    /// Destroys everything we have, in-memory and on disk.
-    ///
-    /// # Errors
-    /// KeyStore errors, such as IO
-    pub async fn wipe(self) -> CryptoResult<()> {
-        self.mls_backend.destroy_and_reset().await?;
-        Ok(())
-    }
-
     /// see [mls_crypto_provider::MlsCryptoProvider::reseed]
     pub async fn reseed(&self, seed: Option<EntropySeed>) -> CryptoResult<()> {
         self.mls_backend.reseed(seed)?;

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -40,6 +40,7 @@ xshell = "0.2"
 spinoff = { version = "0.8", features = ["aesthetic"], default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+async-fs = "2.1"
 cryptobox = { git = "https://github.com/wireapp/cryptobox", optional = true }
 proteus = { git = "https://github.com/wireapp/proteus", branch = "otak/fix-1.0.3", optional = true }
 tokio = { version = "1.42", features = ["full"] }

--- a/interop/src/clients/mod.rs
+++ b/interop/src/clients/mod.rs
@@ -70,13 +70,13 @@ pub(crate) trait EmulatedClient {
 #[async_trait::async_trait(?Send)]
 #[allow(dead_code)]
 pub(crate) trait EmulatedMlsClient: EmulatedClient {
-    async fn get_keypackage(&mut self) -> Result<Vec<u8>>;
-    async fn add_client(&mut self, conversation_id: &[u8], kp: &[u8]) -> Result<Vec<u8>>;
-    async fn kick_client(&mut self, conversation_id: &[u8], client_id: &[u8]) -> Result<Vec<u8>>;
-    async fn process_welcome(&mut self, welcome: &[u8]) -> Result<Vec<u8>>;
-    async fn encrypt_message(&mut self, conversation_id: &[u8], message: &[u8]) -> Result<Vec<u8>>;
+    async fn get_keypackage(&self) -> Result<Vec<u8>>;
+    async fn add_client(&self, conversation_id: &[u8], kp: &[u8]) -> Result<Vec<u8>>;
+    async fn kick_client(&self, conversation_id: &[u8], client_id: &[u8]) -> Result<Vec<u8>>;
+    async fn process_welcome(&self, welcome: &[u8]) -> Result<Vec<u8>>;
+    async fn encrypt_message(&self, conversation_id: &[u8], message: &[u8]) -> Result<Vec<u8>>;
     // TODO: Make it more complex so that we can extract other things like proposals etc. Tracking issue: WPB-9647
-    async fn decrypt_message(&mut self, conversation_id: &[u8], message: &[u8]) -> Result<Option<Vec<u8>>>;
+    async fn decrypt_message(&self, conversation_id: &[u8], message: &[u8]) -> Result<Option<Vec<u8>>>;
 }
 
 #[async_trait::async_trait(?Send)]
@@ -85,11 +85,11 @@ pub(crate) trait EmulatedProteusClient: EmulatedClient {
     async fn init(&mut self) -> Result<()> {
         Ok(())
     }
-    async fn get_prekey(&mut self) -> Result<Vec<u8>>;
-    async fn session_from_prekey(&mut self, session_id: &str, prekey: &[u8]) -> Result<()>;
-    async fn session_from_message(&mut self, session_id: &str, message: &[u8]) -> Result<Vec<u8>>;
-    async fn encrypt(&mut self, session_id: &str, plaintext: &[u8]) -> Result<Vec<u8>>;
-    async fn decrypt(&mut self, session_id: &str, ciphertext: &[u8]) -> Result<Vec<u8>>;
+    async fn get_prekey(&self) -> Result<Vec<u8>>;
+    async fn session_from_prekey(&self, session_id: &str, prekey: &[u8]) -> Result<()>;
+    async fn session_from_message(&self, session_id: &str, message: &[u8]) -> Result<Vec<u8>>;
+    async fn encrypt(&self, session_id: &str, plaintext: &[u8]) -> Result<Vec<u8>>;
+    async fn decrypt(&self, session_id: &str, ciphertext: &[u8]) -> Result<Vec<u8>>;
     async fn fingerprint(&self) -> Result<String>;
 }
 

--- a/mls-provider/src/lib.rs
+++ b/mls-provider/src/lib.rs
@@ -175,13 +175,6 @@ impl MlsCryptoProvider {
         Ok(self.key_store.close().await?)
     }
 
-    /// Tears down this provider and **obliterates every single piece of data stored on disk**.
-    ///
-    /// *you have been warned*
-    pub async fn destroy_and_reset(self) -> MlsProviderResult<()> {
-        Ok(self.key_store.wipe().await?)
-    }
-
     /// Clone keystore (its an `Arc` internnaly)
     pub fn keystore(&self) -> CryptoKeystore {
         self.key_store.clone()


### PR DESCRIPTION
# What's new in this PR

Stop exposing `wipe()` and `unload()`

Clients should instead call close() which will close the  database connection, it's then safe to delete the core crypto database.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
