### PR TITLE
[3.x] chore: emit info log when buffering, restoring, or clearing future messages

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup bun (web)
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.1
       - name: Install wasm-pack (web)
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -111,7 +111,7 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.1
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,7 +201,7 @@ jobs:
           chrome-version: stable
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.1
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -69,3 +69,6 @@ wasm-opt = false
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -209,7 +209,7 @@ impl From<CryptoError> for CoreCryptoError {
         match value {
             CryptoError::ConversationAlreadyExists(id) => MlsError::ConversationAlreadyExists(id).into(),
             CryptoError::DuplicateMessage => MlsError::DuplicateMessage.into(),
-            CryptoError::BufferedFutureMessage => MlsError::BufferedFutureMessage.into(),
+            CryptoError::BufferedFutureMessage { .. } => MlsError::BufferedFutureMessage.into(),
             CryptoError::WrongEpoch => MlsError::WrongEpoch.into(),
             CryptoError::MessageEpochTooOld => MlsError::MessageEpochTooOld.into(),
             CryptoError::SelfCommitIgnored => MlsError::SelfCommitIgnored.into(),

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -211,7 +211,7 @@ impl From<CryptoError> for InternalError {
         match value {
             CryptoError::ConversationAlreadyExists(id) => MlsError::ConversationAlreadyExists(id).into(),
             CryptoError::DuplicateMessage => MlsError::DuplicateMessage.into(),
-            CryptoError::BufferedFutureMessage => MlsError::BufferedFutureMessage.into(),
+            CryptoError::BufferedFutureMessage { .. } => MlsError::BufferedFutureMessage.into(),
             CryptoError::WrongEpoch => MlsError::WrongEpoch.into(),
             CryptoError::MessageEpochTooOld => MlsError::MessageEpochTooOld.into(),
             CryptoError::SelfCommitIgnored => MlsError::SelfCommitIgnored.into(),

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -139,7 +139,10 @@ pub enum CryptoError {
     WrongEpoch,
     /// Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives
     #[error("Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives")]
-    BufferedFutureMessage,
+    BufferedFutureMessage {
+        /// The epoch of the buffered message
+        message_epoch: u64,
+    },
     /// Proteus Error Wrapper
     #[error(transparent)]
     ProteusError(#[from] ProteusError),

--- a/crypto/src/mls/buffer_external_commit.rs
+++ b/crypto/src/mls/buffer_external_commit.rs
@@ -192,9 +192,15 @@ mod tests {
 
                     // Since Alice missed Bob's commit she should buffer this message
                     let decrypt = alice_central.context.decrypt_message(&id, msg1).await;
-                    assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                    assert!(matches!(
+                        decrypt.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { .. }
+                    ));
                     let decrypt = alice_central.context.decrypt_message(&id, msg2).await;
-                    assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                    assert!(matches!(
+                        decrypt.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { .. }
+                    ));
                     assert_eq!(alice_central.context.count_entities().await.pending_messages, 2);
 
                     let gi = bob_central.get_group_info(&id).await;

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -8,7 +8,7 @@ use crate::{
     group_store::GroupStoreValue,
     prelude::{
         decrypt::MlsBufferedConversationDecryptMessage, Client, ConversationId, CoreCryptoCallbacks, CryptoError,
-        CryptoResult, MlsConversation, MlsConversationDecryptMessage, MlsError,
+        CryptoResult, MlsConversation, MlsError,
     },
 };
 use core_crypto_keystore::{
@@ -25,7 +25,7 @@ impl CentralContext {
         &self,
         id: &ConversationId,
         message: impl AsRef<[u8]>,
-    ) -> CryptoResult<MlsConversationDecryptMessage> {
+    ) -> CryptoResult<()> {
         let keystore = self.keystore().await?;
 
         let pending_msg = MlsPendingMessage {
@@ -33,7 +33,7 @@ impl CentralContext {
             message: message.as_ref().to_vec(),
         };
         keystore.save::<MlsPendingMessage>(pending_msg).await?;
-        Err(CryptoError::BufferedFutureMessage)
+        Ok(())
     }
 
     pub(crate) async fn restore_pending_messages(

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -216,10 +216,16 @@ mod tests {
                         .map(|m| m.to_bytes().unwrap());
                     for m in messages {
                         let decrypt = bob_central.context.decrypt_message(&id, m).await;
-                        assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                        assert!(matches!(
+                            decrypt.unwrap_err(),
+                            CryptoError::BufferedFutureMessage { .. }
+                        ));
                     }
                     let decrypt = bob_central.context.decrypt_message(&id, app_msg).await;
-                    assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                    assert!(matches!(
+                        decrypt.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { .. }
+                    ));
 
                     // Bob should have buffered the messages
                     assert_eq!(bob_central.context.count_entities().await.pending_messages, 4);
@@ -343,10 +349,16 @@ mod tests {
                             .map(|m| m.to_bytes().unwrap());
                         for m in messages {
                             let decrypt = alice_central.context.decrypt_message(&id, m).await;
-                            assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                            assert!(matches!(
+                                decrypt.unwrap_err(),
+                                CryptoError::BufferedFutureMessage { .. }
+                            ));
                         }
                         let decrypt = alice_central.context.decrypt_message(&id, app_msg).await;
-                        assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                        assert!(matches!(
+                            decrypt.unwrap_err(),
+                            CryptoError::BufferedFutureMessage { .. }
+                        ));
 
                         // Alice should have buffered the messages
                         assert_eq!(alice_central.context.count_entities().await.pending_messages, 4);

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -4,6 +4,7 @@
 //! Feel free to delete all of this when the issue is fixed on the DS side !
 
 use crate::context::CentralContext;
+use crate::obfuscate::Obfuscated;
 use crate::{
     group_store::GroupStoreValue,
     prelude::{
@@ -73,7 +74,6 @@ impl MlsConversation {
         is_rejoin: bool,
     ) -> CryptoResult<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
         // using the macro produces a clippy warning
-        info!("restore_pending_messages");
         let result = async move {
             let keystore = backend.keystore();
             let group_id = self.id().as_slice();
@@ -108,6 +108,8 @@ impl MlsConversation {
             // We want to restore application messages first, then Proposals & finally Commits
             // luckily for us that's the exact same order as the [ContentType] enum
             pending_messages.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+            info!(group_id = Obfuscated::from(&self.id); "Attempting to restore {} buffered messages", pending_messages.len());
 
             let mut decrypted_messages = Vec::with_capacity(pending_messages.len());
             for (_, m) in pending_messages {

--- a/crypto/src/mls/conversation/commit.rs
+++ b/crypto/src/mls/conversation/commit.rs
@@ -1112,7 +1112,10 @@ mod tests {
 
                     // fails when a commit is skipped
                     let out_of_order = bob_central.context.decrypt_message(&id, &commit2).await;
-                    assert!(matches!(out_of_order.unwrap_err(), CryptoError::BufferedFutureMessage));
+                    assert!(matches!(
+                        out_of_order.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { .. }
+                    ));
 
                     // works in the right order though
                     // NB: here 'commit2' has been buffered so it is also applied when we decrypt commit1

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -347,7 +347,9 @@ impl MlsConversation {
                     } else if msg_epoch == group_epoch + 1 {
                         // limit to next epoch otherwise if we were buffering a commit for epoch + 2
                         // we would fail when trying to decrypt it in [MlsCentral::commit_accepted]
-                        CryptoError::BufferedFutureMessage
+                        CryptoError::BufferedFutureMessage {
+                            message_epoch: msg_epoch,
+                        }
                     } else if msg_epoch < group_epoch {
                         match content_type {
                             ContentType::Application => CryptoError::StaleMessage,
@@ -1291,7 +1293,10 @@ mod tests {
 
                     // which Bob cannot decrypt because of Post CompromiseSecurity
                     let decrypt = bob_central.context.decrypt_message(&id, &encrypted).await;
-                    assert!(matches!(decrypt.unwrap_err(), CryptoError::BufferedFutureMessage));
+                    assert!(matches!(
+                        decrypt.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { .. }
+                    ));
 
                     let decrypted_commit = bob_central
                         .context

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -49,7 +49,7 @@ impl MlsConversation {
         }
     }
 
-    pub(crate) async fn handle_own_commit<'a>(
+    pub(crate) async fn handle_own_commit(
         &mut self,
         backend: &MlsCryptoProvider,
         ct: &ConfirmationTag,

--- a/extras/webdriver-installation/Cargo.toml
+++ b/extras/webdriver-installation/Cargo.toml
@@ -38,3 +38,6 @@ zip = "0.6"
 flate2 = "1.0"
 tar = "0.4"
 tracing = "0.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }

--- a/keystore/src/connection/platform/generic/mod.rs
+++ b/keystore/src/connection/platform/generic/mod.rs
@@ -32,7 +32,7 @@ pub struct SqlCipherConnection {
 pub struct TransactionWrapper<'conn> {
     transaction: Transaction<'conn>,
 }
-impl<'conn> TransactionWrapper<'conn> {
+impl TransactionWrapper<'_> {
     // this is async just to conform with the wasm impl
     pub(crate) async fn commit_tx(self) -> CryptoKeystoreResult<()> {
         Ok(self.transaction.commit()?)

--- a/keystore/src/connection/platform/wasm/storage.rs
+++ b/keystore/src/connection/platform/wasm/storage.rs
@@ -45,7 +45,7 @@ pub enum WasmStorageTransaction<'a> {
     },
 }
 
-impl<'a> WasmStorageTransaction<'a> {
+impl WasmStorageTransaction<'_> {
     pub(crate) async fn commit_tx(self) -> CryptoKeystoreResult<()> {
         let Self::Persistent {
             tx: transaction,


### PR DESCRIPTION
# What's new in this PR
See commit messages

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
