### PR TITLE
chore: remove debug_assert! calls from mem keystore [WPB-14558]

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -100,7 +100,6 @@ args = [
 
 [tasks.wasm-build]
 command = "wasm-pack"
-# env = { "WASM_BINDGEN_WEAKREF" = 1, "WASM_BINDGEN_EXTERNREF" = 1 }
 args = [
     "build",
     "--locked",

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -112,10 +112,6 @@ args = [
     "${@}"
 ]
 
-# Quiets warning related to wasm-opt. Used to generate bindings and check Typescript wrapper
-[tasks.wasm-build-dev]
-script = "cargo make wasm-build --dev"
-
 [tasks.wasm]
 dependencies = ["wasm-build", "bun-deps"]
 command = "bun"

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -2,19 +2,6 @@
 ANDROID_NDK_PREFER_VERSION = "25.2"
 LIBRARY_EXTENSION = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "so", mapping = { "linux" = "so", "macos" = "dylib", "windows" = "dll" } }
 
-[tasks.clean]
-command = "cargo"
-args = ["clean"]
-
-[tasks.test]
-command = "cargo"
-args = ["test"]
-dependencies = ["clean"]
-
-[tasks.check]
-command = "cargo"
-args = ["check"]
-
 [tasks.release-build]
 command = "cargo"
 args = ["build", "--release", "--locked"]

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -1,6 +1,6 @@
 [env]
 ANDROID_NDK_PREFER_VERSION = "25.2"
-LIBRARY_EXTENSION = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "so", mapping = { "linux" = "so", "macos" = "dylib", "windows" = "dll", "openbsd" = "so" } }
+LIBRARY_EXTENSION = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "so", mapping = { "linux" = "so", "macos" = "dylib", "windows" = "dll" } }
 
 [tasks.clean]
 command = "cargo"

--- a/crypto-ffi/bindings/js/test/tsc-import-test.ts
+++ b/crypto-ffi/bindings/js/test/tsc-import-test.ts
@@ -1,1 +1,0 @@
-export { CoreCrypto } from "../../../../platforms/web/corecrypto.js";

--- a/crypto-ffi/bindings/js/wdio.conf.ts
+++ b/crypto-ffi/bindings/js/wdio.conf.ts
@@ -89,7 +89,7 @@ export const config: WebdriverIO.Config = {
     //
     // Level of logging verbosity: trace | debug | info | warn | error | silent
     // logLevel: "warn",
-    logLevel: "info",
+    logLevel: "warn",
     //
     // Set specific log levels per logger
     // loggers:

--- a/keystore/src/connection/platform/wasm/migrations/keystore_v_1_0_0/connection/platform/wasm/storage.rs
+++ b/keystore/src/connection/platform/wasm/migrations/keystore_v_1_0_0/connection/platform/wasm/storage.rs
@@ -253,8 +253,7 @@ impl WasmEncryptedStorage {
             WasmStorageWrapper::InMemory(map) => {
                 map.entry(collection.into()).and_modify(|store| {
                     for k in ids {
-                        let result = store.remove(k.as_ref());
-                        debug_assert!(result.is_some());
+                        store.remove(k.as_ref());
                     }
                 });
             }

--- a/keystore/src/connection/platform/wasm/storage.rs
+++ b/keystore/src/connection/platform/wasm/storage.rs
@@ -72,8 +72,7 @@ impl<'a> WasmStorageTransaction<'a> {
             }
             WasmStorageTransaction::InMemory { db, cipher: _cipher } => {
                 db.borrow_mut().entry(collection_name.into()).and_modify(|store| {
-                    let result = store.remove(id.as_ref());
-                    debug_assert!(result.is_some());
+                    store.remove(id.as_ref());
                 });
             }
         }
@@ -404,8 +403,7 @@ impl WasmEncryptedStorage {
                 let mut map = map.borrow_mut();
                 map.entry(collection.into()).and_modify(|store| {
                     for k in ids {
-                        let result = store.remove(k.as_ref());
-                        debug_assert!(result.is_some());
+                        store.remove(k.as_ref());
                     }
                 });
             }


### PR DESCRIPTION
An assortment of minor cleanups and a fix that removes `debug_assert!` calls from the memory keystore, which were breaking web tests and were there without a good reason.