### PR TITLE
chore: fix few doc warnings

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCryptoE2EI.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoE2EI.ts
@@ -147,7 +147,7 @@ export class E2eiEnrollment {
     /**
      * Creates a new authorization request.
      *
-     * @param url one of the URL in new order's authorizations (use {@link NewAcmeOrder.authorizations} from {@link newOrderResponse})
+     * @param url one of the URL in new order's authorizations from {@link newOrderResponse})
      * @param previousNonce `replay-nonce` response header from `POST /acme/{provisioner-name}/new-order` (or from the
      * previous to this method if you are creating the second authorization)
      * @see https://www.rfc-editor.org/rfc/rfc8555.html#section-7.5

--- a/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
@@ -330,7 +330,7 @@ export interface ProposalBundle {
      */
     proposal: Uint8Array;
     /**
-     * Unique identifier of a proposal. Use this in {@link CoreCrypto.clearPendingProposal} to roll back (delete) the proposal
+     * Unique identifier of a proposal.
      *
      * @readonly
      */

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -632,7 +632,7 @@ impl From<MlsGroupInfoBundle> for GroupInfoBundle {
 pub struct ProposalBundle {
     /// TLS-serialized MLS proposal that needs to be fanned out to other (existing) members of the conversation
     proposal: Vec<u8>,
-    /// Unique identifier of a proposal. Use this in {@link CoreCrypto.clearPendingProposal} to roll back (delete) the proposal
+    /// Unique identifier of a proposal.
     proposal_ref: Vec<u8>,
     /// New CRL Distribution of members of this group
     crl_new_distribution_points: Option<Vec<String>>,


### PR DESCRIPTION
We reference non-existing items in JS docs, so just remove those.