### PR TITLE
chore: scripts: update update-versions.sh

### DIFF
--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -1,6 +1,6 @@
 # Update version numbers of various core-crypto components.
 new_version=$1
-for crate in crypto-attributes \
+for crate in crypto-macros \
              crypto-ffi \
              crypto \
              interop \
@@ -15,8 +15,9 @@ cargo update -w
 
 # Update the NPM package version. Be careful not to overwrite the same
 # file we're reading from.
-jq "setpath([\"version\"]; \"${new_version}\")" package.json > package.json.new
-mv package.json.new package.json
+js_path=crypto-ffi/bindings/js
+jq "setpath([\"version\"]; \"${new_version}\")" ${js_path}/package.json > ${js_path}/package.json.new
+mv ${js_path}/package.json.new ${js_path}/package.json
 
 # Update Maven package version.
 sed -i "0,/^VERSION_NAME=[0-9.]\+$/{s//VERSION_NAME=${new_version}/;b;}" crypto-ffi/bindings/gradle.properties


### PR DESCRIPTION
We moved package.json from the top level and crypto-attributes was renamed, so make sure the script is up to date.
