### PR TITLE
refactor: rework JS wrapper, phase 2 [WPB-15318]

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -54,7 +54,6 @@ export type {
     BufferedDecryptedMessage,
     CommitBundle,
     ConversationInitBundle,
-    CustomConfiguration,
     DecryptedMessage,
 } from "./CoreCryptoMLS.js";
 
@@ -68,7 +67,10 @@ export type {
 
 export type { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 
-export { ConversationConfiguration } from "./core-crypto-ffi.js";
+export {
+    ConversationConfiguration,
+    CustomConfiguration,
+} from "./core-crypto-ffi.js";
 import initWasm from "./core-crypto-ffi.js";
 
 if (typeof window !== "undefined") {

--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -55,7 +55,6 @@ export type {
     CommitBundle,
     ConversationInitBundle,
     CustomConfiguration,
-    ConversationConfiguration,
     DecryptedMessage,
 } from "./CoreCryptoMLS.js";
 
@@ -69,6 +68,7 @@ export type {
 
 export type { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 
+export { ConversationConfiguration } from "./core-crypto-ffi.js";
 import initWasm from "./core-crypto-ffi.js";
 
 if (typeof window !== "undefined") {

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -1,7 +1,7 @@
 import {
     CoreCryptoContext as CoreCryptoContextFfi,
     ConversationConfiguration,
-    CustomConfiguration as CustomConfigurationFfi,
+    CustomConfiguration,
     E2eiDumpedPkiEnv,
     WireIdentity,
 } from "./core-crypto-ffi.js";
@@ -12,7 +12,6 @@ import {
     Ciphersuite,
     ClientId,
     CommitBundle,
-    CustomConfiguration,
     ConversationId,
     ConversationInitBundle,
     CredentialType,
@@ -335,14 +334,11 @@ export class CoreCryptoContext {
      */
     async processWelcomeMessage(
         welcomeMessage: Uint8Array,
-        configuration: CustomConfiguration = {}
+        configuration: Partial<CustomConfiguration> = {}
     ): Promise<WelcomeBundle> {
         try {
             const { keyRotationSpan, wirePolicy } = configuration || {};
-            const config = new CustomConfigurationFfi(
-                keyRotationSpan,
-                wirePolicy
-            );
+            const config = new CustomConfiguration(keyRotationSpan, wirePolicy);
             const ffiRet: CoreCryptoFfiTypes.WelcomeBundle =
                 await CoreCryptoError.asyncMapErr(
                     this.#ctx.process_welcome_message(welcomeMessage, config)
@@ -547,14 +543,11 @@ export class CoreCryptoContext {
     async joinByExternalCommit(
         groupInfo: Uint8Array,
         credentialType: CredentialType,
-        configuration: CustomConfiguration = {}
+        configuration: Partial<CustomConfiguration> = {}
     ): Promise<ConversationInitBundle> {
         try {
             const { keyRotationSpan, wirePolicy } = configuration || {};
-            const config = new CustomConfigurationFfi(
-                keyRotationSpan,
-                wirePolicy
-            );
+            const config = new CustomConfiguration(keyRotationSpan, wirePolicy);
             const ffiInitMessage: CoreCryptoFfiTypes.ConversationInitBundle =
                 await CoreCryptoError.asyncMapErr(
                     this.#ctx.join_by_external_commit(

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -451,36 +451,17 @@ export class CoreCryptoContext {
      *
      * @param conversationId - The ID of the conversation
      * @param clientIds - Array of Client IDs to remove.
-     *
-     * @returns A {@link CommitBundle}
      */
     async removeClientsFromConversation(
         conversationId: ConversationId,
         clientIds: ClientId[]
-    ): Promise<CommitBundle> {
-        try {
-            const ffiRet: CoreCryptoFfiTypes.CommitBundle =
-                await CoreCryptoError.asyncMapErr(
-                    this.#ctx.remove_clients_from_conversation(
-                        conversationId,
-                        clientIds
-                    )
-                );
-
-            const gi = ffiRet.group_info;
-
-            return {
-                welcome: ffiRet.welcome,
-                commit: ffiRet.commit,
-                groupInfo: {
-                    encryptionType: gi.encryption_type,
-                    ratchetTreeType: gi.ratchet_tree_type,
-                    payload: gi.payload,
-                },
-            };
-        } catch (e) {
-            throw CoreCryptoError.fromStdError(e as Error);
-        }
+    ): Promise<void> {
+        return await CoreCryptoError.asyncMapErr(
+            this.#ctx.remove_clients_from_conversation(
+                conversationId,
+                clientIds
+            )
+        );
     }
 
     /**

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -1,6 +1,6 @@
 import {
     CoreCryptoContext as CoreCryptoContextFfi,
-    ConversationConfiguration as ConversationConfigurationFfi,
+    ConversationConfiguration,
     CustomConfiguration as CustomConfigurationFfi,
     E2eiDumpedPkiEnv,
     WireIdentity,
@@ -12,7 +12,6 @@ import {
     Ciphersuite,
     ClientId,
     CommitBundle,
-    ConversationConfiguration,
     CustomConfiguration,
     ConversationId,
     ConversationInitBundle,
@@ -216,7 +215,7 @@ export class CoreCryptoContext {
     async createConversation(
         conversationId: ConversationId,
         creatorCredentialType: CredentialType,
-        configuration: ConversationConfiguration = {}
+        configuration: Partial<ConversationConfiguration> = {}
     ) {
         try {
             const {
@@ -224,11 +223,11 @@ export class CoreCryptoContext {
                 externalSenders,
                 custom = {},
             } = configuration || {};
-            const config = new ConversationConfigurationFfi(
+            const config = new ConversationConfiguration(
                 ciphersuite,
                 externalSenders,
-                custom?.keyRotationSpan,
-                custom?.wirePolicy
+                (custom as CustomConfiguration)?.keyRotationSpan,
+                (custom as CustomConfiguration)?.wirePolicy
             );
             return await CoreCryptoError.asyncMapErr(
                 this.#ctx.create_conversation(

--- a/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
@@ -25,6 +25,7 @@ import {
     MlsTransportProvider,
     WireIdentity,
     ConversationConfiguration,
+    CustomConfiguration,
 } from "./core-crypto-ffi.js";
 
 import { CoreCryptoError } from "./CoreCryptoError.js";
@@ -36,7 +37,6 @@ import {
     ClientId,
     Ciphersuite,
     ConversationInitBundle,
-    CustomConfiguration,
     WelcomeBundle,
     CommitBundle,
     DecryptedMessage,
@@ -552,7 +552,7 @@ export class CoreCrypto {
      */
     async processWelcomeMessage(
         welcomeMessage: Uint8Array,
-        configuration: CustomConfiguration = {}
+        configuration: Partial<CustomConfiguration> = {}
     ): Promise<WelcomeBundle> {
         return await this.transaction(
             async (ctx) =>
@@ -712,7 +712,7 @@ export class CoreCrypto {
     async joinByExternalCommit(
         groupInfo: Uint8Array,
         credentialType: CredentialType,
-        configuration: CustomConfiguration = {}
+        configuration: Partial<CustomConfiguration> = {}
     ): Promise<ConversationInitBundle> {
         return await this.transaction(
             async (ctx) =>

--- a/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
@@ -24,6 +24,7 @@ import {
     E2eiDumpedPkiEnv,
     MlsTransportProvider,
     WireIdentity,
+    ConversationConfiguration,
 } from "./core-crypto-ffi.js";
 
 import { CoreCryptoError } from "./CoreCryptoError.js";
@@ -39,7 +40,6 @@ import {
     WelcomeBundle,
     CommitBundle,
     DecryptedMessage,
-    ConversationConfiguration,
     MlsTransport,
 } from "./CoreCryptoMLS.js";
 
@@ -502,7 +502,7 @@ export class CoreCrypto {
     async createConversation(
         conversationId: ConversationId,
         creatorCredentialType: CredentialType,
-        configuration: ConversationConfiguration = {}
+        configuration: Partial<ConversationConfiguration> = {}
     ) {
         return await this.transaction(
             async (ctx) =>

--- a/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
@@ -653,7 +653,7 @@ export class CoreCrypto {
     async removeClientsFromConversation(
         conversationId: ConversationId,
         clientIds: ClientId[]
-    ): Promise<CommitBundle> {
+    ): Promise<void> {
         return await this.transaction(
             async (ctx) =>
                 await ctx.removeClientsFromConversation(

--- a/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
@@ -65,22 +65,6 @@ export enum WirePolicy {
 }
 
 /**
- * Implementation specific configuration object for a conversation
- */
-export interface CustomConfiguration {
-    /**
-     * Duration in seconds after which we will automatically force a self_update commit
-     * Note: This isn't currently implemented
-     */
-    keyRotationSpan?: number;
-    /**
-     * Defines if handshake messages are encrypted or not
-     * Note: Ciphertext is not currently supported by wire-server
-     */
-    wirePolicy?: WirePolicy;
-}
-
-/**
  * Alias for conversation IDs.
  * This is a freeform, uninspected buffer.
  */

--- a/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
@@ -51,24 +51,6 @@ export enum CredentialType {
 }
 
 /**
- * Configuration object for new conversations
- */
-export interface ConversationConfiguration {
-    /**
-     * Conversation ciphersuite
-     */
-    ciphersuite?: Ciphersuite;
-    /**
-     * List of client IDs that are allowed to be external senders of commits
-     */
-    externalSenders?: Uint8Array[];
-    /**
-     * Implementation specific configuration
-     */
-    custom?: CustomConfiguration;
-}
-
-/**
  * see [core_crypto::prelude::MlsWirePolicy]
  */
 export enum WirePolicy {

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1128,8 +1128,14 @@ impl ConversationConfiguration {
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 /// see [core_crypto::prelude::MlsCustomConfiguration]
 pub struct CustomConfiguration {
-    key_rotation_span: Option<u32>,
-    wire_policy: Option<WirePolicy>,
+    ///  Duration in seconds after which we will automatically force a self-update commit
+    ///  Note: This isn't currently implemented
+    #[wasm_bindgen(js_name = keyRotationSpan)]
+    pub key_rotation_span: Option<u32>,
+    /// Defines if handshake messages are encrypted or not
+    /// Note: encrypted handshake messages are not supported by wire-server
+    #[wasm_bindgen(js_name = wirePolicy)]
+    pub wire_policy: Option<WirePolicy>,
 }
 
 #[wasm_bindgen]

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1110,7 +1110,7 @@ impl ConversationConfiguration {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 /// see [core_crypto::prelude::MlsCustomConfiguration]
 pub struct CustomConfiguration {
     key_rotation_span: Option<u32>,
@@ -1125,13 +1125,6 @@ impl CustomConfiguration {
             key_rotation_span,
             wire_policy,
         }
-    }
-}
-
-impl Drop for CustomConfiguration {
-    fn drop(&mut self) {
-        let _ = self.key_rotation_span.take();
-        let _ = self.wire_policy.take();
     }
 }
 

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1082,11 +1082,16 @@ impl From<core_crypto::e2e_identity::E2eiDumpedPkiEnv> for E2eiDumpedPkiEnv {
 
 #[wasm_bindgen]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+/// Configuration object for new conversations
 /// see [core_crypto::prelude::MlsConversationConfiguration]
 pub struct ConversationConfiguration {
-    ciphersuite: Option<Ciphersuite>,
+    #[wasm_bindgen(readonly)]
+    /// Conversation ciphersuite
+    pub ciphersuite: Option<Ciphersuite>,
     external_senders: Vec<Vec<u8>>,
-    custom: CustomConfiguration,
+    #[wasm_bindgen(readonly)]
+    /// Additional configuration
+    pub custom: CustomConfiguration,
 }
 
 #[wasm_bindgen]
@@ -1106,6 +1111,16 @@ impl ConversationConfiguration {
             external_senders,
             custom: CustomConfiguration::new(key_rotation_span, wire_policy),
         })
+    }
+
+    /// List of client IDs that are allowed to be external senders
+    #[wasm_bindgen(getter, js_name = externalSenders)]
+    pub fn external_senders(&self) -> js_sys::Array {
+        self.external_senders
+            .iter()
+            .cloned()
+            .map(JsValue::from)
+            .collect::<js_sys::Array>()
     }
 }
 


### PR DESCRIPTION
This PR is a continuation of the work done in https://github.com/wireapp/core-crypto/pull/848.

It resolves the remaining warnings about conflicting Typescript types and does it by eliminating wrapper types and instead only exposing types defined on the Rust level.