### PR TITLE
feat!(ffi/error): expose `OrphanWelcome` to clients [WPB-14954]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoException.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoException.kt
@@ -102,6 +102,11 @@ sealed class MlsException: Exception() {
             get() = ""
     }
 
+    class OrphanWelcome() : MlsException() {
+        override val message
+            get() = ""
+    }
+
     class Other(override val message: String) : MlsException()
 }
 
@@ -143,6 +148,7 @@ fun com.wire.crypto.uniffi.MlsException.lift() =
         is com.wire.crypto.uniffi.MlsException.StaleProposal -> MlsException.StaleProposal()
         is com.wire.crypto.uniffi.MlsException.UnmergedPendingGroup -> MlsException.UnmergedPendingGroup()
         is com.wire.crypto.uniffi.MlsException.WrongEpoch -> MlsException.WrongEpoch()
+        is com.wire.crypto.uniffi.MlsException.OrphanWelcome -> MlsException.OrphanWelcome()
         is com.wire.crypto.uniffi.MlsException.Other -> MlsException.Other(this.v1)
     }
 

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -110,6 +110,12 @@ pub enum MlsError {
     StaleProposal,
     #[error("The received commit is deemed stale and is from an older epoch.")]
     StaleCommit,
+    /// This happens when the DS cannot flag KeyPackages as claimed or not. It this scenario, a client
+    /// requests their old KeyPackages to be deleted but one has already been claimed by another client to create a Welcome.
+    /// In that case the only solution is that the client receiving such a Welcome tries to join the group
+    /// with an External Commit instead
+    #[error("Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit")]
+    OrphanWelcome,
     #[error("{0}")]
     Other(String),
 }
@@ -210,6 +216,7 @@ impl From<CryptoError> for CoreCryptoError {
             CryptoError::UnmergedPendingGroup => MlsError::UnmergedPendingGroup.into(),
             CryptoError::StaleProposal => MlsError::StaleProposal.into(),
             CryptoError::StaleCommit => MlsError::StaleCommit.into(),
+            CryptoError::OrphanWelcome => MlsError::OrphanWelcome.into(),
             CryptoError::E2eiError(e) => Self::E2eiError(e.to_string()),
             _ => MlsError::Other(value.to_string()).into(),
         }

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -101,6 +101,12 @@ pub enum MlsError {
     StaleProposal,
     #[error("The received commit is deemed stale and is from an older epoch.")]
     StaleCommit,
+    /// This happens when the DS cannot flag KeyPackages as claimed or not. It this scenario, a client
+    /// requests their old KeyPackages to be deleted but one has already been claimed by another client to create a Welcome.
+    /// In that case the only solution is that the client receiving such a Welcome tries to join the group
+    /// with an External Commit instead
+    #[error("Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit")]
+    OrphanWelcome,
     #[error("{0}")]
     Other(String),
 }
@@ -219,6 +225,7 @@ impl From<CryptoError> for InternalError {
             CryptoError::UnmergedPendingGroup => MlsError::UnmergedPendingGroup.into(),
             CryptoError::StaleProposal => MlsError::StaleProposal.into(),
             CryptoError::StaleCommit => MlsError::StaleCommit.into(),
+            CryptoError::OrphanWelcome => MlsError::OrphanWelcome.into(),
             CryptoError::E2eiError(e) => Self::E2eiError(e.to_string()),
             _ => MlsError::Other(value.to_string()).into(),
         }


### PR DESCRIPTION
Turns out that clients _do_ care about this error variant, so let's give it back to them.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
