### PR TITLE
fix: don't swallow transaction errors if they don't originate from the closure [WPB-14895]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
@@ -94,13 +94,15 @@ class CoreCrypto(private val cc: com.wire.crypto.uniffi.CoreCrypto) {
                     }
                 }
             })
-            // Catch the wrapped error, which we don't need, because we caught the original error above.
-        } catch (_: Throwable) { }
+        } catch (e: Throwable) {
+            // We prefer the closure error if it's available since the transaction won't include it
+            error = error?: e
+        }
         if (error != null) {
             throw error as Throwable
         }
 
-        // Since we know that transaction will either run or throw it's safe to do unchecked cast here
+        // Since we know that the transaction will either succeed or throw it's safe to do an unchecked cast here
         return result as R
     }
 


### PR DESCRIPTION
# What's new in this PR

We were assuming errors when executing a transaction can only come from the client provided closure. This is not true since errors can also come from core crypto, for example when we throw `TransactionInProgress` when there is an attempt to perform parallel transactions.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
