### PR TITLE
chore: fix clippy warnings about needless lifetimes so CI can build cleanly again

### DIFF
--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -70,3 +70,6 @@ wasm-opt = false
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -46,7 +46,7 @@ impl MlsConversation {
         }
     }
 
-    pub(crate) async fn handle_own_commit<'a>(
+    pub(crate) async fn handle_own_commit(
         &mut self,
         backend: &MlsCryptoProvider,
         ct: &ConfirmationTag,

--- a/keystore/src/connection/platform/generic/mod.rs
+++ b/keystore/src/connection/platform/generic/mod.rs
@@ -32,7 +32,7 @@ pub struct SqlCipherConnection {
 pub struct TransactionWrapper<'conn> {
     transaction: Transaction<'conn>,
 }
-impl<'conn> TransactionWrapper<'conn> {
+impl TransactionWrapper<'_> {
     // this is async just to conform with the wasm impl
     pub(crate) async fn commit_tx(self) -> CryptoKeystoreResult<()> {
         Ok(self.transaction.commit()?)

--- a/keystore/src/connection/platform/wasm/storage.rs
+++ b/keystore/src/connection/platform/wasm/storage.rs
@@ -45,7 +45,7 @@ pub enum WasmStorageTransaction<'a> {
     },
 }
 
-impl<'a> WasmStorageTransaction<'a> {
+impl WasmStorageTransaction<'_> {
     pub(crate) async fn commit_tx(self) -> CryptoKeystoreResult<()> {
         let Self::Persistent {
             tx: transaction,


### PR DESCRIPTION
With most new rustc versions come new lints. These are great, because they cause our codebase to gradually improve. But they necessitate commits like this from time to time where a lint got stricter.

# What's new in this PR

Fix some lifetime style lints.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
