### PR TITLE
chore: crypto-ffi: don't use the base maven-publish plugin

### DIFF
--- a/crypto-ffi/bindings/android/build.gradle.kts
+++ b/crypto-ffi/bindings/android/build.gradle.kts
@@ -6,7 +6,7 @@ import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 plugins {
     id("com.android.library")
     kotlin("android")
-    id("com.vanniktech.maven.publish.base")
+    id("com.vanniktech.maven.publish")
 }
 
 val kotlinSources = projectDir.resolve("../jvm/src")
@@ -38,7 +38,6 @@ dependencies {
 }
 
 mavenPublishing {
-    pomFromGradleProperties()
     configure(AndroidSingleVariantLibrary(
         variant = "release",
         sourcesJar = true,


### PR DESCRIPTION
The base plugin is missing tasks to publish to Maven Central. Instead, use the high-level plugin, that provides those tasks, but still try to disable javadoc generation.

For POM information it looks like the high-level plugin picks up gradle.properties automatically, so we can remove the
```
  pomFromGradleProperties()
```
bit. Actually, we have to remove it, because it's incompatible with the high-level plugin and using it results in an error.

