### PR TITLE
chore: silence warning about unexpected cfg in wasm-bindgen everywhere

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -141,3 +141,6 @@ anyhow = "1.0.94"
 # is available on the command line. If not, we should replace this with
 # `vergen-gix` or `vergen-git2`.
 vergen-gitcl = { version = "1.0.2", features = ["build", "cargo"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -114,3 +114,6 @@ features = ["async_futures", "html_reports"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -64,3 +64,6 @@ async-std = { workspace = true, features = ["attributes"] }
 cfg-if.workspace = true
 hex-literal = "0.4"
 mls-crypto-provider = { workspace = true, features = ["raw-rand-access"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }


### PR DESCRIPTION
We had this already for the crypto-ffi crate, however, the warning still appeared for all other crates with wasm-bindgen tests.

# What's new in this PR
See title


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
