### PR TITLE
chore: improve logs when buffering messages

### DIFF
--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -286,7 +286,7 @@ impl From<RecursiveError> for CoreCryptoError {
 
         match_heterogenous!(innermost => {
             core_crypto::LeafError::ConversationAlreadyExists(id) => MlsError::ConversationAlreadyExists(id.clone()).into(),
-            core_crypto::mls::conversation::Error::BufferedFutureMessage => MlsError::BufferedFutureMessage.into(),
+            core_crypto::mls::conversation::Error::BufferedFutureMessage{..} => MlsError::BufferedFutureMessage.into(),
             core_crypto::mls::conversation::Error::DuplicateMessage => MlsError::DuplicateMessage.into(),
             core_crypto::mls::conversation::Error::MessageEpochTooOld => MlsError::MessageEpochTooOld.into(),
             core_crypto::mls::conversation::Error::SelfCommitIgnored => MlsError::SelfCommitIgnored.into(),

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -293,7 +293,7 @@ impl From<RecursiveError> for InternalError {
 
         match_heterogenous!(innermost => {
             core_crypto::LeafError::ConversationAlreadyExists(id) => MlsError::ConversationAlreadyExists(id.clone()).into(),
-            core_crypto::mls::conversation::Error::BufferedFutureMessage => MlsError::BufferedFutureMessage.into(),
+            core_crypto::mls::conversation::Error::BufferedFutureMessage{..} => MlsError::BufferedFutureMessage.into(),
             core_crypto::mls::conversation::Error::DuplicateMessage => MlsError::DuplicateMessage.into(),
             core_crypto::mls::conversation::Error::MessageEpochTooOld => MlsError::MessageEpochTooOld.into(),
             core_crypto::mls::conversation::Error::SelfCommitIgnored => MlsError::SelfCommitIgnored.into(),

--- a/crypto/src/mls/buffer_external_commit.rs
+++ b/crypto/src/mls/buffer_external_commit.rs
@@ -321,12 +321,12 @@ mod tests {
                     let decrypt = alice_central.context.decrypt_message(&id, msg1).await;
                     assert!(matches!(
                         decrypt.unwrap_err(),
-                        mls::conversation::Error::BufferedFutureMessage
+                        mls::conversation::Error::BufferedFutureMessage { .. }
                     ));
                     let decrypt = alice_central.context.decrypt_message(&id, msg2).await;
                     assert!(matches!(
                         decrypt.unwrap_err(),
-                        mls::conversation::Error::BufferedFutureMessage
+                        mls::conversation::Error::BufferedFutureMessage { .. }
                     ));
                     assert_eq!(alice_central.context.count_entities().await.pending_messages, 2);
 

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -4,6 +4,7 @@
 //! Feel free to delete all of this when the issue is fixed on the DS side !
 
 use super::{Error, Result};
+use crate::obfuscate::Obfuscated;
 use crate::{
     context::CentralContext,
     group_store::GroupStoreValue,
@@ -71,7 +72,6 @@ impl MlsConversation {
         is_rejoin: bool,
     ) -> Result<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
         // using the macro produces a clippy warning
-        info!("restore_pending_messages");
         let result = async move {
             let keystore = backend.keystore();
             let group_id = self.id().as_slice();
@@ -116,6 +116,8 @@ impl MlsConversation {
             // We want to restore application messages first, then Proposals & finally Commits
             // luckily for us that's the exact same order as the [ContentType] enum
             pending_messages.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+            info!(group_id = Obfuscated::from(&self.id); "Attempting to restore {} buffered messages", pending_messages.len());
 
             let mut decrypted_messages = Vec::with_capacity(pending_messages.len());
             for (_, m) in pending_messages {

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -238,10 +238,10 @@ mod tests {
                         .map(|m| m.to_bytes().unwrap());
                     for m in messages {
                         let decrypt = bob_central.context.decrypt_message(&id, m).await;
-                        assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage));
+                        assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage { .. }));
                     }
                     let decrypt = bob_central.context.decrypt_message(&id, app_msg).await;
-                    assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage));
+                    assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage { .. }));
 
                     // Bob should have buffered the messages
                     assert_eq!(bob_central.context.count_entities().await.pending_messages, 4);
@@ -369,10 +369,10 @@ mod tests {
                         .map(|m| m.to_bytes().unwrap());
                     for m in messages {
                         let decrypt = alice_central.context.decrypt_message(&id, m).await;
-                        assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage));
+                        assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage { .. }));
                     }
                     let decrypt = alice_central.context.decrypt_message(&id, app_msg).await;
-                    assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage));
+                    assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage { .. }));
 
                     // Alice should have buffered the messages
                     assert_eq!(alice_central.context.count_entities().await.pending_messages, 4);

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -7,10 +7,7 @@ use super::{Error, Result};
 use crate::{
     context::CentralContext,
     group_store::GroupStoreValue,
-    prelude::{
-        decrypt::MlsBufferedConversationDecryptMessage, Client, ConversationId, MlsConversation,
-        MlsConversationDecryptMessage,
-    },
+    prelude::{decrypt::MlsBufferedConversationDecryptMessage, Client, ConversationId, MlsConversation},
     KeystoreError, RecursiveError,
 };
 use core_crypto_keystore::{
@@ -23,11 +20,7 @@ use openmls::prelude::{MlsMessageIn, MlsMessageInBody};
 use tls_codec::Deserialize;
 
 impl CentralContext {
-    pub(crate) async fn handle_future_message(
-        &self,
-        id: &ConversationId,
-        message: impl AsRef<[u8]>,
-    ) -> Result<MlsConversationDecryptMessage> {
+    pub(crate) async fn handle_future_message(&self, id: &ConversationId, message: impl AsRef<[u8]>) -> Result<()> {
         let keystore = self
             .keystore()
             .await
@@ -41,7 +34,7 @@ impl CentralContext {
             .save::<MlsPendingMessage>(pending_msg)
             .await
             .map_err(KeystoreError::wrap("saving pending mls message"))?;
-        Err(Error::BufferedFutureMessage)
+        Ok(())
     }
 
     pub(crate) async fn restore_pending_messages(

--- a/crypto/src/mls/conversation/commit.rs
+++ b/crypto/src/mls/conversation/commit.rs
@@ -1341,7 +1341,7 @@ mod tests {
 
                     // fails when a commit is skipped
                     let out_of_order = bob_central.context.decrypt_message(&id, &commit2).await;
-                    assert!(matches!(out_of_order.unwrap_err(), Error::BufferedFutureMessage));
+                    assert!(matches!(out_of_order.unwrap_err(), Error::BufferedFutureMessage { .. }));
 
                     // works in the right order though
                     // NB: here 'commit2' has been buffered so it is also applied when we decrypt commit1

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -373,7 +373,9 @@ impl MlsConversation {
                     } else if msg_epoch == group_epoch + 1 {
                         // limit to next epoch otherwise if we were buffering a commit for epoch + 2
                         // we would fail when trying to decrypt it in [MlsCentral::commit_accepted]
-                        Error::BufferedFutureMessage
+                        Error::BufferedFutureMessage {
+                            message_epoch: msg_epoch,
+                        }
                     } else if msg_epoch < group_epoch {
                         match content_type {
                             ContentType::Application => Error::StaleMessage,
@@ -1040,7 +1042,7 @@ mod tests {
 
                     // which Bob cannot decrypt because of Post CompromiseSecurity
                     let decrypt = bob_central.context.decrypt_message(&id, &encrypted).await;
-                    assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage));
+                    assert!(matches!(decrypt.unwrap_err(), Error::BufferedFutureMessage { .. }));
 
                     let decrypted_commit = bob_central
                         .context

--- a/crypto/src/mls/conversation/error.rs
+++ b/crypto/src/mls/conversation/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Incoming message is from a prior epoch")]
     StaleMessage,
     #[error("Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives")]
-    BufferedFutureMessage,
+    BufferedFutureMessage { message_epoch: u64 },
     #[error("Incoming message is from an epoch too far in the future to buffer.")]
     UnbufferedFarFutureMessage,
     #[error("The received commit is deemed stale and is from an older epoch.")]


### PR DESCRIPTION
# What's new in this PR

We have observed some unexpected behaviour when restoring buffered proposals, so let's improve the logs.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
