### PR TITLE
fix: wait for current transaction to finish when creating a new one

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1656,9 +1656,12 @@ export class CoreCrypto {
 
     /**
      * Initializes the proteus client
+     *
+     * @deprecated Create a transaction with {@link CoreCrypto.transaction}
+     * and use {@link CoreCryptoContext.proteusInit} instead.
      */
     async proteusInit(): Promise<void> {
-        return await CoreCryptoError.asyncMapErr(this.#cc.proteus_init());
+        return await this.transaction(async (ctx) => await ctx.proteusInit());
     }
 
     /**

--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -1040,30 +1040,32 @@ export class CoreCrypto {
         callback: (ctx: CoreCryptoContext) => Promise<R>
     ): Promise<R> {
         let result!: R;
-        let error: CoreCryptoError | null = null;
+        let error: CoreCryptoError | Error | null = null;
         try {
-            await this.#cc.transaction({
-                execute: async (ctx: CoreCryptoFfiTypes.CoreCryptoContext) => {
-                    try {
-                        result = await callback(
-                            CoreCryptoContext.fromFfiContext(ctx)
-                        );
-                    } catch (e) {
-                        // We want to catch the error before it gets wrapped by core crypto.
-                        if (e instanceof CoreCryptoError) {
-                            error = e as CoreCryptoError;
-                        } else {
-                            error = CoreCryptoError.fromStdError(
-                                e as Error
-                            ) as CoreCryptoError;
+            await CoreCryptoError.asyncMapErr(
+                this.#cc.transaction({
+                    execute: async (
+                        ctx: CoreCryptoFfiTypes.CoreCryptoContext
+                    ) => {
+                        try {
+                            result = await CoreCryptoError.asyncMapErr(
+                                callback(CoreCryptoContext.fromFfiContext(ctx))
+                            );
+                        } catch (e) {
+                            // We want to catch the error before it gets wrapped by core crypto.
+                            error = e as Error | CoreCryptoError;
+                            // This is to tell core crypto that there was an error inside the transaction.
+                            throw error;
                         }
-                        // This is to tell core crypto that there was an error inside the transaction.
-                        throw error;
-                    }
-                },
-            });
-            // Catch the wrapped error, which we don't need, because we caught the original error above.
-        } catch (_) {}
+                    },
+                })
+            );
+        } catch (e) {
+            // We prefer the closure error if it's available since the transaction will just wrap and re-throw it.
+            if (error === null) {
+                error = e as Error | CoreCryptoError;
+            }
+        }
         if (error !== null) {
             throw error;
         }

--- a/crypto-ffi/bindings/js/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/CoreCryptoContext.ts
@@ -859,6 +859,13 @@ export default class CoreCryptoContext {
     }
 
     /**
+     * Initializes the proteus client
+     */
+    async proteusInit(): Promise<void> {
+        return await CoreCryptoError.asyncMapErr(this.#ctx.proteus_init());
+    }
+
+    /**
      * Create a Proteus session using a prekey
      *
      * @param sessionId - ID of the Proteus session

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
@@ -109,8 +109,9 @@ class CoreCrypto(private val cc: com.wire.crypto.uniffi.CoreCrypto) {
      *
      * All proteus related methods will fail until this function is called.
      */
+    @Deprecated("Use the method inside a transaction on the CoreCryptoContext object.")
     suspend fun proteusInit() {
-        cc.proteusInit()
+        this.transaction { ctx -> ctx.proteusInit() }
     }
 
     suspend fun provideTransport(transport: MlsTransport) {

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
@@ -94,13 +94,15 @@ class CoreCrypto(private val cc: com.wire.crypto.uniffi.CoreCrypto) {
                     }
                 }
             })
-            // Catch the wrapped error, which we don't need, because we caught the original error above.
-        } catch (_: Throwable) { }
+        } catch (e: Throwable) {
+            // We prefer the closure error if it's available since the transaction won't include it
+            error = error?: e
+        }
         if (error != null) {
             throw error as Throwable
         }
 
-        // Since we know that transaction will either run or throw it's safe to do unchecked cast here
+        // Since we know that the transaction will either succeed or throw it's safe to do an unchecked cast here
         return result as R
     }
 

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
@@ -777,6 +777,15 @@ class CoreCryptoContext(private val cc: com.wire.crypto.uniffi.CoreCryptoContext
 
     // Proteus below
 
+    /**
+     * Initialise [CoreCrypto] to be used with proteus.
+     *
+     * All proteus related methods will fail until this function is called.
+     */
+    suspend fun proteusInit() {
+        cc.proteusInit()
+    }
+
     private fun toPreKey(id: UShort, data: ByteArray): PreKey = PreKey(id, data)
 
     suspend fun proteusGetLocalFingerprint(): ByteArray {

--- a/crypto-ffi/src/generic/context/proteus.rs
+++ b/crypto-ffi/src/generic/context/proteus.rs
@@ -5,6 +5,16 @@ use crate::{CoreCryptoError, ProteusAutoPrekeyBundle};
 
 #[uniffi::export]
 impl CoreCryptoContext {
+    /// See [core_crypto::proteus::ProteusCentral::try_new]
+    pub async fn proteus_init(&self) -> CoreCryptoResult<()> {
+        proteus_impl! { self.proteus_last_error_code => {
+            self.context
+                .proteus_init()
+                .await?;
+            Ok(())
+        }}
+    }
+
     /// See [core_crypto::context::CentralContext::proteus_session_from_prekey]
     pub async fn proteus_session_from_prekey(&self, session_id: String, prekey: Vec<u8>) -> CoreCryptoResult<()> {
         proteus_impl! { self.proteus_last_error_code => {

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -1582,13 +1582,13 @@ impl From<core_crypto::prelude::E2eiConversationState> for E2eiConversationState
 #[uniffi::export]
 impl CoreCrypto {
     /// See [core_crypto::proteus::ProteusCentral::try_new]
+    #[deprecated = "Please create a transaction in Core Crypto and call this method from it."]
     pub async fn proteus_init(&self) -> CoreCryptoResult<()> {
         proteus_impl! { self.proteus_last_error_code => {
-            self.central
-                .proteus_init()
-                .await?;
-
-            CoreCryptoResult::Ok(())
+            self.deprecated_transaction(|context| async move {
+                context.proteus_init().await?;
+            Ok(())
+            }).await
         }}
     }
 

--- a/crypto-ffi/src/wasm/context/proteus.rs
+++ b/crypto-ffi/src/wasm/context/proteus.rs
@@ -12,6 +12,25 @@ use wasm_bindgen_futures::future_to_promise;
 impl CoreCryptoContext {
     /// Returns: [`WasmCryptoResult<()>`]
     ///
+    /// see [core_crypto::proteus::ProteusCentral::try_new]
+    #[cfg_attr(not(feature = "proteus"), allow(unused_variables))]
+    pub fn proteus_init(&self) -> Promise {
+        let errcode_dest = self.proteus_last_error_code.clone();
+        let context = self.inner.clone();
+
+        future_to_promise(
+            async move {
+                proteus_impl! { errcode_dest => {
+                    context.proteus_init().await.map_err(CoreCryptoError::from)?;
+                    WasmCryptoResult::Ok(JsValue::UNDEFINED)
+                } or throw WasmCryptoResult<_> }
+            }
+            .err_into(),
+        )
+    }
+
+    /// Returns: [`WasmCryptoResult<()>`]
+    ///
     /// See [core_crypto::context::CentralContext::proteus_session_from_prekey]
     pub fn proteus_session_from_prekey(&self, session_id: String, prekey: Box<[u8]>) -> Promise {
         let errcode_dest = self.proteus_last_error_code.clone();

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1719,25 +1719,6 @@ impl CoreCrypto {
         )
     }
 
-    /// Returns: [`WasmCryptoResult<()>`]
-    ///
-    /// see [core_crypto::proteus::ProteusCentral::try_new]
-    #[cfg_attr(not(feature = "proteus"), allow(unused_variables))]
-    pub fn proteus_init(&self) -> Promise {
-        let errcode_dest = self.proteus_last_error_code.clone();
-        let central = self.inner.clone();
-
-        future_to_promise(
-            async move {
-                proteus_impl! { errcode_dest => {
-                    central.proteus_init().await.map_err(CoreCryptoError::from)?;
-                    WasmCryptoResult::Ok(JsValue::UNDEFINED)
-                } or throw WasmCryptoResult<_> }
-            }
-            .err_into(),
-        )
-    }
-
     /// Returns: [`WasmCryptoResult<bool>`]
     ///
     /// see [core_crypto::proteus::ProteusCentral::session_exists]

--- a/crypto/benches/utils/proteus_bench.rs
+++ b/crypto/benches/utils/proteus_bench.rs
@@ -8,7 +8,9 @@ use proteus_wasm::{
 
 pub async fn setup_proteus(in_memory: bool) -> CoreCrypto {
     let (core_crypto, _) = setup_mls(Default::default(), Default::default(), in_memory).await;
-    core_crypto.proteus_init().await.unwrap();
+    let transaction = core_crypto.new_transaction().await.unwrap();
+    transaction.proteus_init().await.unwrap();
+    transaction.finish().await.unwrap();
     core_crypto
 }
 

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -185,7 +185,12 @@ impl EmulatedMlsClient for CoreCryptoFfiClient {
 #[async_trait::async_trait(?Send)]
 impl crate::clients::EmulatedProteusClient for CoreCryptoFfiClient {
     async fn init(&mut self) -> Result<()> {
-        self.cc.proteus_init().await.map_err(Into::into)
+        self.cc
+            .transaction(TransactionHelper::new(move |context| async move {
+                context.proteus_init().await.map_err(Into::into)
+            }))
+            .await?;
+        Ok(())
     }
 
     async fn get_prekey(&self) -> Result<Vec<u8>> {

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -176,7 +176,9 @@ impl EmulatedMlsClient for CoreCryptoNativeClient {
 #[async_trait::async_trait(?Send)]
 impl crate::clients::EmulatedProteusClient for CoreCryptoNativeClient {
     async fn init(&mut self) -> Result<()> {
-        Ok(self.cc.proteus_init().await?)
+        let transaction = self.cc.new_transaction().await?;
+        transaction.proteus_init().await?;
+        Ok(transaction.finish().await?)
     }
 
     async fn get_prekey(&self) -> Result<Vec<u8>> {

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -318,7 +318,8 @@ async fn run_proteus_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<(
         Some(100),
     )?;
     let master_client = CoreCrypto::from(MlsCentral::try_new_in_memory(configuration).await?);
-    master_client.proteus_init().await?;
+    let transaction = master_client.new_transaction().await?;
+    transaction.proteus_init().await?;
 
     let master_fingerprint = master_client.proteus_fingerprint().await?;
 
@@ -345,7 +346,6 @@ async fn run_proteus_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<(
     let mut master_sessions = vec![];
     let mut messages = std::collections::HashMap::new();
     const PROTEUS_INITIAL_MESSAGE: &[u8] = b"Hello world!";
-    let transaction = master_client.new_transaction().await?;
     for (fingerprint, prekey) in prekeys {
         spinner.update(format!(
             "[Proteus] Step 2: Session master -> {fingerprint}@{}",


### PR DESCRIPTION
Previously, an error was thrown when a new transaction was started and there was one in progress. This was not the intended behavior.

# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
