### PR TITLE
build: use reusable workflows in ci [WPB-14852]

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,4 +1,4 @@
-name: Continuous Benchmarks with Bencher
+name: continuous benchmarks with bencher
 on:
   push:
     branches:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmarks_with_bencher:
-    name: Rust Benchmarks with Bencher
+    name: rust benchmarks with bencher
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
       - uses: actions/checkout@v4
-      - name: Run bencher CLI
+      - name: run bencher cli
         uses: ./.github/actions/run-bencher
         with:
           bencher-api-token: ${{ secrets.BENCHER_API_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
           bench-command: cargo bench --bench ${{ matrix.rust_bench }} -- --quick
 
   web_benchmarks_with_bencher:
-    name: Web Benchmarks with Bencher
+    name: web benchmarks with bencher
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -37,16 +37,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - name: Install wasm-pack
+      - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
       - uses: davidB/rust-cargo-make@v1
-      - name: build WASM
+      - name: build wasm
         run: |
           cd crypto-ffi
           cargo make wasm
-      - name: Bench WASM/JS
+      - name: bench wasm/js
         run: |
           cd crypto-ffi/bindings/js
           bun install
@@ -56,7 +56,7 @@ jobs:
         with:
           # Keep result file
           clean: 'false'
-      - name: Run bencher CLI
+      - name: run bencher cli
         uses: ./.github/actions/run-bencher
         with:
           bencher-api-token: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,22 +33,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-      - name: Setup bun (web)
-        uses: oven-sh/setup-bun@v2
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - name: Install wasm-pack (web)
+      - name: Install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-      - name: Setup cargo-make (web)
-        uses: davidB/rust-cargo-make@v1
-      - name: Build & test WASM / JS package (web)
+      - uses: davidB/rust-cargo-make@v1
+      - name: build WASM
         run: |
           cd crypto-ffi
           cargo make wasm
-          cd bindings/js
+      - name: Bench WASM/JS
+        run: |
+          cd crypto-ffi/bindings/js
           bun install
           bun run build
           bun run bench

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -1,4 +1,4 @@
-name: Build bindings
+name: build bindings
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -28,14 +28,14 @@ jobs:
     needs: build-android
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: set up jdk 17
         uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "adopt"
-      - name: Gradle Setup
+      - name: gradle setup
         uses: gradle/actions/setup-gradle@v4
-      - name: Validate Gradle wrapper
+      - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
       - uses: actions/download-artifact@v4
         with:
@@ -45,12 +45,12 @@ jobs:
         with:
           name: android-${{ github.run_id }}
           path: crypto-ffi/bindings
-      - name: Enable KVM group perms
+      - name: enable kvm group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Android Instrumentation Tests
+      - name: android instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 32
@@ -64,14 +64,14 @@ jobs:
     needs: build-jvm-linux
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: set up jdk 17
         uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "adopt"
-      - name: Gradle Setup
+      - name: gradle setup
         uses: gradle/actions/setup-gradle@v4
-      - name: Validate Gradle wrapper
+      - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
       - name: download linux library
         uses: actions/download-artifact@v4
@@ -83,7 +83,7 @@ jobs:
         with:
           name: jvm-linux-bindings-${{ github.run_id }}
           path: crypto-ffi/bindings
-      - name: Build and test JVM package
+      - name: build and test jvm package
         run: |
           cd crypto-ffi/bindings
           ./gradlew jvm:build -x lint -x lintRelease
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine Rust target
+      - name: determine rust target
         id: rust-target
         run: |
           if [[ "${{ matrix.task }}" == "ios-device" ]]; then
@@ -114,15 +114,15 @@ jobs:
         with:
           target: ${{ env.target }}
 
-      - name: Setup cargo-make
+      - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
 
-      - name: Build ${{ matrix.task }}
+      - name: build ${{ matrix.task }}
         run: |
           cd crypto-ffi
           cargo make ${{ matrix.task }}
 
-      - name: Upload artifact
+      - name: upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{github.event.number}}-${{ matrix.task }}
@@ -130,7 +130,7 @@ jobs:
           retention-days: 1
           overwrite: 'true'
       # Only needs to be uploaded once, this step finishes fastest.
-      - name: Upload FFI artifact
+      - name: upload ffi artifact
         if: startsWith(matrix.task, 'ios-simulator-arm')
         uses: actions/upload-artifact@v4
         with:
@@ -144,18 +144,18 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Download artifacts for ios
+      - name: download artifacts for ios
         uses: actions/download-artifact@v4
         with:
           path: target
           pattern: ${{github.event.number}}-ios-*
           merge-multiple: 'true'
-      - name: Download FFI artifacts
+      - name: download ffi artifacts
         uses: actions/download-artifact@v4
         with:
           name: ${{github.event.number}}-swift-ffi
           path: crypto-ffi/bindings/swift/WireCoreCrypto
-      - name: Create xcframework
+      - name: create xcframework
         run: |
           cd crypto-ffi/bindings/swift
           ./build-xcframework.sh
@@ -181,12 +181,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Install wasm-pack
+      - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
       - uses: davidB/rust-cargo-make@v1
-      - name: build WASM
+      - name: build wasm
         run: |
           cd crypto-ffi
           cargo make wasm
@@ -195,15 +195,15 @@ jobs:
           cd crypto-ffi/bindings/js
           bun install
           bun run build
-      - name: Lint
+      - name: lint
         run: |
           cd crypto-ffi/bindings/js
           bun eslint . --max-warnings=0
-      - name: check all TS files
+      - name: check all ts files
         run: |
           cd crypto-ffi/bindings/js
           bun tsc --noEmit
-      - name: Test
+      - name: test
         run: |
           cd crypto-ffi/bindings/js
           bun run test

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -175,9 +175,8 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: stable
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          rustflags: ''
           target: wasm32-unknown-unknown
       - uses: oven-sh/setup-bun@v2
         with:
@@ -185,21 +184,29 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-      - name: Build & test WASM / JS package
+      - uses: davidB/rust-cargo-make@v1
+      - name: build WASM
         run: |
           cd crypto-ffi
           cargo make wasm
-          cd bindings/js
-          bun eslint . --max-warnings=0
-
-          # check all Typescript files (wdio.conf.ts, benches)
-          bunx tsc --noEmit
-
+      - name: build ts
+        run: |
+          cd crypto-ffi/bindings/js
+          bun install
           bun run build
+      - name: Lint
+        run: |
+          cd crypto-ffi/bindings/js
+          bun eslint . --max-warnings=0
+      - name: check all TS files
+        run: |
+          cd crypto-ffi/bindings/js
+          bun tsc --noEmit
+      - name: Test
+        run: |
+          cd crypto-ffi/bindings/js
           bun run test

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -16,9 +16,13 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
-  build-and-test-android:
+  build-android:
+    uses: ./.github/workflows/build-android.yml
+
+  test-android:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
+    needs: build-android
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -30,27 +34,14 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      - name: "Setup rust"
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: actions/download-artifact@v4
         with:
-          rustflags: ''
-          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - name: Install NDK 25
-        run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
-      - name: Build Android package
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/25.2.9519653
-        run: |
-          cd crypto-ffi
-          cargo make android
-      - name: Build package
-        run: |
-          cd crypto-ffi/bindings
-          ./gradlew android:build -x lint -x lintRelease
+          name: android-target-${{ github.run_id }}
+          path: target
+      - uses: actions/download-artifact@v4
+        with:
+          name: android-${{ github.run_id }}
+          path: crypto-ffi/bindings
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -19,6 +19,9 @@ jobs:
   build-android:
     uses: ./.github/workflows/build-android.yml
 
+  build-jvm-linux:
+    uses: ./.github/workflows/build-jvm-linux.yml
+
   test-android:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
@@ -58,6 +61,7 @@ jobs:
   build-and-test-jvm:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
+    needs: build-jvm-linux
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -69,14 +73,16 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      - name: "Setup rust"
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
-      - name: Build JVM rust binaries
-        run: |
-          cd crypto-ffi
-          cargo make jvm-linux
+      - name: download linux library
+        uses: actions/download-artifact@v4
+        with:
+          name: jvm-linux-so-file-${{ github.run_id }}
+          path: target/x86_64-unknown-linux-gnu/release
+      - name: download linux bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: jvm-linux-bindings-${{ github.run_id }}
+          path: crypto-ffi/bindings
       - name: Build and test JVM package
         run: |
           cd crypto-ffi/bindings

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -16,33 +16,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: set up jdk 17
         uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "adopt"
-      - name: Gradle Setup
+      - name: gradle setup
         uses: gradle/actions/setup-gradle@v4
-      - name: Validate Gradle wrapper
+      - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      - name: "Setup rust"
+      - name: "setup rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
           target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
-      - name: Setup cargo-make
+      - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
-      - name: Setup Android SDK
+      - name: setup android sdk
         uses: android-actions/setup-android@v3
-      - name: Install NDK 25
+      - name: install ndk 25
         run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
-      - name: Build Android package
+      - name: build android package
         env:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/25.2.9519653
         run: |
           cd crypto-ffi
           cargo make android
-      - name: Build package
+      - name: build package
         run: |
           cd crypto-ffi/bindings
           ./gradlew android:build -x lint -x lintRelease

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,58 @@
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}-build-android"
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  build-android:
+    if: github.repository == 'wireapp/core-crypto'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "adopt"
+      - name: Gradle Setup
+        uses: gradle/actions/setup-gradle@v4
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+      - name: "Setup rust"
+        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+        with:
+          rustflags: ''
+          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
+      - name: Setup cargo-make
+        uses: davidB/rust-cargo-make@v1
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Install NDK 25
+        run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
+      - name: Build Android package
+        env:
+          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/25.2.9519653
+        run: |
+          cd crypto-ffi
+          cargo make android
+      - name: Build package
+        run: |
+          cd crypto-ffi/bindings
+          ./gradlew android:build -x lint -x lintRelease
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-target-${{ github.run_id }}
+          path: target/*android*
+          retention-days: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-${{ github.run_id }}
+          path: crypto-ffi/bindings
+          retention-days: 1

--- a/.github/workflows/build-jvm-linux.yml
+++ b/.github/workflows/build-jvm-linux.yml
@@ -1,0 +1,38 @@
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}-build-jvm-linux"
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  build-jvm:
+    if: github.repository == 'wireapp/core-crypto'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: "x86_64-unknown-linux-gnu"
+      - uses: davidB/rust-cargo-make@v1
+      - name: build jvm-linux
+        run: |
+          cd crypto-ffi
+          cargo make jvm-linux
+      - name: upload static rust library
+        uses: actions/upload-artifact@v4
+        with:
+            name: jvm-linux-so-file-${{ github.run_id }}
+            path: target/x86_64-unknown-linux-gnu/release/*.so
+            retention-days: 1
+      - name: upload bindings
+        uses: actions/upload-artifact@v4
+        with:
+          name: jvm-linux-bindings-${{ github.run_id }}
+          path: crypto-ffi/bindings
+          retention-days: 1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Test coverage
+name: test coverage
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -20,17 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust toolchain
+      - name: install rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-      - name: Install cargo-llvm-cov
+      - name: install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Install cargo-nextest
+      - name: install cargo-nextest
         uses: taiki-e/install-action@nextest
-      - name: Generate code coverage
+      - name: generate code coverage
         run: cargo llvm-cov nextest --workspace --lcov --exclude interop --output-path lcov.info
-      - name: Upload to codecov.io
+      - name: upload to codecov.io
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,4 +1,4 @@
-name: Check License, sources
+name: check license, sources
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -24,9 +24,9 @@ jobs:
         with:
           rustflags: ''
       - uses: taiki-e/install-action@cargo-deny
-      - name: "Check Licenses / Supply Chain"
+      - name: "check licenses / supply chain"
         run: |
           cargo deny --all-features check >> $GITHUB_STEP_SUMMARY
-      - name: "Build a dependency licenses inventory and post it to Summary"
+      - name: "build a dependency licenses inventory and post it to summary"
         run: |
           cargo deny --all-features list --layout crate --format json | jq -r 'to_entries[] | "* \(.key)", "    * \(.value.licenses[])"' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: documentation
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -16,7 +16,7 @@ env:
 
 jobs:
   rustdoc:
-    name: Rust
+    name: rust
     runs-on: ubuntu-latest
 
     steps:
@@ -36,11 +36,11 @@ jobs:
 
 
   tsdoc:
-    name: Typescript
+    name: typescript
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
+    - name: checkout repository
       uses: actions/checkout@v4
 
     - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
@@ -50,20 +50,20 @@ jobs:
           wasm32-unknown-unknown
           x86_64-unknown-linux-gnu
 
-    - name: Setup cargo-make
+    - name: setup cargo-make
       uses: davidB/rust-cargo-make@v1
 
-    - name: Install wasm-pack
+    - name: install wasm-pack
       uses: taiki-e/install-action@v2
       with:
         tool: wasm-pack
 
-    - name: Setup bun
+    - name: setup bun
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
 
-    - name: Make TS Docs
+    - name: make ts docs
       run: |
         cd crypto-ffi
         cargo make docs-ts
@@ -78,21 +78,21 @@ jobs:
 
 
   ktdoc:
-    name: Kotlin
+    name: kotlin
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
+    - name: checkout repository
       uses: actions/checkout@v4
 
     - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
       with:
         rustflags: '' # note that this is _not_ the default
 
-    - name: Setup cargo-make
+    - name: setup cargo-make
       uses: davidB/rust-cargo-make@v1
 
-    - name: Make Kotlin Docs
+    - name: make kotlin docs
       run: |
         mkdir -p target/doc/core_crypto_ffi/bindings/kotlin
         cd crypto-ffi
@@ -108,7 +108,7 @@ jobs:
 
 
   deploy:
-    name: Deploy
+    name: deploy
     runs-on: ubuntu-latest
     if: github.repository == 'wireapp/core-crypto' && github.ref_name == 'main'
     needs:
@@ -123,7 +123,7 @@ jobs:
         path: target/doc
         merge-multiple: true
 
-    - name: Deploy Docs
+    - name: deploy docs
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,10 @@
-name: Publish docs
+name: Documentation
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
 
 on:
   push:
-    branches:
-    - main
 
 env:
   CARGO_INCREMENTAL: 0
@@ -17,8 +15,32 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
-  docgen:
-    if: github.repository == 'wireapp/core-crypto'
+  rustdoc:
+    name: Rust
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      with:
+        rustflags: ''
+
+    - name: Build Rust documentation
+      run: cargo doc --all --no-deps
+
+    - uses: actions/upload-artifact@v4.5.0
+      with:
+        name: rustdoc
+        path: target/doc
+        retention-days: 1
+        overwrite: true
+        include-hidden-files: true
+
+
+  tsdoc:
+    name: Typescript
     runs-on: ubuntu-latest
 
     steps:
@@ -40,19 +62,70 @@ jobs:
       with:
         tool: wasm-pack
 
-    - name: Build Rust documentation
-      run: cargo doc --all --no-deps
-
     - name: Setup bun
       uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
 
-    - name: Build TypeScript and Kotlin docs
+    - name: Make TS Docs
       run: |
         cd crypto-ffi
         cargo make docs-ts
+
+    - uses: actions/upload-artifact@v4.5.0
+      with:
+        name: tsdoc
+        path: target/doc
+        retention-days: 1
+        overwrite: true
+        include-hidden-files: true
+
+
+  ktdoc:
+    name: Kotlin
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      with:
+        rustflags: '' # note that this is _not_ the default
+
+    - name: Setup cargo-make
+      uses: davidB/rust-cargo-make@v1
+
+    - name: Make Kotlin Docs
+      run: |
+        mkdir -p target/doc/core_crypto_ffi/bindings/kotlin
+        cd crypto-ffi
         cargo make docs-kotlin
+
+    - uses: actions/upload-artifact@v4.5.0
+      with:
+        name: ktdoc
+        path: target/doc
+        retention-days: 1
+        overwrite: true
+        include-hidden-files: true
+
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: github.repository == 'wireapp/core-crypto' && github.ref_name == 'main'
+    needs:
+      - rustdoc
+      - tsdoc
+      - ktdoc
+
+    steps:
+    - uses: actions/download-artifact@v4.1.8
+      with:
+        pattern: "*doc"
+        path: target/doc
+        merge-multiple: true
 
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,15 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
+    - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
       with:
-        rustflags: ''
-
-    - name: Build Rust documentation
-      run: cargo doc --all --no-deps
+        rustflags: '-D warnings -W unreachable-pub'
+    - run: cargo doc --all --no-deps
 
     - uses: actions/upload-artifact@v4.5.0
       with:

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,4 +1,4 @@
-name: Publish Android packages
+name: publish android packages
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -26,18 +26,18 @@ jobs:
     needs: build-android
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: set up jdk 17
         uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "adopt"
-      - name: Gradle Setup
+      - name: gradle setup
         uses: gradle/actions/setup-gradle@v4
-      - name: Validate Gradle wrapper
+      - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      - name: Setup Android SDK
+      - name: setup android sdk
         uses: android-actions/setup-android@v3
-      - name: Install NDK 25
+      - name: install ndk 25
         run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
       - uses: actions/download-artifact@v4
         with:
@@ -47,7 +47,7 @@ jobs:
         with:
           name: android-${{ github.run_id }}
           path: crypto-ffi/bindings
-      - name: Publish package
+      - name: publish package
         run: |
           cd crypto-ffi/bindings
           ./gradlew uniffi-android:publishAllPublicationsToMavenCentral --no-configuration-cache

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -17,9 +17,13 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
+  build-android:
+    uses: ./.github/workflows/build-android.yml
+
   publish-android:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
+    needs: build-android
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -31,23 +35,18 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      - name: "Setup rust"
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          rustflags: ''
-          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
       - name: Install NDK 25
         run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
-      - name: Build Android package
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/25.2.9519653
-        run: |
-          cd crypto-ffi
-          cargo make android
+      - uses: actions/download-artifact@v4
+        with:
+          name: android-target-${{ github.run_id }}
+          path: target
+      - uses: actions/download-artifact@v4
+        with:
+          name: android-${{ github.run_id }}
+          path: crypto-ffi/bindings
       - name: Publish package
         run: |
           cd crypto-ffi/bindings

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -17,28 +17,8 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
-  build-linux-artifacts:
-    if: github.repository == 'wireapp/core-crypto'
-    name: Build Linux Artifacts
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Setup rust"
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          rustflags: ''
-          targets: "x86_64-unknown-linux-gnu"
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
-      - name: Build Artifacts
-        run: |
-          cd crypto-ffi
-          cargo make jvm-linux
-      - name: Upload x86_64-unknown-linux-gnu artifacts
-        uses: actions/upload-artifact@v4
-        with:
-            name: x86_64-unknown-linux-gnu
-            path: target/x86_64-unknown-linux-gnu/release/*.so
+  build-linux:
+    uses: ./.github/workflows/build-jvm-linux.yml
 
   build-darwin-artifacts:
     if: github.repository == 'wireapp/core-crypto'
@@ -71,7 +51,7 @@ jobs:
   publish-jvm:
     if: github.repository == 'wireapp/core-crypto'
     name: Publish JVM Package
-    needs: [build-linux-artifacts, build-darwin-artifacts]
+    needs: [build-linux, build-darwin-artifacts]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -96,7 +76,7 @@ jobs:
       - name: Download x86_64 Linux Artifact
         uses: actions/download-artifact@v4
         with:
-          name: x86_64-unknown-linux-gnu
+          name: jvm-linux-so-file-${{ github.run_id }}
           path: target/x86_64-unknown-linux-gnu/release
       - name: Download x86_64 Apple Darwin Artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -1,4 +1,4 @@
-name: Publish JVM packages
+name: publish jvm packages
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -22,27 +22,27 @@ jobs:
 
   build-darwin-artifacts:
     if: github.repository == 'wireapp/core-crypto'
-    name: Build Darwin Artifacts
+    name: build darwin artifacts
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup rust
+      - name: setup rust
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
           target: "x86_64-apple-darwin,aarch64-apple-darwin"
-      - name: Setup cargo-make
+      - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
-      - name: Build Artifacts
+      - name: build artifacts
         run: |
           cd crypto-ffi
           cargo make jvm-darwin
-      - name: Upload x86_64-apple-darwin artifacts
+      - name: upload x86_64-apple-darwin artifacts
         uses: actions/upload-artifact@v4
         with:
             name: x86_64-apple-darwin
             path: target/x86_64-apple-darwin/release/*.dylib
-      - name: Upload aarch64-apple-darwin artifacts
+      - name: upload aarch64-apple-darwin artifacts
         uses: actions/upload-artifact@v4
         with:
             name: aarch64-apple-darwin
@@ -50,12 +50,12 @@ jobs:
 
   publish-jvm:
     if: github.repository == 'wireapp/core-crypto'
-    name: Publish JVM Package
+    name: publish jvm package
     needs: [build-linux, build-darwin-artifacts]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: set up jdk 17
         uses: actions/setup-java@v4
         with:
           java-version: "17"
@@ -63,32 +63,32 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-      - name: Setup cargo-make
+      - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
-      - name: Build Artifacts
+      - name: build artifacts
         run: |
           cd crypto-ffi
           cargo make ffi-kotlin-jvm
-      - name: Gradle Setup
+      - name: gradle setup
         uses: gradle/actions/setup-gradle@v4
-      - name: Validate Gradle wrapper
+      - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
-      - name: Download x86_64 Linux Artifact
+      - name: download x86_64 linux artifact
         uses: actions/download-artifact@v4
         with:
           name: jvm-linux-so-file-${{ github.run_id }}
           path: target/x86_64-unknown-linux-gnu/release
-      - name: Download x86_64 Apple Darwin Artifact
+      - name: download x86_64 apple darwin artifact
         uses: actions/download-artifact@v4
         with:
           name: x86_64-apple-darwin
           path: target/x86_64-apple-darwin/release
-      - name: Download Aarch64 Apple Darwin Artifact
+      - name: download aarch64 apple darwin artifact
         uses: actions/download-artifact@v4
         with:
           name: aarch64-apple-darwin
           path: target/aarch64-apple-darwin/release
-      - name: Publish package
+      - name: publish package
         run: |
           cd crypto-ffi/bindings
           ./gradlew :uniffi-jvm:publishAllPublicationsToMavenCentral --no-configuration-cache

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -1,4 +1,4 @@
-name: Publish Swift package
+name: publish swift package
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -25,18 +25,18 @@ jobs:
         with:
           xcode-version: '14.3.1'
       - uses: actions/checkout@v4
-      - name: "Setup rust"
+      - name: "setup rust"
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
           target: "aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim"
-      - name: Setup cargo-make
+      - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
-      - name: Build xcframework
+      - name: build xcframework
         run: |
           cd crypto-ffi
           cargo make ios-create-xcframework
-      - name: Upload xcframework
+      - name: upload xcframework
         uses: softprops/action-gh-release@v2
         with:
             files: crypto-ffi/bindings/swift/WireCoreCrypto.xcframework.zip

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -1,4 +1,4 @@
-name: Publish Node packages
+name: publish node packages
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -28,18 +28,18 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - name: Install wasm-pack
+      - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
       - uses: davidB/rust-cargo-make@v1
-      - name: build WASM
+      - name: build wasm
         run: |
           cd crypto-ffi
           cargo make wasm
           cd bindings/js
           bun run build
-      - name: Publishes package to NPM
+      - name: publishes package to npm
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -22,36 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          node-version: 18
-
+          target: wasm32-unknown-unknown
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          rustflags: ''
-          target: wasm32-unknown-unknown
-
-
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
-
       - name: Install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-
-      - name: Build WASM package
+      - uses: davidB/rust-cargo-make@v1
+      - name: build WASM
         run: |
           cd crypto-ffi
           cargo make wasm
           cd bindings/js
           bun run build
-
       - name: Publishes package to NPM
         uses: JS-DevTools/npm-publish@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust compile & test
+name: Rust
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -30,6 +30,21 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - name: fmt
+            trailer: --all -- --check
+          - name: clippy
+            trailer: -- -D warnings
+          - name: check
+            trailer: --tests
+        target: ["", "--target wasm32-unknown-unknown"]
+        exclude:
+          - {tool: {name: fmt},
+             target: "--target wasm32-unknown-unknown"}
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
@@ -37,11 +52,7 @@ jobs:
           components: rustfmt, clippy
           rustflags: ''
           target: wasm32-unknown-unknown
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy -- -D warnings
-      - run: cargo clippy --target wasm32-unknown-unknown -- -D warnings
-      - run: cargo check --tests
-      - run: cargo check --tests --target wasm32-unknown-unknown
+      - run: cargo ${{ matrix.tool.name }} ${{ matrix.target }} ${{ matrix.tool.trailer }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,15 +19,6 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
-  doc:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          rustflags: '-D warnings -W unreachable-pub'
-      - run: cargo doc --all --no-deps
-
   check:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,9 +163,8 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           rustflags: ''
-      - name: Setup cargo-make
-        uses: davidB/rust-cargo-make@v1
-      - name: Install wasm-pack
+      - uses: davidB/rust-cargo-make@v1
+      - name: setup wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
@@ -173,14 +172,14 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: stable
+      - run: |
+          echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: |
-          echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - name: Build Wasm artifacts
         run: |
           cd crypto-ffi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: rust
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -53,11 +53,11 @@ jobs:
         with:
           rustflags: ''
       - uses: taiki-e/install-action@nextest
-      - name: "Test CoreCrypto"
+      - name: "test corecrypto"
         run: cargo nextest run --verbose
-      - name: "Test CoreCrypto documentation"
+      - name: "test corecrypto documentation"
         run: cargo test --doc
-      - name: "Upload test results"
+      - name: "upload test results"
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
@@ -70,7 +70,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-      - name: "Test Keystore regressions"
+      - name: "test keystore regressions"
         run: |
           cd extras/keystore-regression-versions
           cargo run
@@ -83,7 +83,7 @@ jobs:
         with:
           rustflags: ''
       - uses: taiki-e/install-action@nextest
-      - name: "Test CoreCrypto's proteus implementation"
+      - name: "test corecrypto's proteus implementation"
         run: cargo nextest run --verbose --features proteus,cryptobox-migrate,proteus-keystore proteus
 
   wasm-test:
@@ -103,11 +103,11 @@ jobs:
           chrome-version: stable
       - run: |
           echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-      - name: Install wasm-pack
+      - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-      - name: Run tests (wasm)
+      - name: run tests (wasm)
         run: wasm-pack test --headless --chrome ./${{ matrix.crate_paths }}
 
   # TODO: pending a proper solution to fix the size limit for WASM tests. Tracking issue: WPB-9581
@@ -125,11 +125,11 @@ jobs:
           chrome-version: stable
       - run: |
           echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-      - name: Install wasm-pack
+      - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-      - name: Run core tests (wasm)
+      - name: run core tests (wasm)
         run: sh crypto-ffi/bindings/js/test/wasm-tests.sh
 
   proteus-wasm-test:
@@ -146,11 +146,11 @@ jobs:
           chrome-version: stable
       - run: |
           echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-      - name: Install wasm-pack
+      - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-      - name: Run tests (wasm)
+      - name: run tests (wasm)
         run: |
           wasm-pack test --headless --chrome ./keystore -F "proteus-keystore" -- proteus
           wasm-pack test --headless --chrome ./crypto -F "proteus,cryptobox-migrate" -- proteus
@@ -180,11 +180,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Build Wasm artifacts
+      - name: build wasm artifacts
         run: |
           cd crypto-ffi
           cargo make wasm
-      - name: Run E2E interop test
+      - name: run e2e interop test
         run: cargo run --bin interop
 
   hack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,15 +43,6 @@ jobs:
       - run: cargo check --tests
       - run: cargo check --tests --target wasm32-unknown-unknown
 
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          rustflags: ''
-      - run: cargo build --verbose
-
   test:
     runs-on: ubuntu-latest
     steps:
@@ -92,25 +83,6 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: "Test CoreCrypto's proteus implementation"
         run: cargo nextest run --verbose --features proteus,cryptobox-migrate,proteus-keystore proteus
-
-  wasm-build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        workspace: [ "crypto", "keystore", "mls-provider" ]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          target: wasm32-unknown-unknown
-          rustflags: ''
-      - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack
-      - name: WASM build
-        run: wasm-pack build --dev --target web ${{ matrix.workspace }}
-
 
   wasm-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What's new in this PR

- [x] ensure docs get built in all cases, but only deployed when `main` does
- [x] identify all cases where multiple workflows do the same things and isolate those in workflows
- [x] use parallel jobs wherever possible

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
