### PR TITLE
refactor: move version function to module [WPB-15329]

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -26,6 +26,7 @@ export {
     CoreCryptoLogLevel,
     setMaxLogLevel,
     buildMetadata,
+    version,
     CoreCrypto,
 } from "./CoreCryptoInstance.js";
 export type {

--- a/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
@@ -172,6 +172,16 @@ export function setMaxLogLevel(level: CoreCryptoLogLevel): void {
 export function buildMetadata(): CoreCryptoFfiTypes.BuildMetadata {
     return CoreCryptoFfi.build_metadata();
 }
+
+/**
+ * Returns the current version of {@link CoreCrypto}
+ *
+ * @returns the CoreCrypto version as a string (e.g. "3.1.2")
+ */
+export function version(): string {
+    return CoreCryptoFfi.version();
+}
+
 /**
  * Wrapper for the WASM-compiled version of CoreCrypto
  */
@@ -1339,14 +1349,5 @@ export class CoreCrypto {
             this.#cc.get_credential_in_use(groupInfo, credentialType)
         );
         return normalizeEnum(E2eiConversationState, state);
-    }
-
-    /**
-     * Returns the current version of {@link CoreCrypto}
-     *
-     * @returns The `core-crypto-ffi` version as defined in its `Cargo.toml` file
-     */
-    static version(): string {
-        return CoreCryptoFfi.version();
     }
 }

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -878,6 +878,19 @@ describe("build", () => {
     });
 });
 
+describe("build", () => {
+    it("version can be retrieved and is a semantic version number", async () => {
+        await expect(
+            browser.execute(async () => window.ccModule.version())
+        ).resolves.toMatch(
+            RegExp(
+                // Regex for matching semantic versions from https://semver.org
+                "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+            )
+        );
+    });
+});
+
 describe("Error type mapping", () => {
     it("should work for conversation already exists", async () => {
         await ccInit(ALICE_ID);


### PR DESCRIPTION
# What's new in this PR

Move the `version()` from the CoreCrypto instance to the module level.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
