### PR TITLE
fix: `merge-pr.sh` emits output when bailing out

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -14,9 +14,7 @@ set -e -o pipefail
 function bail() {
     msg="$1"
     if [ -n "$msg" ]; then
-        # we do want to emit to stderr here
-        #shellcheck disable=SC2210
-        echo >2 "$msg"
+        >&2 printf "%b\n" "$msg"
     fi
     exit 1
 }


### PR DESCRIPTION
Turns out that shellcheck was right, and my bash-fu was weak. This now properly emits output to stderr instead of a file named `2`.

Also it now uses `printf` instead of `echo` so that things like `\n` work.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
