### PR TITLE
docs: fix github pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4.5.0
       with:
-        name: rustdoc
+        name: rustdocs
         path: target/doc
         retention-days: 1
         overwrite: true
@@ -117,6 +117,12 @@ jobs:
       - ktdoc
 
     steps:
+    - uses: actions/download-artifact@v4.1.8
+      with:
+        pattern: "rustdocs"
+        path: target/doc
+        merge-multiple: true
+
     - uses: actions/download-artifact@v4.1.8
       with:
         pattern: "*doc"


### PR DESCRIPTION
The github pages deployment was presumably broken because the upload-artifact action had a "merge multple" policy where the rust docs were overwriting the uploaded kotlin and typescript docs.

This renames the rust doc artifact and uploads it first so that it doesn't overwrite the kotlin and typescript docs anymore.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
