### PR TITLE
chore: remove stale todo comment [WPB-9595]

### DIFF
--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -186,7 +186,6 @@ impl CentralContext {
         let is_rejoin = mls_provider.key_store().mls_group_exists(id.as_slice()).await;
 
         // Persist the now usable MLS group in the keystore
-        // TODO: find a way to make the insertion of the MlsGroup and deletion of the pending group transactional. Tracking issue: WPB-9595
         let mut conversation = MlsConversation::from_mls_group(mls_group, configuration, &mls_provider).await?;
 
         let pending_messages = self.restore_pending_messages(&mut conversation, is_rejoin).await?;


### PR DESCRIPTION
Mls group insertion and deletion of the pending group is transactional since 427e0e0b65dca3b2dce006e4e1aa4da1cf1f9c3c.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
