### PR TITLE
chore: ci: specify full ref mapping

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: force-fetch the tag to work around actions/checkout#290
-        run: git fetch -f origin ${{ github.ref }}
+        run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
       - name: set up jdk 17

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: force-fetch the tag to work around actions/checkout#290
-        run: git fetch -f origin ${{ github.ref }}
+        run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
       - name: setup rust

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -26,7 +26,7 @@ jobs:
           xcode-version: '14.3.1'
       - uses: actions/checkout@v4
       - name: force-fetch the tag to work around actions/checkout#290
-        run: git fetch -f origin ${{ github.ref }}
+        run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
       - name: "setup rust"

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: force-fetch the tag to work around actions/checkout#290
-        run: git fetch -f origin ${{ github.ref }}
+        run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
Apparently,` ${{ github.ref }}` is the full ref name, starting with refs/, so implicit mapping won't work.
