### PR TITLE
feat: include the message of the source error when bundling errors together [WPB-14614]

### DIFF
--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -149,6 +149,9 @@ describe("transaction context", () => {
         }, ALICE_ID);
         expect(error).not.toBeNull();
         expect(error?.name).toEqual("MlsErrorOther");
+        expect(error?.message).toEqual(
+            "This context has already been finished and can no longer be used."
+        );
     });
 
     it("should roll back transaction after error", async () => {

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -110,14 +110,14 @@ pub enum MlsError {
     StaleProposal,
     #[error("The received commit is deemed stale and is from an older epoch.")]
     StaleCommit,
-    #[error("Another MLS error occurred but the details are probably irrelevant to clients")]
-    Other,
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<core_crypto::MlsError> for MlsError {
     #[inline]
-    fn from(_: core_crypto::MlsError) -> Self {
-        Self::Other
+    fn from(e: core_crypto::MlsError) -> Self {
+        Self::Other(e.to_string())
     }
 }
 
@@ -179,8 +179,8 @@ pub enum CoreCryptoError {
     #[cfg(feature = "proteus")]
     #[error(transparent)]
     Proteus(#[from] ProteusError),
-    #[error("End to end identity error")]
-    E2eiError,
+    #[error("End to end identity error: {0}")]
+    E2eiError(String),
     #[error("error from client: {0}")]
     ClientError(String),
 }
@@ -210,15 +210,15 @@ impl From<CryptoError> for CoreCryptoError {
             CryptoError::UnmergedPendingGroup => MlsError::UnmergedPendingGroup.into(),
             CryptoError::StaleProposal => MlsError::StaleProposal.into(),
             CryptoError::StaleCommit => MlsError::StaleCommit.into(),
-            CryptoError::E2eiError(_) => Self::E2eiError,
-            _ => MlsError::Other.into(),
+            CryptoError::E2eiError(e) => Self::E2eiError(e.to_string()),
+            _ => MlsError::Other(value.to_string()).into(),
         }
     }
 }
 
 impl From<E2eIdentityError> for CoreCryptoError {
-    fn from(_: E2eIdentityError) -> Self {
-        Self::E2eiError
+    fn from(e: E2eIdentityError) -> Self {
+        Self::E2eiError(e.to_string())
     }
 }
 

--- a/crypto-ffi/src/wasm/context/mod.rs
+++ b/crypto-ffi/src/wasm/context/mod.rs
@@ -418,7 +418,7 @@ impl CoreCryptoContext {
                     .iter()
                     .map(|kp| {
                         KeyPackageIn::tls_deserialize(&mut kp.to_vec().as_slice())
-                            .map_err(|e| CoreCryptoError::from(crate::MlsError::Other))
+                            .map_err(|e| CoreCryptoError::from(crate::MlsError::Other(e.to_string())))
                     })
                     .collect::<CoreCryptoResult<Vec<_>>>()?;
 


### PR DESCRIPTION
# What's new in this PR

We started to bundle together errors which clients can't act upon, but it's still useful to include source error message for debugging purposes.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
