### PR TITLE
feat: buffer commits until all required proposals have arrived [WPB-15810]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoException.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoException.kt
@@ -77,6 +77,11 @@ sealed class MlsException: Exception() {
             get() = ""
     }
 
+    class BufferedCommit() : MlsException() {
+        override val message
+            get() = ""
+    }
+
     class MessageEpochTooOld() : MlsException() {
         override val message
             get() = ""
@@ -158,6 +163,7 @@ fun com.wire.crypto.uniffi.MlsException.lift() =
         is com.wire.crypto.uniffi.MlsException.StaleProposal -> MlsException.StaleProposal()
         is com.wire.crypto.uniffi.MlsException.UnmergedPendingGroup -> MlsException.UnmergedPendingGroup()
         is com.wire.crypto.uniffi.MlsException.WrongEpoch -> MlsException.WrongEpoch()
+        is com.wire.crypto.uniffi.MlsException.BufferedCommit -> MlsException.BufferedCommit()
         is com.wire.crypto.uniffi.MlsException.OrphanWelcome -> MlsException.OrphanWelcome()
         is com.wire.crypto.uniffi.MlsException.MessageRejected -> MlsException.MessageRejected(this.reason)
         is com.wire.crypto.uniffi.MlsException.Other -> MlsException.Other(this.v1)

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -97,6 +97,8 @@ pub enum MlsError {
     BufferedFutureMessage,
     #[error("Incoming message is from an epoch too far in the future to buffer.")]
     WrongEpoch,
+    #[error("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.")]
+    BufferedCommit,
     #[error("The epoch in which message was encrypted is older than allowed")]
     MessageEpochTooOld,
     #[error("Tried to decrypt a commit created by self which is likely to have been replayed by the DS")]
@@ -293,6 +295,7 @@ impl From<RecursiveError> for CoreCryptoError {
             core_crypto::mls::conversation::Error::StaleCommit => MlsError::StaleCommit.into(),
             core_crypto::mls::conversation::Error::StaleProposal => MlsError::StaleProposal.into(),
             core_crypto::mls::conversation::Error::UnbufferedFarFutureMessage => MlsError::WrongEpoch.into(),
+            core_crypto::mls::conversation::Error::BufferedCommit => MlsError::BufferedCommit.into(),
             core_crypto::mls::conversation::Error::MessageRejected { reason } => MlsError::MessageRejected { reason: reason.clone() }.into(),
             core_crypto::mls::conversation::Error::OrphanWelcome => MlsError::OrphanWelcome.into(),
             core_crypto::mls::Error::UnmergedPendingGroup => MlsError::UnmergedPendingGroup.into(),

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -90,6 +90,8 @@ pub enum MlsError {
     BufferedFutureMessage,
     #[error("Incoming message is from an epoch too far in the future to buffer.")]
     WrongEpoch,
+    #[error("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.")]
+    BufferedCommit,
     #[error("The epoch in which message was encrypted is older than allowed")]
     MessageEpochTooOld,
     #[error("Tried to decrypt a commit created by self which is likely to have been replayed by the DS")]
@@ -300,6 +302,7 @@ impl From<RecursiveError> for InternalError {
             core_crypto::mls::conversation::Error::StaleCommit => MlsError::StaleCommit.into(),
             core_crypto::mls::conversation::Error::StaleProposal => MlsError::StaleProposal.into(),
             core_crypto::mls::conversation::Error::UnbufferedFarFutureMessage => MlsError::WrongEpoch.into(),
+            core_crypto::mls::conversation::Error::BufferedCommit => MlsError::BufferedCommit.into(),
             core_crypto::mls::conversation::Error::MessageRejected { reason } => MlsError::MessageRejected { reason: reason.clone() }.into(),
             core_crypto::mls::conversation::Error::OrphanWelcome => MlsError::OrphanWelcome.into(),
             core_crypto::mls::Error::UnmergedPendingGroup => MlsError::UnmergedPendingGroup.into(),

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -418,4 +418,212 @@ mod tests {
         )
         .await
     }
+
+    /// Replicating [WPB-15810]
+    ///
+    /// [WPB-15810]: https://wearezeta.atlassian.net/browse/WPB-15810
+    #[apply(all_cred_cipher)]
+    async fn wpb_15810(case: TestCase) {
+        use openmls::{
+            group::GroupId,
+            prelude::{ExternalProposal, SenderExtensionIndex},
+        };
+
+        use crate::mls;
+
+        if case.is_pure_ciphertext() {
+            // The use case tested here requires inspecting your own commit.
+            // Openmls does not support this currently when protocol messages are encrypted.
+            return;
+        }
+        run_test_with_client_ids(
+            case.clone(),
+            ["external_0", "new_member", "member_27", "observer", "114", "115"],
+            move |[external_0, new_member, member_27, observer, member_114, member_115]| {
+                Box::pin(async move {
+                    // scenario start: everyone except "new_member" is in the conversation
+                    let conv_id = conversation_id();
+
+                    // set up external_0 as the backend / delivery service
+                    let signature_key = external_0.client_signature_key(&case).await.as_slice().to_vec();
+                    let mut config = case.cfg.clone();
+                    observer
+                        .context
+                        .set_raw_external_senders(&mut config, vec![signature_key])
+                        .await
+                        .unwrap();
+
+                    // create and initialize the conversation
+                    observer
+                        .context
+                        .new_conversation(&conv_id, case.credential_type, config)
+                        .await
+                        .unwrap();
+
+                    // everyone else except new_member joins (also except observer, who created it)
+                    observer
+                        .invite_all(&case, &conv_id, [&member_114, &member_115, &member_27])
+                        .await
+                        .unwrap();
+
+                    // Everyone should agree on the overall state here, to wit: the group consists of everyone
+                    // except "new_member", and "external_0", and no messages have been sent.
+                    // At this point only the observer is going to receive messages, because that shouldn't impact group state.
+
+                    // external 0 sends a proposal to remove 114
+                    let leaf_of_114 = observer.index_of(&conv_id, member_114.get_client_id().await).await;
+                    let sender_index = SenderExtensionIndex::new(0);
+                    let sc = case.signature_scheme();
+                    let ct = case.credential_type;
+                    let cb = external_0.find_most_recent_credential_bundle(sc, ct).await.unwrap();
+                    let group_id = GroupId::from_slice(&conv_id[..]);
+                    let epoch = observer.get_conversation_unchecked(&conv_id).await.group.epoch();
+                    let proposal_remove_114_1 = ExternalProposal::new_remove(
+                        leaf_of_114,
+                        group_id.clone(),
+                        epoch,
+                        &cb.signature_key,
+                        sender_index,
+                    )
+                    .unwrap();
+
+                    // now bump the epoch in external_0: the new member has joined
+                    let new_member_join_commit = new_member
+                        .create_unmerged_external_commit(
+                            observer.get_group_info(&conv_id).await,
+                            case.custom_cfg(),
+                            case.credential_type,
+                        )
+                        .await
+                        .commit;
+
+                    new_member
+                        .context
+                        .merge_pending_group_from_external_commit(&conv_id)
+                        .await
+                        .unwrap();
+
+                    // also create the same proposal with the epoch increased by 1
+                    let leaf_of_114 = new_member.index_of(&conv_id, member_114.get_client_id().await).await;
+                    let proposal_remove_114_2 = ExternalProposal::new_remove(
+                        leaf_of_114,
+                        group_id.clone(),
+                        (epoch.as_u64() + 1).into(),
+                        &cb.signature_key,
+                        sender_index,
+                    )
+                    .unwrap();
+
+                    // now our observer receives these messages out of order
+                    println!("observer executing first proposal");
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    println!("observer executing second proposal");
+                    let result = observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        Error::BufferedFutureMessage { message_epoch: 2 }
+                    ));
+                    println!("executing commit adding new user");
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &new_member_join_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // now the new member receives the messages in order
+                    println!("new_member executing first proposal");
+                    assert!(matches!(
+                        new_member
+                            .context
+                            .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                            .await
+                            .unwrap_err(),
+                        mls::conversation::Error::StaleProposal,
+                    ));
+                    println!("new_member executing second proposal");
+                    new_member
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // now let's switch to the perspective of member 27
+                    // they have observed exactly one of the "remove 114" proposals,
+                    // plus a "remove 115" proposal. We can assume that they observe the 2nd
+                    // "remove 114" proposal because they advanced the epoch correctly when
+                    // the new member was added.
+                    let leaf_of_115 = observer.index_of(&conv_id, member_115.get_client_id().await).await;
+                    let epoch = observer.get_conversation_unchecked(&conv_id).await.group.epoch();
+                    let proposal_remove_115 =
+                        ExternalProposal::new_remove(leaf_of_115, group_id, epoch, &cb.signature_key, sender_index)
+                            .unwrap();
+
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    let result = member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        Error::BufferedFutureMessage { message_epoch: 2 }
+                    ));
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &new_member_join_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    member_27.context.commit_pending_proposals(&conv_id).await.unwrap();
+                    let remove_two_members_commit = member_27.mls_transport.latest_commit().await;
+
+                    // In this case, note that observer receives the proposal before the commit.
+                    // This is the straightforward ordering and easy to deal with.
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &remove_two_members_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // In this case, new_member receives the commit before the proposal. This means that
+                    // the commit has to be buffered until the proposal it references is received.
+                    let result = new_member
+                        .context
+                        .decrypt_message(&conv_id, &remove_two_members_commit.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(result.unwrap_err(), Error::BufferedCommit));
+                    new_member
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    observer.try_talk_to(&conv_id, &new_member).await.unwrap();
+                    observer.try_talk_to(&conv_id, &member_27).await.unwrap();
+                    new_member.try_talk_to(&conv_id, &member_27).await.unwrap();
+                })
+            },
+        )
+        .await
+    }
 }

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -137,13 +137,10 @@ impl MlsConversation {
             Ok(decrypted_messages)
         }
         .await;
-        match result {
-            Ok(r) => Ok(r),
-            Err(e) => {
-                error!(error:% = e; "Error restoring pending messages");
-                Err(e)
-            }
+        if let Err(e) = &result {
+            error!(error:% = e; "Error restoring pending messages");
         }
+        result
     }
 }
 

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -18,10 +18,12 @@ use openmls::{
     },
 };
 use openmls_traits::OpenMlsCryptoProvider;
-use std::fmt::Debug;
 use tls_codec::Deserialize;
 
-use core_crypto_keystore::entities::MlsPendingMessage;
+use core_crypto_keystore::{
+    connection::FetchFromDatabase,
+    entities::{MlsBufferedCommit, MlsPendingMessage},
+};
 use mls_crypto_provider::MlsCryptoProvider;
 
 use super::{Error, Result};
@@ -111,6 +113,12 @@ impl From<MlsConversationDecryptMessage> for MlsBufferedConversationDecryptMessa
     }
 }
 
+struct ParsedMessage {
+    is_duplicate: bool,
+    protocol_message: ProtocolMessage,
+    content_type: ContentType,
+}
+
 /// Abstraction over a MLS group capable of decrypting a MLS message
 impl MlsConversation {
     /// see [CentralContext::decrypt_message]
@@ -126,26 +134,46 @@ impl MlsConversation {
         backend: &MlsCryptoProvider,
         restore_pending: bool,
     ) -> Result<MlsConversationDecryptMessage> {
-        let message = match self.parse_message(backend, message.clone()).await {
-            // Handles the case where we receive our own commits.
-            Err(Error::Mls(crate::MlsError {
-                source:
-                    crate::MlsErrorKind::MlsMessageError(ProcessMessageError::InvalidCommit(StageCommitError::OwnCommit)),
-                ..
-            })) => {
-                let ct = self.extract_confirmation_tag_from_own_commit(&message)?;
-                let mut decrypted_message = self.handle_own_commit(backend, ct).await?;
-                decrypted_message.buffered_messages = if !restore_pending {
-                    None
-                } else {
-                    self.decrypt_and_clear_pending_messages(client, backend, parent_conv)
-                        .await?
-                };
-                return Ok(decrypted_message);
+        let parsed_message = self.parse_message(backend, message.clone())?;
+
+        let message_result = self.process_message(backend, parsed_message).await;
+
+        // Handles the case where we receive our own commits.
+        if let Err(Error::Mls(crate::MlsError {
+            source:
+                crate::MlsErrorKind::MlsMessageError(ProcessMessageError::InvalidCommit(StageCommitError::OwnCommit)),
+            ..
+        })) = message_result
+        {
+            let ct = self.extract_confirmation_tag_from_own_commit(&message)?;
+            let mut decrypted_message = self.handle_own_commit(backend, ct).await?;
+            // can't use `.then` because async
+            debug_assert!(
+                decrypted_message.buffered_messages.is_none(),
+                "decrypted message should be constructed with empty buffer"
+            );
+            if restore_pending {
+                decrypted_message.buffered_messages = self
+                    .decrypt_and_clear_pending_messages(client, backend, parent_conv)
+                    .await?;
             }
-            Ok(processed_message) => Ok(processed_message),
-            Err(e) => Err(e),
-        }?;
+
+            return Ok(decrypted_message);
+        }
+
+        // In this error case, we have a missing proposal, so we need to buffer the commit.
+        // We can't do that here--we don't have the appropriate data in scope--but we can at least
+        // produce the proper error and return that, so our caller can handle it.
+        if let Err(Error::Mls(crate::MlsError {
+            source:
+                crate::MlsErrorKind::MlsMessageError(ProcessMessageError::InvalidCommit(StageCommitError::MissingProposal)),
+            ..
+        })) = message_result
+        {
+            return Err(Error::BufferedCommit);
+        }
+
+        let message = message_result?;
 
         let credential = message.credential();
         let epoch = message.epoch();
@@ -196,6 +224,38 @@ impl MlsConversation {
 
                 self.group.store_pending_proposal(*proposal);
 
+                if let Some(commit) =
+                    self.retrieve_buffered_commit(backend)
+                        .await
+                        .map_err(RecursiveError::mls_conversation(
+                            "retrieving buffered commit while handling proposal",
+                        ))?
+                {
+                    let process_result = self
+                        .try_process_buffered_commit(commit, parent_conv, client, backend, restore_pending)
+                        .await;
+
+                    if process_result.is_ok() {
+                        self.clear_buffered_commit(backend)
+                            .await
+                            .map_err(RecursiveError::mls_conversation(
+                                "clearing buffered commit after successful application",
+                            ))?;
+                    }
+                    // If we got back a buffered commit error, then we still don't have enough proposals.
+                    // In that case, we want to just proceed as normal for this proposal.
+                    //
+                    // In any other case, the result from the commit overrides the result from the proposal.
+                    if !matches!(process_result, Err(Error::BufferedCommit)) {
+                        // either the commit applied successfully, in which case its return value
+                        // should override the return value from the proposal, or it raised some kind
+                        // of error, in which case the caller needs to know about that.
+                        return process_result
+                            .map_err(RecursiveError::mls_conversation("processing buffered commit"))
+                            .map_err(Into::into);
+                    }
+                }
+
                 MlsConversationDecryptMessage {
                     app_msg: None,
                     proposals: vec![],
@@ -211,7 +271,6 @@ impl MlsConversation {
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
                 self.validate_commit(&staged_commit, backend).await?;
 
-                #[allow(clippy::needless_collect)] // false positive
                 let pending_proposals = self.self_pending_proposals().cloned().collect::<Vec<_>>();
 
                 let proposal_refs: Vec<Proposal> = pending_proposals
@@ -259,12 +318,13 @@ impl MlsConversation {
                     .renew_proposals_for_current_epoch(client, backend, proposals_to_renew.into_iter(), needs_update)
                     .await?;
 
-                let buffered_messages = if !restore_pending {
-                    None
-                } else {
-                    self.decrypt_and_clear_pending_messages(client, backend, parent_conv)
-                        .await?
-                };
+                // can't use `.then` because async
+                let mut buffered_messages = None;
+                if restore_pending {
+                    buffered_messages = self
+                        .decrypt_and_clear_pending_messages(client, backend, parent_conv)
+                        .await?;
+                }
 
                 info!(
                     group_id = Obfuscated::from(&self.id),
@@ -318,29 +378,93 @@ impl MlsConversation {
         Ok(decrypted)
     }
 
+    /// Cache the bytes of a pending commit in the backend.
+    ///
+    /// By storing the raw commit bytes and doing deserialization/decryption from scratch, we preserve all
+    /// security guarantees. When we do restore, it's as though the commit had simply been received later.
+    async fn buffer_pending_commit(&self, backend: &MlsCryptoProvider, commit: impl AsRef<[u8]>) -> Result<()> {
+        info!(group_id = Obfuscated::from(&self.id); "buffering pending commit");
+
+        let pending_commit = MlsBufferedCommit::new(self.id.clone(), commit.as_ref().to_owned());
+
+        backend
+            .key_store()
+            .save(pending_commit)
+            .await
+            .map_err(KeystoreError::wrap("buffering pending commit"))?;
+        Ok(())
+    }
+
+    /// Retrieve the bytes of a pending commit.
+    async fn retrieve_buffered_commit(&self, backend: &MlsCryptoProvider) -> Result<Option<Vec<u8>>> {
+        info!(group_id = Obfuscated::from(&self.id); "attempting to retrieve pending commit");
+
+        backend
+            .keystore()
+            .find::<MlsBufferedCommit>(&self.id)
+            .await
+            .map(|option| option.map(MlsBufferedCommit::into_commit_data))
+            .map_err(KeystoreError::wrap("attempting to retrieve buffered commit"))
+            .map_err(Into::into)
+    }
+
+    /// Try to apply a buffered commit.
+    ///
+    /// This is largely a convenience function which handles deserializing the message, and
+    /// gives a convenient point around which we can add context to errors. However, it's also
+    /// a place where we can introduce a pin, given that we're otherwise doing a recursive
+    /// async call, which would result in an infinitely-sized future.
+    async fn try_process_buffered_commit(
+        &mut self,
+        commit: impl AsRef<[u8]>,
+        parent_conv: Option<&GroupStoreValue<MlsConversation>>,
+        client: &Client,
+        backend: &MlsCryptoProvider,
+        restore_pending: bool,
+    ) -> Result<MlsConversationDecryptMessage> {
+        info!(group_id = Obfuscated::from(&self.id); "attempting to process pending commit");
+
+        let message =
+            MlsMessageIn::tls_deserialize(&mut commit.as_ref()).map_err(Error::tls_deserialize("mls message in"))?;
+
+        Box::pin(self.decrypt_message(message, parent_conv, client, backend, restore_pending)).await
+    }
+
+    /// Remove the buffered commit for this conversation; it has been applied.
+    async fn clear_buffered_commit(&self, backend: &MlsCryptoProvider) -> Result<()> {
+        info!(group_id = Obfuscated::from(&self.id); "attempting to delete pending commit");
+
+        backend
+            .keystore()
+            .remove::<MlsBufferedCommit, _>(&self.id)
+            .await
+            .map_err(KeystoreError::wrap("attempting to clear buffered commit"))
+            .map_err(Into::into)
+    }
+
     async fn decrypt_and_clear_pending_messages(
         &mut self,
         client: &Client,
         backend: &MlsCryptoProvider,
         parent_conv: Option<&GroupStoreValue<MlsConversation>>,
     ) -> Result<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
-        if let Some(pm) = self
+        let pending_messages = self
             .restore_pending_messages(client, backend, parent_conv, false)
-            .await?
-        {
+            .await?;
+
+        if pending_messages.is_some() {
             info!(group_id = Obfuscated::from(&self.id); "Clearing all buffered messages for conversation");
             backend
                 .key_store()
                 .remove::<MlsPendingMessage, _>(self.id())
                 .await
                 .map_err(KeystoreError::wrap("removing MlsPendingMessage from keystore"))?;
-            Ok(Some(pm))
-        } else {
-            Ok(None)
         }
+
+        Ok(pending_messages)
     }
 
-    async fn parse_message(&mut self, backend: &MlsCryptoProvider, msg_in: MlsMessageIn) -> Result<ProcessedMessage> {
+    fn parse_message(&self, backend: &MlsCryptoProvider, msg_in: MlsMessageIn) -> Result<ParsedMessage> {
         let mut is_duplicate = false;
         let (protocol_message, content_type) = match msg_in.extract() {
             MlsMessageInBody::PublicMessage(m) => {
@@ -358,6 +482,22 @@ impl MlsConversation {
                 )
             }
         };
+        Ok(ParsedMessage {
+            is_duplicate,
+            protocol_message,
+            content_type,
+        })
+    }
+
+    async fn process_message(
+        &mut self,
+        backend: &MlsCryptoProvider,
+        ParsedMessage {
+            is_duplicate,
+            protocol_message,
+            content_type,
+        }: ParsedMessage,
+    ) -> Result<ProcessedMessage> {
         let msg_epoch = protocol_message.epoch().as_u64();
         let group_epoch = self.group.epoch().as_u64();
         let processed_msg = self
@@ -458,32 +598,38 @@ impl CentralContext {
                 .map_err(Into::into);
         };
         let parent_conversation = self.get_parent_conversation(&conversation).await?;
+
         let client = &self
             .mls_client()
             .await
             .map_err(RecursiveError::root("getting mls client"))?;
-        let decrypt_message = conversation
+        let backend = &self
+            .mls_provider()
+            .await
+            .map_err(RecursiveError::root("getting mls provider"))?;
+
+        let decrypt_message_result = conversation
             .write()
             .await
-            .decrypt_message(
-                msg,
-                parent_conversation.as_ref(),
-                client,
-                &self
-                    .mls_provider()
-                    .await
-                    .map_err(RecursiveError::root("getting mls provider"))?,
-                true,
-            )
+            .decrypt_message(msg, parent_conversation.as_ref(), client, backend, true)
             .await;
 
-        if let Err(Error::BufferedFutureMessage { message_epoch }) = decrypt_message {
-            self.handle_future_message(id, message).await?;
+        if let Err(Error::BufferedFutureMessage { message_epoch }) = decrypt_message_result {
+            self.handle_future_message(id, message.as_ref()).await?;
             info!(group_id = Obfuscated::from(id); "Buffered future message from epoch {message_epoch}");
-            return decrypt_message;
         }
 
-        let decrypt_message = decrypt_message?;
+        // In the inner `decrypt_message` above, we raise the `BufferedCommit` error, but we only handle it here.
+        // That's because in that scope we don't have access to the raw message bytes; here, we do.
+        if let Err(Error::BufferedCommit) = decrypt_message_result {
+            conversation
+                .read()
+                .await
+                .buffer_pending_commit(backend, message)
+                .await?;
+        }
+
+        let decrypt_message = decrypt_message_result?;
 
         if !decrypt_message.is_active {
             self.wipe_conversation(id).await?;

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -690,12 +690,11 @@ mod tests {
                             .await
                             .unwrap();
                         // So Charlie has not been added to the group
-                        assert!(alice_central
+                        assert!(!alice_central
                             .get_conversation_unchecked(&id)
                             .await
                             .members()
-                            .get(&b"charlie".to_vec())
-                            .is_none());
+                            .contains_key(b"charlie".as_slice()));
                         // Make sure we are suggesting a commit delay
                         assert!(delay.is_some());
 
@@ -727,16 +726,14 @@ mod tests {
                             .get_conversation_unchecked(&id)
                             .await
                             .members()
-                            .get::<Vec<u8>>(&charlie_central.get_client_id().await.to_vec())
-                            .is_some());
+                            .contains_key::<Vec<u8>>(&charlie_central.get_client_id().await.to_vec()));
 
                         // Bob also has Charlie in the group
                         assert!(bob_central
                             .get_conversation_unchecked(&id)
                             .await
                             .members()
-                            .get::<Vec<u8>>(&charlie_central.get_client_id().await.to_vec())
-                            .is_some());
+                            .contains_key::<Vec<u8>>(&charlie_central.get_client_id().await.to_vec()));
                         assert!(decrypted.has_epoch_changed);
                     })
                 },

--- a/crypto/src/mls/conversation/error.rs
+++ b/crypto/src/mls/conversation/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     MessageEpochTooOld,
     #[error("Incoming message is from a prior epoch")]
     StaleMessage,
+    #[error("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.")]
+    BufferedCommit,
     #[error("Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives")]
     BufferedFutureMessage { message_epoch: u64 },
     #[error("Incoming message is from an epoch too far in the future to buffer.")]

--- a/crypto/src/test_utils/context.rs
+++ b/crypto/src/test_utils/context.rs
@@ -147,12 +147,12 @@ impl ClientContext {
             .context
             .encrypt_message(id, msg)
             .await
-            .map_err(RecursiveError::mls_conversation("encrypting message"))?;
+            .map_err(RecursiveError::mls_conversation("encrypting message; self -> other"))?;
         let decrypted = other
             .context
             .decrypt_message(id, encrypted)
             .await
-            .map_err(RecursiveError::mls_conversation("decrypting message"))?
+            .map_err(RecursiveError::mls_conversation("decrypting message; other <- self"))?
             .app_msg
             .ok_or(TestError::ImplementationError)?;
         assert_eq!(&msg[..], &decrypted[..]);
@@ -162,12 +162,12 @@ impl ClientContext {
             .context
             .encrypt_message(id, msg)
             .await
-            .map_err(RecursiveError::mls_conversation("encrypting message"))?;
+            .map_err(RecursiveError::mls_conversation("encrypting message; other -> self"))?;
         let decrypted = self
             .context
             .decrypt_message(id, encrypted)
             .await
-            .map_err(RecursiveError::mls_conversation("decrypting message"))?
+            .map_err(RecursiveError::mls_conversation("decrypting message; self <- other"))?
             .app_msg
             .ok_or(TestError::ImplementationError)?;
         assert_eq!(&msg[..], &decrypted[..]);

--- a/keystore/src/connection/platform/generic/migrations/V14__buffered_commits.sql
+++ b/keystore/src/connection/platform/generic/migrations/V14__buffered_commits.sql
@@ -1,0 +1,4 @@
+CREATE TABLE mls_buffered_commits (
+    conversation_id_hex TEXT UNIQUE,
+    commit_data BLOB
+);

--- a/keystore/src/entities/mls.rs
+++ b/keystore/src/entities/mls.rs
@@ -91,6 +91,48 @@ pub struct MlsPendingMessage {
     pub message: Vec<u8>,
 }
 
+/// Entity representing a buffered commit.
+///
+/// There should always exist either 0 or 1 of these in the store per conversation.
+/// Commits are buffered if not all proposals they reference have yet been received.
+///
+/// We don't automatically zeroize on drop because the commit data is still encrypted at this point;
+/// it is not risky to leave it in memory.
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, core_crypto_macros::Entity)]
+#[cfg_attr(
+    any(target_family = "wasm", feature = "serde"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct MlsBufferedCommit {
+    // we'd ideally just call this field `conversation_id`, but as of right now the
+    // Entity macro does not yet support id columns not named `id`
+    #[id(hex, column = "conversation_id_hex")]
+    conversation_id: Vec<u8>,
+    commit_data: Vec<u8>,
+}
+
+impl MlsBufferedCommit {
+    /// Create a new `Self` from conversation id and the commit data.
+    pub fn new(conversation_id: Vec<u8>, commit_data: Vec<u8>) -> Self {
+        Self {
+            conversation_id,
+            commit_data,
+        }
+    }
+
+    pub fn conversation_id(&self) -> &[u8] {
+        &self.conversation_id
+    }
+
+    pub fn commit_data(&self) -> &[u8] {
+        &self.commit_data
+    }
+
+    pub fn into_commit_data(self) -> Vec<u8> {
+        self.commit_data
+    }
+}
+
 /// Entity representing a persisted `Credential`
 #[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
 #[zeroize(drop)]

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -35,6 +35,8 @@ pub enum MissingKeyErrorKind {
     MlsPskBundle,
     #[error("MLS CredentialBundle")]
     MlsCredential,
+    #[error("MLS Buffered Commit")]
+    MlsBufferedCommit,
     #[error("MLS Persisted Group")]
     PersistedMlsGroup,
     #[error("MLS Persisted Pending Group")]

--- a/keystore/src/transaction/dynamic_dispatch.rs
+++ b/keystore/src/transaction/dynamic_dispatch.rs
@@ -4,9 +4,9 @@
 use crate::connection::TransactionWrapper;
 use crate::entities::{
     ConsumerData, E2eiAcmeCA, E2eiCrl, E2eiEnrollment, E2eiIntermediateCert, E2eiRefreshToken, EntityBase,
-    EntityTransactionExt, MlsCredential, MlsEncryptionKeyPair, MlsEpochEncryptionKeyPair, MlsHpkePrivateKey,
-    MlsKeyPackage, MlsPendingMessage, MlsPskBundle, MlsSignatureKeyPair, PersistedMlsGroup, PersistedMlsPendingGroup,
-    StringEntityId, UniqueEntity,
+    EntityTransactionExt, MlsBufferedCommit, MlsCredential, MlsEncryptionKeyPair, MlsEpochEncryptionKeyPair,
+    MlsHpkePrivateKey, MlsKeyPackage, MlsPendingMessage, MlsPskBundle, MlsSignatureKeyPair, PersistedMlsGroup,
+    PersistedMlsPendingGroup, StringEntityId, UniqueEntity,
 };
 #[cfg(feature = "proteus-keystore")]
 use crate::entities::{ProteusIdentity, ProteusPrekey, ProteusSession};
@@ -22,6 +22,7 @@ pub enum Entity {
     EncryptionKeyPair(MlsEncryptionKeyPair),
     MlsEpochEncryptionKeyPair(MlsEpochEncryptionKeyPair),
     MlsCredential(MlsCredential),
+    MlsBufferedCommit(MlsBufferedCommit),
     PersistedMlsGroup(PersistedMlsGroup),
     PersistedMlsPendingGroup(PersistedMlsPendingGroup),
     MlsPendingMessage(MlsPendingMessage),
@@ -47,6 +48,7 @@ pub enum EntityId {
     EncryptionKeyPair(Vec<u8>),
     EpochEncryptionKeyPair(Vec<u8>),
     MlsCredential(Vec<u8>),
+    MlsBufferedCommit(Vec<u8>),
     PersistedMlsGroup(Vec<u8>),
     PersistedMlsPendingGroup(Vec<u8>),
     MlsPendingMessage(Vec<u8>),
@@ -73,6 +75,7 @@ impl EntityId {
             EntityId::EncryptionKeyPair(vec) => vec.as_slice().into(),
             EntityId::EpochEncryptionKeyPair(vec) => vec.as_slice().into(),
             EntityId::MlsCredential(vec) => vec.as_slice().into(),
+            EntityId::MlsBufferedCommit(vec) => vec.as_slice().into(),
             EntityId::PersistedMlsGroup(vec) => vec.as_slice().into(),
             EntityId::PersistedMlsPendingGroup(vec) => vec.as_slice().into(),
             EntityId::MlsPendingMessage(vec) => vec.as_slice().into(),
@@ -98,6 +101,7 @@ impl EntityId {
             MlsPskBundle::COLLECTION_NAME => Ok(Self::PskBundle(id.into())),
             MlsEncryptionKeyPair::COLLECTION_NAME => Ok(Self::EncryptionKeyPair(id.into())),
             MlsEpochEncryptionKeyPair::COLLECTION_NAME => Ok(Self::EpochEncryptionKeyPair(id.into())),
+            MlsBufferedCommit::COLLECTION_NAME => Ok(Self::MlsBufferedCommit(id.into())),
             PersistedMlsGroup::COLLECTION_NAME => Ok(Self::PersistedMlsGroup(id.into())),
             PersistedMlsPendingGroup::COLLECTION_NAME => Ok(Self::PersistedMlsPendingGroup(id.into())),
             MlsCredential::COLLECTION_NAME => Ok(Self::MlsCredential(id.into())),
@@ -125,6 +129,7 @@ impl EntityId {
             EntityId::EncryptionKeyPair(_) => MlsEncryptionKeyPair::COLLECTION_NAME,
             EntityId::EpochEncryptionKeyPair(_) => MlsEpochEncryptionKeyPair::COLLECTION_NAME,
             EntityId::MlsCredential(_) => MlsCredential::COLLECTION_NAME,
+            EntityId::MlsBufferedCommit(_) => MlsBufferedCommit::COLLECTION_NAME,
             EntityId::PersistedMlsGroup(_) => PersistedMlsGroup::COLLECTION_NAME,
             EntityId::PersistedMlsPendingGroup(_) => PersistedMlsPendingGroup::COLLECTION_NAME,
             EntityId::MlsPendingMessage(_) => MlsPendingMessage::COLLECTION_NAME,
@@ -156,6 +161,7 @@ pub async fn execute_save(tx: &TransactionWrapper<'_>, entity: &Entity) -> Crypt
             mls_epoch_encryption_key_pair.save(tx).await
         }
         Entity::MlsCredential(mls_credential) => mls_credential.save(tx).await,
+        Entity::MlsBufferedCommit(mls_pending_commit) => mls_pending_commit.save(tx).await,
         Entity::PersistedMlsGroup(persisted_mls_group) => persisted_mls_group.save(tx).await,
         Entity::PersistedMlsPendingGroup(persisted_mls_pending_group) => persisted_mls_pending_group.save(tx).await,
         Entity::MlsPendingMessage(mls_pending_message) => mls_pending_message.save(tx).await,
@@ -182,6 +188,7 @@ pub async fn execute_delete(tx: &TransactionWrapper<'_>, entity_id: &EntityId) -
         id @ EntityId::EncryptionKeyPair(_) => MlsEncryptionKeyPair::delete(tx, id.as_id()).await,
         id @ EntityId::EpochEncryptionKeyPair(_) => MlsEpochEncryptionKeyPair::delete(tx, id.as_id()).await,
         id @ EntityId::MlsCredential(_) => MlsCredential::delete(tx, id.as_id()).await,
+        id @ EntityId::MlsBufferedCommit(_) => MlsBufferedCommit::delete(tx, id.as_id()).await,
         id @ EntityId::PersistedMlsGroup(_) => PersistedMlsGroup::delete(tx, id.as_id()).await,
         id @ EntityId::PersistedMlsPendingGroup(_) => PersistedMlsPendingGroup::delete(tx, id.as_id()).await,
         id @ EntityId::MlsPendingMessage(_) => MlsPendingMessage::delete(tx, id.as_id()).await,


### PR DESCRIPTION
After creating a test replicating [the 15810 scenario](https://wearezeta.atlassian.net/browse/WPB-15810). Turns out that one key issue was that clients who received a commit prior to a referenced proposal were just giving up. This PR fixes that issue by adding the capability to buffer one commit per conversation. When there is a buffered commit, it is re-attempted each time a proposal arrives until it succeeds.

Clients still need to watch out for desync! If the required proposal is simply never delivered, the client will lag behind until the epoch changes again, at which point they can prove desync. This fix solves everything under the hood, in the expected case that all messages are delivered, and reorderings don't delay any single message by more than a few seconds. 

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
