### PR TITLE
DO NOT MERGE: attempt 3 to backport commit buffering

### DIFF
--- a/crypto-ffi/bindings/js/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/CoreCrypto.ts
@@ -20,12 +20,13 @@ import initWasm, {
     ConversationConfiguration as ConversationConfigurationFfi,
     CoreCrypto as CoreCryptoFfi,
     CoreCryptoContext as CoreCryptoContextFfi,
-    CoreCryptoWasmCallbacks,
+    WasmMlsTransportResponse,
     CoreCryptoWasmLogger,
     CustomConfiguration as CustomConfigurationFfi,
     E2eiDumpedPkiEnv,
     NewAcmeAuthz,
     NewAcmeOrder,
+    MlsTransportProvider,
 } from "./wasm";
 
 import CoreCryptoContext from "./CoreCryptoContext";
@@ -822,54 +823,23 @@ export interface ExternalAddProposalArgs extends ExternalProposalArgs {
     credentialType: CredentialType;
 }
 
-export interface CoreCryptoCallbacks {
+export interface MlsTransport {
     /**
-     * This callback is called by CoreCrypto to know whether a given clientId is authorized to "write"
-     * in the given conversationId. Think of it as a "isAdmin" callback conceptually
+     * This callback is called by CoreCrypto to send a commit bundle to the delivery service.
      *
-     * This callback exists because there are many business cases where CoreCrypto doesn't have enough knowledge
-     * (such as what can exist on a backend) to inform the decision
-     *
-     * @param conversationId - id of the group/conversation
-     * @param clientId - id of the client performing an operation requiring authorization
-     * @returns whether the user is authorized by the logic layer to perform the operation
+     * @param commitBundle - the commit bundle
+     * @returns a promise resolving to a {@link WasmMlsTransportResponse}
      */
-    authorize: (
-        conversationId: Uint8Array,
-        clientId: Uint8Array
-    ) => Promise<boolean>;
+    sendCommitBundle: (
+        commitBundle: CommitBundle
+    ) => Promise<WasmMlsTransportResponse>;
 
     /**
-     * A mix between {@link authorize} and {@link clientIsExistingGroupUser}. We currently use this callback to verify
-     * external commits to join a group ; in such case, the client has to:
-     * * first, belong to a user which is already in the MLS group (similar to {@link clientIsExistingGroupUser})
-     * * then, this user should be authorized to "write" in the given conversation (similar to {@link authorize})
-     *
-     * @param conversationId - id of the group/conversation
-     * @param externalClientId - id of the client performing an operation requiring authorization
-     * @param existingClients - all the clients currently within the MLS group
-     * @returns true if the external client is authorized to write to the conversation
+     *  This callback is called by CoreCrypto to send a regular message to the delivery service.
+     * @param message
+     * @returns a promise resolving to a {@link WasmMlsTransportResponse}
      */
-    userAuthorize: (
-        conversationId: Uint8Array,
-        externalClientId: Uint8Array,
-        existingClients: Uint8Array[]
-    ) => Promise<boolean>;
-
-    /**
-     * Callback to ensure that the given `clientId` belongs to one of the provided `existingClients`
-     * This basically allows to defer the client ID parsing logic to the caller - because CoreCrypto is oblivious to such things
-     *
-     * @param conversationId - id of the group/conversation
-     * @param clientId - id of a client
-     * @param existingClients - all the clients currently within the MLS group
-     */
-    clientIsExistingGroupUser: (
-        conversationId: Uint8Array,
-        clientId: Uint8Array,
-        existingClients: Uint8Array[],
-        parent_conversation_clients?: Uint8Array[]
-    ) => Promise<boolean>;
+    sendMessage: (message: Uint8Array) => Promise<WasmMlsTransportResponse>;
 }
 
 /**
@@ -1191,22 +1161,23 @@ export class CoreCrypto {
     }
 
     /**
-     * Registers the callbacks for CoreCrypto to use in order to gain additional information
+     * Registers the transport callbacks for core crypto to give it access to backend endpoints for sending
+     * a commit bundle or a message, respectively.
      *
-     * @param callbacks - Any interface following the {@link CoreCryptoCallbacks} interface
+     * @param transportProvider - Any interface following the {@link MlsTransport} interface
      */
-    async registerCallbacks(
-        callbacks: CoreCryptoCallbacks,
+    async provideTransport(
+        transportProvider: MlsTransport,
         ctx: unknown = null
     ): Promise<void> {
         try {
-            const wasmCallbacks = new CoreCryptoWasmCallbacks(
-                callbacks.authorize,
-                callbacks.userAuthorize,
-                callbacks.clientIsExistingGroupUser,
-                ctx
+            await this.#cc.provide_transport(
+                new MlsTransportProvider(
+                    transportProvider.sendCommitBundle,
+                    transportProvider.sendMessage,
+                    ctx
+                )
             );
-            await this.#cc.set_callbacks(wasmCallbacks);
         } catch (e) {
             throw CoreCryptoError.fromStdError(e as Error);
         }

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoCentral.kt
@@ -6,22 +6,20 @@ import java.io.File
 
 typealias EnrollmentHandle = ByteArray
 
-private class Callbacks : CoreCryptoCallbacks {
+/**
+ * You must implement this interface and pass the implementing object to [CoreCrypto.provideTransport].
+ * CoreCrypto uses it to communicate with the delivery service.
+ */
+interface MlsTransport : com.wire.crypto.uniffi.MlsTransport {
+    /**
+     * Send a message to the delivery service.
+     */
+    override suspend fun sendMessage(mlsMessage: ByteArray): MlsTransportResponse
 
-    override suspend fun authorize(conversationId: ByteArray, clientId: ByteArray): Boolean = true
-
-    override suspend fun userAuthorize(
-        conversationId: ByteArray,
-        externalClientId: ByteArray,
-        existingClients: List<ByteArray>,
-    ): Boolean = true
-
-    override suspend fun clientIsExistingGroupUser(
-        conversationId: ByteArray,
-        clientId: ByteArray,
-        existingClients: List<ByteArray>,
-        parentConversationClients: List<ByteArray>?,
-    ): Boolean = true
+    /**
+     * Send a commit bundle to the delivery service.
+     */
+    override suspend fun sendCommitBundle(commitBundle: CommitBundle): MlsTransportResponse
 }
 
 /**
@@ -397,7 +395,6 @@ private constructor(internal val cc: CoreCrypto, private val rootDir: String) {
             val path = "$rootDir/$KEYSTORE_NAME"
             File(rootDir).mkdirs()
             val cc = coreCryptoDeferredInit(path, databaseKey)
-            cc.setCallbacks(Callbacks())
             return CoreCryptoCentral(cc, rootDir)
         }
     }

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoContext.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/CoreCryptoContext.kt
@@ -782,8 +782,9 @@ class CoreCryptoContext(private val cc: CoreCryptoContext) {
         cc.proteusInit()
     }
 
-
-
+    suspend fun provideTransport(transport: MlsTransport) {
+        cc.provideTransport(transport)
+    }
 
     private fun toPreKey(id: UShort, data: ByteArray): PreKey = PreKey(id, data)
 

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -837,67 +837,64 @@ impl From<MlsCredentialType> for core_crypto::prelude::MlsCredentialType {
     }
 }
 
-#[derive(Debug)]
-struct CoreCryptoCallbacksWrapper(std::sync::Arc<dyn CoreCryptoCallbacks>);
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Enum)]
+pub enum MlsTransportResponse {
+    /// The message was accepted by the distribution service
+    Success,
+    /// A client should have consumed all incoming messages before re-trying.
+    Retry,
+    /// The message was rejected by the distribution service and there's no recovery.
+    Abort { reason: String },
+}
 
-#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-impl core_crypto::prelude::CoreCryptoCallbacks for CoreCryptoCallbacksWrapper {
-    async fn authorize(&self, conversation_id: Vec<u8>, client_id: core_crypto::prelude::ClientId) -> bool {
-        self.0.authorize(conversation_id, ClientId(client_id)).await
-    }
-    async fn user_authorize(
-        &self,
-        conversation_id: Vec<u8>,
-        external_client_id: core_crypto::prelude::ClientId,
-        existing_clients: Vec<core_crypto::prelude::ClientId>,
-    ) -> bool {
-        self.0
-            .user_authorize(
-                conversation_id,
-                ClientId(external_client_id),
-                existing_clients.into_iter().map(ClientId).collect(),
-            )
-            .await
-    }
-    async fn client_is_existing_group_user(
-        &self,
-        conversation_id: Vec<u8>,
-        client_id: core_crypto::prelude::ClientId,
-        existing_clients: Vec<core_crypto::prelude::ClientId>,
-        parent_conversation_clients: Option<Vec<core_crypto::prelude::ClientId>>,
-    ) -> bool {
-        self.0
-            .client_is_existing_group_user(
-                conversation_id,
-                ClientId(client_id),
-                existing_clients.into_iter().map(ClientId).collect(),
-                parent_conversation_clients.map(|pccs| pccs.into_iter().map(ClientId).collect()),
-            )
-            .await
+impl From<MlsTransportResponse> for core_crypto::MlsTransportResponse {
+    fn from(value: MlsTransportResponse) -> Self {
+        match value {
+            MlsTransportResponse::Success => Self::Success,
+            MlsTransportResponse::Retry => Self::Retry,
+            MlsTransportResponse::Abort { reason } => Self::Abort { reason },
+        }
     }
 }
 
-/// This is needed instead of the original trait ([core_crypto::CoreCryptoCallbacks]) to use the
-/// custom type [ClientId], that UniFFi can handle.
+impl From<core_crypto::MlsTransportResponse> for MlsTransportResponse {
+    fn from(value: core_crypto::MlsTransportResponse) -> Self {
+        match value {
+            core_crypto::MlsTransportResponse::Success => Self::Success,
+            core_crypto::MlsTransportResponse::Retry => Self::Retry,
+            core_crypto::MlsTransportResponse::Abort { reason } => Self::Abort { reason },
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MlsTransportWrapper(Arc<dyn MlsTransport>);
+
+#[async_trait::async_trait]
+impl core_crypto::prelude::MlsTransport for MlsTransportWrapper {
+    async fn send_commit_bundle(
+        &self,
+        commit_bundle: MlsCommitBundle,
+    ) -> Result<core_crypto::MlsTransportResponse, Box<dyn std::error::Error>> {
+        let commit_bundle = CommitBundle::try_from(commit_bundle)?;
+        Ok(self.0.send_commit_bundle(commit_bundle).await.into())
+    }
+
+    async fn send_message(
+        &self,
+        mls_message: Vec<u8>,
+    ) -> Result<core_crypto::MlsTransportResponse, Box<dyn std::error::Error>> {
+        Ok(self.0.send_message(mls_message).await.into())
+    }
+}
+
+/// This is needed instead of the original trait ([core_crypto::CoreCryptoTransport]) to use types
+/// that we export via uniffi.
 #[uniffi::export(with_foreign)]
-#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-pub trait CoreCryptoCallbacks: std::fmt::Debug + Send + Sync {
-    async fn authorize(&self, conversation_id: Vec<u8>, client_id: ClientId) -> bool;
-    async fn user_authorize(
-        &self,
-        conversation_id: Vec<u8>,
-        external_client_id: ClientId,
-        existing_clients: Vec<ClientId>,
-    ) -> bool;
-    async fn client_is_existing_group_user(
-        &self,
-        conversation_id: Vec<u8>,
-        client_id: ClientId,
-        existing_clients: Vec<ClientId>,
-        parent_conversation_clients: Option<Vec<ClientId>>,
-    ) -> bool;
+#[async_trait::async_trait]
+pub trait MlsTransport: std::fmt::Debug + Send + Sync {
+    async fn send_commit_bundle(&self, commit_bundle: CommitBundle) -> MlsTransportResponse;
+    async fn send_message(&self, mls_message: Vec<u8>) -> MlsTransportResponse;
 }
 
 static INIT_LOGGER: Once = Once::new();
@@ -1190,10 +1187,10 @@ impl CoreCrypto {
         }
     }
 
-    /// See [core_crypto::mls::MlsCentral::callbacks]
-    pub async fn set_callbacks(&self, callbacks: std::sync::Arc<dyn CoreCryptoCallbacks>) -> CoreCryptoResult<()> {
+    /// See [core_crypto::mls::MlsCentral::provide_transport]
+    pub async fn provide_transport(&self, callbacks: Arc<dyn MlsTransport>) -> CoreCryptoResult<()> {
         self.central
-            .callbacks(std::sync::Arc::new(CoreCryptoCallbacksWrapper(callbacks)))
+            .provide_transport(Arc::new(MlsTransportWrapper(callbacks)))
             .await;
         Ok(())
     }

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 
 use crate::proteus_impl;
 use core_crypto::prelude::*;
-use core_crypto::CryptoError;
+use core_crypto::{CryptoError, MlsTransportResponse};
 use futures_util::future::TryFutureExt;
 use js_sys::{Promise, Uint8Array};
 use log::kv::{Key, Value, Visitor};
@@ -191,6 +191,13 @@ pub(crate) enum InternalError {
     TransactionFailed {
         uncaught_error: JsValue,
         proteus_error_code: Option<u16>,
+    },
+    #[error(
+        "Error during transport callback execution. Attempted operation: {attempted_operation:?}. JsError: {error:?}"
+    )]
+    TransportError {
+        attempted_operation: String,
+        error: JsValue,
     },
 }
 
@@ -1334,133 +1341,142 @@ impl log::Log for CoreCryptoWasmLogger {
     fn flush(&self) {}
 }
 
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-/// see [core_crypto::prelude::CoreCryptoCallbacks]
-pub struct CoreCryptoWasmCallbacks {
-    authorize: std::sync::Arc<async_lock::RwLock<js_sys::Function>>,
-    user_authorize: std::sync::Arc<async_lock::RwLock<js_sys::Function>>,
-    client_is_existing_group_user: std::sync::Arc<async_lock::RwLock<js_sys::Function>>,
-    ctx: std::sync::Arc<async_lock::RwLock<JsValue>>,
+#[derive(serde::Serialize, serde::Deserialize)]
+#[wasm_bindgen(inspectable)]
+pub enum MlsTransportResponseVariant {
+    Success,
+    Retry,
+    Abort,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[wasm_bindgen(inspectable)]
+pub struct WasmMlsTransportResponse {
+    variant: MlsTransportResponseVariant,
+    abort_reason: Option<String>,
 }
 
 #[wasm_bindgen]
-impl CoreCryptoWasmCallbacks {
+impl WasmMlsTransportResponse {
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        authorize: js_sys::Function,
-        user_authorize: js_sys::Function,
-        client_is_existing_group_user: js_sys::Function,
-        ctx: JsValue,
-    ) -> Self {
-        #[allow(clippy::arc_with_non_send_sync)] // see https://github.com/rustwasm/wasm-bindgen/pull/955
-        Self {
-            authorize: std::sync::Arc::new(authorize.into()),
-            user_authorize: std::sync::Arc::new(user_authorize.into()),
-            client_is_existing_group_user: std::sync::Arc::new(client_is_existing_group_user.into()),
-            ctx: std::sync::Arc::new(ctx.into()),
+    pub fn new(variant: MlsTransportResponseVariant, abort_reason: Option<String>) -> WasmMlsTransportResponse {
+        WasmMlsTransportResponse { variant, abort_reason }
+    }
+}
+
+impl From<WasmMlsTransportResponse> for MlsTransportResponse {
+    fn from(response: WasmMlsTransportResponse) -> Self {
+        match response.variant {
+            MlsTransportResponseVariant::Success => MlsTransportResponse::Success,
+            MlsTransportResponseVariant::Retry => MlsTransportResponse::Retry,
+            MlsTransportResponseVariant::Abort => MlsTransportResponse::Abort {
+                reason: response.abort_reason.unwrap_or_default(),
+            },
         }
     }
 }
 
-impl CoreCryptoWasmCallbacks {
-    async fn drive_js_func_call(result: Result<JsValue, JsValue>) -> Result<bool, JsValue> {
+impl From<MlsTransportResponse> for WasmMlsTransportResponse {
+    fn from(response: MlsTransportResponse) -> Self {
+        match response {
+            MlsTransportResponse::Success => WasmMlsTransportResponse {
+                variant: MlsTransportResponseVariant::Success,
+                abort_reason: None,
+            },
+            MlsTransportResponse::Retry => WasmMlsTransportResponse {
+                variant: MlsTransportResponseVariant::Retry,
+                abort_reason: None,
+            },
+            MlsTransportResponse::Abort { reason } => WasmMlsTransportResponse {
+                variant: MlsTransportResponseVariant::Abort,
+                abort_reason: (!reason.is_empty()).then_some(reason),
+            },
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+/// see [core_crypto::prelude::MlsTransport]
+pub struct MlsTransportProvider {
+    send_commit_bundle: Arc<async_lock::RwLock<js_sys::Function>>,
+    send_message: Arc<async_lock::RwLock<js_sys::Function>>,
+    ctx: Arc<async_lock::RwLock<JsValue>>,
+}
+
+#[wasm_bindgen]
+impl MlsTransportProvider {
+    #[wasm_bindgen(constructor)]
+    pub fn new(send_commit_bundle: js_sys::Function, send_message: js_sys::Function, ctx: JsValue) -> Self {
+        #[allow(clippy::arc_with_non_send_sync)] // see https://github.com/rustwasm/wasm-bindgen/pull/955
+        Self {
+            send_commit_bundle: Arc::new(send_commit_bundle.into()),
+            send_message: Arc::new(send_message.into()),
+            ctx: Arc::new(ctx.into()),
+        }
+    }
+}
+
+impl MlsTransportProvider {
+    async fn drive_js_func_call(result: Result<JsValue, JsValue>) -> Result<WasmMlsTransportResponse, JsValue> {
         let value = result?;
-        let promise: js_sys::Promise = match value.dyn_into() {
+        let promise: Promise = match value.dyn_into() {
             Ok(promise) => promise,
             Err(e) => {
                 web_sys::console::warn_1(&js_sys::JsString::from(
                     r#"
-[CoreCrypto] One or more callbacks are not returning a `Promise`
-
-They will thus be automatically coerced into returning `false`.
+[CoreCrypto] One or more transport functions are not returning a `Promise`
 Please make all callbacks `async` or manually return a `Promise` via `Promise.resolve(boolean)`"#,
                 ));
                 return Err(e);
             }
         };
         let fut = wasm_bindgen_futures::JsFuture::from(promise);
+        let result = fut.await?;
+        let result = serde_wasm_bindgen::from_value(result)?;
 
-        fut.await.map(|jsval| jsval.as_bool().unwrap_or_default())
+        Ok(result)
     }
 }
 
 // SAFETY: All callback instances are wrapped into Arc<RwLock> so this is safe to mark
-unsafe impl Send for CoreCryptoWasmCallbacks {}
-unsafe impl Sync for CoreCryptoWasmCallbacks {}
+unsafe impl Send for MlsTransportProvider {}
+unsafe impl Sync for MlsTransportProvider {}
 unsafe impl Send for CoreCryptoWasmLogger {}
 unsafe impl Sync for CoreCryptoWasmLogger {}
 
 #[async_trait::async_trait(?Send)]
-impl CoreCryptoCallbacks for CoreCryptoWasmCallbacks {
-    async fn authorize(&self, conversation_id: ConversationId, client_id: ClientId) -> bool {
-        let authorize = self.authorize.read().await;
+impl MlsTransport for MlsTransportProvider {
+    async fn send_commit_bundle(
+        &self,
+        commit_bundle: MlsCommitBundle,
+    ) -> Result<MlsTransportResponse, Box<dyn std::error::Error>> {
+        let send_commit_bundle = self.send_commit_bundle.read().await;
         let this = self.ctx.read().await;
-
-        Self::drive_js_func_call(authorize.call2(
-            &this,
-            &js_sys::Uint8Array::from(conversation_id.as_slice()),
-            &js_sys::Uint8Array::from(client_id.as_slice()),
-        ))
-        .await
-        .unwrap_or_default()
+        let commit_bundle = CommitBundle::try_from(commit_bundle)?;
+        Ok(
+            Self::drive_js_func_call(send_commit_bundle.call1(&this, &commit_bundle.into()))
+                .await
+                .map_err(|e| InternalError::TransportError {
+                    attempted_operation: "send_message".into(),
+                    error: e,
+                })?
+                .into(),
+        )
     }
 
-    async fn user_authorize(
-        &self,
-        conversation_id: ConversationId,
-        external_client_id: ClientId,
-        existing_clients: Vec<ClientId>,
-    ) -> bool {
-        let user_authorize = self.user_authorize.read().await;
+    async fn send_message(&self, mls_message: Vec<u8>) -> Result<MlsTransportResponse, Box<dyn std::error::Error>> {
+        let send_message = self.send_message.read().await;
         let this = self.ctx.read().await;
-        let clients = existing_clients
-            .into_iter()
-            .map(|client| js_sys::Uint8Array::from(client.as_slice()))
-            .collect::<js_sys::Array>();
-
-        Self::drive_js_func_call(user_authorize.call3(
-            &this,
-            &js_sys::Uint8Array::from(conversation_id.as_slice()),
-            &js_sys::Uint8Array::from(external_client_id.as_slice()),
-            &clients,
-        ))
-        .await
-        .unwrap_or_default()
-    }
-
-    async fn client_is_existing_group_user(
-        &self,
-        conversation_id: ConversationId,
-        client_id: ClientId,
-        existing_clients: Vec<ClientId>,
-        parent_conversation_clients: Option<Vec<ClientId>>,
-    ) -> bool {
-        let client_is_existing_group_user = self.client_is_existing_group_user.read().await;
-        let this = self.ctx.read().await;
-        let clients = existing_clients
-            .into_iter()
-            .map(|client| js_sys::Uint8Array::from(client.as_slice()))
-            .collect::<js_sys::Array>();
-
-        let parent_clients = parent_conversation_clients.map(|clients| {
-            clients
-                .into_iter()
-                .map(|client_id| js_sys::Uint8Array::from(client_id.as_slice()))
-                .collect::<js_sys::Array>()
-        });
-
-        Self::drive_js_func_call(client_is_existing_group_user.apply(
-            &this,
-            &js_sys::Array::of4(
-                &js_sys::Uint8Array::from(conversation_id.as_slice()).into(),
-                &js_sys::Uint8Array::from(client_id.as_slice()).into(),
-                &clients.into(),
-                &parent_clients.into(),
-            ),
-        ))
-        .await
-        .unwrap_or_default()
+        let mls_message = js_sys::Uint8Array::from(mls_message.as_slice());
+        Ok(Self::drive_js_func_call(send_message.call1(&this, &mls_message))
+            .await
+            .map_err(|e| InternalError::TransportError {
+                attempted_operation: "send_message".into(),
+                error: e,
+            })?
+            .into())
     }
 }
 
@@ -1610,12 +1626,12 @@ impl CoreCrypto {
 
     /// Returns: [`WasmCryptoResult<()>`]
     ///
-    /// see [core_crypto::mls::MlsCentral::callbacks]
-    pub fn set_callbacks(&self, callbacks: CoreCryptoWasmCallbacks) -> Promise {
+    /// see [core_crypto::mls::MlsCentral::provide_transport]
+    pub fn provide_transport(&self, callbacks: MlsTransportProvider) -> Promise {
         let central = self.inner.clone();
         future_to_promise(
             async move {
-                central.callbacks(std::sync::Arc::new(callbacks)).await;
+                central.provide_transport(Arc::new(callbacks)).await;
 
                 WasmCryptoResult::Ok(JsValue::UNDEFINED)
             }

--- a/crypto/src/context.rs
+++ b/crypto/src/context.rs
@@ -88,9 +88,9 @@ impl CentralContext {
         }
     }
 
-    // This is going to be needed soon.
-    #[expect(dead_code)]
-    pub(crate) async fn transport(&self) -> CryptoResult<RwLockReadGuardArc<Option<Arc<dyn MlsTransport + 'static>>>> {
+    pub(crate) async fn mls_transport(
+        &self,
+    ) -> CryptoResult<RwLockReadGuardArc<Option<Arc<dyn MlsTransport + 'static>>>> {
         match self.state.read().await.deref() {
             ContextState::Valid {
                 transport: callbacks, ..
@@ -99,8 +99,6 @@ impl CentralContext {
         }
     }
 
-    // This is going to be needed soon.
-    #[expect(dead_code)]
     #[cfg(test)]
     pub(crate) async fn set_transport_callbacks(
         &self,

--- a/crypto/src/e2e_identity/conversation_state.rs
+++ b/crypto/src/e2e_identity/conversation_state.rs
@@ -381,8 +381,8 @@ mod tests {
                     .find_local_intermediate_ca();
                 let cert = CertificateBundle::new_with_default_values(intermediate_ca, Some(expiration_time));
                 let cb = Client::new_x509_credential_bundle(cert.clone()).unwrap();
-                let commit = alice_central.context.e2ei_rotate(&id, Some(&cb)).await.unwrap().commit;
-                alice_central.context.commit_accepted(&id).await.unwrap();
+                alice_central.context.e2ei_rotate(&id, Some(&cb)).await.unwrap();
+                let commit = alice_central.mls_transport.latest_commit().await;
                 bob_central
                     .context
                     .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -453,7 +453,6 @@ mod tests {
                         CertificateBundle::from_certificate_and_issuer(&alice_cert.certificate, alice_intermediate_ca);
                     let cb = Client::new_x509_credential_bundle(cert_bundle.clone()).unwrap();
                     alice_central.context.e2ei_rotate(&id, Some(&cb)).await.unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
 
                     let alice_client = alice_central.client().await;
                     let alice_provider = alice_central.context.mls_provider().await.unwrap();

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -122,6 +122,11 @@ pub enum CryptoError {
     /// Incoming message is from a prior epoch
     #[error("Incoming message is from a prior epoch")]
     StaleMessage,
+    /// Incoming message is a commit for which we have not yet received all the proposals.
+    ///
+    /// Buffering until all proposals have arrived.
+    #[error("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.")]
+    BufferedCommit,
     /// Incoming message is from an epoch too far in the future to buffer.
     #[error("Incoming message is from an epoch too far in the future to buffer.")]
     WrongEpoch,

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -113,18 +113,6 @@ pub enum CryptoError {
     /// Standard I/O Error
     #[error(transparent)]
     IoError(#[from] std::io::Error),
-    /// Authorization error
-    #[error("The current client id isn't authorized to perform this action")]
-    Unauthorized,
-    /// Callbacks are not provided
-    #[error("The callbacks needed for CoreCrypto to operate were not set")]
-    CallbacksNotSet,
-    /// External Add Proposal Validation failed
-    #[error("External add proposal validation failed: only users already in the group are allowed")]
-    UnauthorizedExternalAddProposal,
-    /// External Commit sender was not authorized to perform such
-    #[error("External Commit sender was not authorized to perform such")]
-    UnauthorizedExternalCommit,
     /// A supplied [`openmls::ciphersuite::hash_ref::HashReference`] is not of the expected size: 16
     #[error("A supplied reference is not of the expected size: 16")]
     InvalidHashReference,

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -122,12 +122,9 @@ pub enum MlsTransportResponse {
 #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub trait MlsTransport: std::fmt::Debug + Send + Sync {
     /// Send a commit bundle to the corresponding endpoint.
-    async fn send_commit_bundle(
-        &self,
-        commit_bundle: MlsCommitBundle,
-    ) -> Result<MlsTransportResponse, Box<dyn std::error::Error>>;
+    async fn send_commit_bundle(&self, commit_bundle: MlsCommitBundle) -> Result<MlsTransportResponse>;
     /// Send a message to the corresponding endpoint.
-    async fn send_message(&self, mls_message: Vec<u8>) -> Result<MlsTransportResponse, Box<dyn std::error::Error>>;
+    async fn send_message(&self, mls_message: Vec<u8>) -> Result<MlsTransportResponse>;
 }
 
 #[derive(Debug)]

--- a/crypto/src/mls/buffer_external_commit.rs
+++ b/crypto/src/mls/buffer_external_commit.rs
@@ -185,7 +185,6 @@ mod tests {
 
                     // Alice will never see this commit
                     bob_central.context.update_keying_material(&id).await.unwrap();
-                    bob_central.context.commit_accepted(&id).await.unwrap();
 
                     let msg1 = bob_central.context.encrypt_message(&id, "A").await.unwrap();
                     let msg2 = bob_central.context.encrypt_message(&id, "B").await.unwrap();

--- a/crypto/src/mls/client/key_package.rs
+++ b/crypto/src/mls/client/key_package.rs
@@ -367,7 +367,7 @@ impl CentralContext {
     }
 
     /// Prunes local KeyPackages after making sure they also have been deleted on the backend side
-    /// You should only use this after [CentralContext::e2ei_rotate_all]
+    /// You should only use this after [CentralContext::save_x509_credential]
     #[cfg_attr(test, crate::dispotent)]
     pub async fn delete_keypackages(&self, refs: &[KeyPackageRef]) -> CryptoResult<()> {
         if refs.is_empty() {
@@ -472,7 +472,7 @@ mod tests {
 
                 let _rotate_bundle = client_context
                     .context
-                    .e2ei_rotate_all(&mut enrollment, cert_chain, 5)
+                    .save_x509_credential(&mut enrollment, cert_chain)
                     .await
                     .unwrap();
 

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -413,4 +413,212 @@ mod tests {
         )
         .await
     }
+
+    /// Replicating [WPB-15810]
+    ///
+    /// [WPB-15810]: https://wearezeta.atlassian.net/browse/WPB-15810
+    #[apply(all_cred_cipher)]
+    async fn wpb_15810(case: TestCase) {
+        use openmls::{
+            group::GroupId,
+            prelude::{ExternalProposal, SenderExtensionIndex},
+        };
+
+        use crate::mls;
+
+        if case.is_pure_ciphertext() {
+            // The use case tested here requires inspecting your own commit.
+            // Openmls does not support this currently when protocol messages are encrypted.
+            return;
+        }
+        run_test_with_client_ids(
+            case.clone(),
+            ["external_0", "new_member", "member_27", "observer", "114", "115"],
+            move |[external_0, new_member, member_27, observer, member_114, member_115]| {
+                Box::pin(async move {
+                    // scenario start: everyone except "new_member" is in the conversation
+                    let conv_id = conversation_id();
+
+                    // set up external_0 as the backend / delivery service
+                    let signature_key = external_0.client_signature_key(&case).await.as_slice().to_vec();
+                    let mut config = case.cfg.clone();
+                    observer
+                        .context
+                        .set_raw_external_senders(&mut config, vec![signature_key])
+                        .await
+                        .unwrap();
+
+                    // create and initialize the conversation
+                    observer
+                        .context
+                        .new_conversation(&conv_id, case.credential_type, config)
+                        .await
+                        .unwrap();
+
+                    // everyone else except new_member joins (also except observer, who created it)
+                    observer
+                        .invite_all(&case, &conv_id, [&member_114, &member_115, &member_27])
+                        .await
+                        .unwrap();
+
+                    // Everyone should agree on the overall state here, to wit: the group consists of everyone
+                    // except "new_member", and "external_0", and no messages have been sent.
+                    // At this point only the observer is going to receive messages, because that shouldn't impact group state.
+
+                    // external 0 sends a proposal to remove 114
+                    let leaf_of_114 = observer.index_of(&conv_id, member_114.get_client_id().await).await;
+                    let sender_index = SenderExtensionIndex::new(0);
+                    let sc = case.signature_scheme();
+                    let ct = case.credential_type;
+                    let cb = external_0.find_most_recent_credential_bundle(sc, ct).await.unwrap();
+                    let group_id = GroupId::from_slice(&conv_id[..]);
+                    let epoch = observer.get_conversation_unchecked(&conv_id).await.group.epoch();
+                    let proposal_remove_114_1 = ExternalProposal::new_remove(
+                        leaf_of_114,
+                        group_id.clone(),
+                        epoch,
+                        &cb.signature_key,
+                        sender_index,
+                    )
+                    .unwrap();
+
+                    // now bump the epoch in external_0: the new member has joined
+                    let new_member_join_commit = new_member
+                        .create_unmerged_external_commit(
+                            observer.get_group_info(&conv_id).await,
+                            case.custom_cfg(),
+                            case.credential_type,
+                        )
+                        .await
+                        .commit;
+
+                    new_member
+                        .context
+                        .merge_pending_group_from_external_commit(&conv_id)
+                        .await
+                        .unwrap();
+
+                    // also create the same proposal with the epoch increased by 1
+                    let leaf_of_114 = new_member.index_of(&conv_id, member_114.get_client_id().await).await;
+                    let proposal_remove_114_2 = ExternalProposal::new_remove(
+                        leaf_of_114,
+                        group_id.clone(),
+                        (epoch.as_u64() + 1).into(),
+                        &cb.signature_key,
+                        sender_index,
+                    )
+                    .unwrap();
+
+                    // now our observer receives these messages out of order
+                    println!("observer executing first proposal");
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    println!("observer executing second proposal");
+                    let result = observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { message_epoch: 2 }
+                    ));
+                    println!("executing commit adding new user");
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &new_member_join_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // now the new member receives the messages in order
+                    println!("new_member executing first proposal");
+                    assert!(matches!(
+                        new_member
+                            .context
+                            .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                            .await
+                            .unwrap_err(),
+                        CryptoError::StaleProposal,
+                    ));
+                    println!("new_member executing second proposal");
+                    new_member
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // now let's switch to the perspective of member 27
+                    // they have observed exactly one of the "remove 114" proposals,
+                    // plus a "remove 115" proposal. We can assume that they observe the 2nd
+                    // "remove 114" proposal because they advanced the epoch correctly when
+                    // the new member was added.
+                    let leaf_of_115 = observer.index_of(&conv_id, member_115.get_client_id().await).await;
+                    let epoch = observer.get_conversation_unchecked(&conv_id).await.group.epoch();
+                    let proposal_remove_115 =
+                        ExternalProposal::new_remove(leaf_of_115, group_id, epoch, &cb.signature_key, sender_index)
+                            .unwrap();
+
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    let result = member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { message_epoch: 2 }
+                    ));
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &new_member_join_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    member_27.context.commit_pending_proposals(&conv_id).await.unwrap();
+                    let remove_two_members_commit = member_27.mls_transport.latest_commit().await;
+
+                    // In this case, note that observer receives the proposal before the commit.
+                    // This is the straightforward ordering and easy to deal with.
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &remove_two_members_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // In this case, new_member receives the commit before the proposal. This means that
+                    // the commit has to be buffered until the proposal it references is received.
+                    let result = new_member
+                        .context
+                        .decrypt_message(&conv_id, &remove_two_members_commit.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(result.unwrap_err(), CryptoError::BufferedCommit));
+                    new_member
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    observer.try_talk_to(&conv_id, &new_member).await.unwrap();
+                    observer.try_talk_to(&conv_id, &member_27).await.unwrap();
+                    new_member.try_talk_to(&conv_id, &member_27).await.unwrap();
+                })
+            },
+        )
+        .await
+    }
 }

--- a/crypto/src/mls/conversation/commit.rs
+++ b/crypto/src/mls/conversation/commit.rs
@@ -42,12 +42,6 @@ impl CentralContext {
         key_packages: Vec<KeyPackageIn>,
     ) -> CryptoResult<MlsConversationCreationMessage> {
         let client = self.mls_client().await?;
-        if let Some(callbacks) = self.callbacks().await?.as_ref() {
-            let client_id = client.id().await?;
-            if !callbacks.authorize(id.clone(), client_id).await {
-                return Err(CryptoError::Unauthorized);
-            }
-        }
         self.get_conversation(id)
             .await?
             .write()
@@ -76,12 +70,6 @@ impl CentralContext {
         clients: &[ClientId],
     ) -> CryptoResult<MlsCommitBundle> {
         let client = self.mls_client().await?;
-        if let Some(callbacks) = self.callbacks().await?.as_ref() {
-            let client_id = client.id().await?;
-            if !callbacks.authorize(id.clone(), client_id).await {
-                return Err(CryptoError::Unauthorized);
-            }
-        }
         self.get_conversation(id)
             .await?
             .write()

--- a/crypto/src/mls/conversation/commit.rs
+++ b/crypto/src/mls/conversation/commit.rs
@@ -21,6 +21,62 @@ use crate::{
 };
 
 impl CentralContext {
+    pub(crate) async fn send_and_merge_commit(
+        &self,
+        conversation: &mut MlsConversation,
+        commit: MlsCommitBundle,
+    ) -> Result<()> {
+        match self.send_commit(commit).await {
+            Ok(()) => {
+                conversation
+                    .commit_accepted(
+                        &self
+                            .mls_provider()
+                            .await
+                            .map_err(RecursiveError::root("getting mls provider"))?,
+                    )
+                    .await
+            }
+            Err(e @ Error::MessageRejected { .. }) => {
+                conversation
+                    .clear_pending_commit(
+                        &self
+                            .mls_provider()
+                            .await
+                            .map_err(RecursiveError::root("getting mls provider"))?,
+                    )
+                    .await?;
+                Err(e)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub(crate) async fn send_commit(&self, commit: MlsCommitBundle) -> Result<()> {
+        let guard = self
+            .mls_transport()
+            .await
+            .map_err(RecursiveError::root("getting mls transport"))?;
+        let transport = guard.as_ref().ok_or::<Error>(
+            RecursiveError::root("getting mls transport")(crate::Error::MlsTransportNotProvided).into(),
+        )?;
+        loop {
+            match transport
+                .send_commit_bundle(commit.clone())
+                .await
+                .map_err(RecursiveError::root("sending commit bundle"))?
+            {
+                MlsTransportResponse::Success => {
+                    return Ok(());
+                }
+                MlsTransportResponse::Abort { reason } => {
+                    return Err(Error::MessageRejected { reason });
+                }
+                MlsTransportResponse::Retry => {}
+            }
+        }
+    }
+
     /// Adds new members to the group/conversation
     ///
     /// # Arguments
@@ -40,14 +96,25 @@ impl CentralContext {
         &self,
         id: &ConversationId,
         key_packages: Vec<KeyPackageIn>,
-    ) -> CryptoResult<MlsConversationCreationMessage> {
+    ) -> Result<NewCrlDistributionPoint> {
         let client = self.mls_client().await?;
-        self.get_conversation(id)
-            .await?
-            .write()
-            .await
+        let conversation = self.get_conversation(id).await?;
+        let mut conversation_guard = conversation.write().await;
+
+        let message = conversation_guard
             .add_members(&client, key_packages, &self.mls_provider().await?)
-            .await
+            .await?;
+
+        let commit = MlsCommitBundle {
+            commit: message.commit,
+            welcome: Some(message.welcome),
+            group_info: message.group_info,
+        };
+
+        self.send_and_merge_commit(&mut conversation_guard, commit.clone())
+            .await?;
+
+        Ok(message.crl_new_distribution_points)
     }
 
     /// Removes clients from the group/conversation.
@@ -68,14 +135,14 @@ impl CentralContext {
         &self,
         id: &ConversationId,
         clients: &[ClientId],
-    ) -> CryptoResult<MlsCommitBundle> {
+    ) -> CryptoResult<()> {
         let client = self.mls_client().await?;
-        self.get_conversation(id)
-            .await?
-            .write()
-            .await
+        let conversation = self.get_conversation(id).await?;
+        let mut conversation_guard = conversation.write().await;
+        let commit = conversation_guard
             .remove_members(&client, clients, &self.mls_provider().await?)
-            .await
+            .await?;
+        self.send_and_merge_commit(&mut conversation_guard, commit).await
     }
 
     /// Self updates the KeyPackage and automatically commits. Pending proposals will be commited
@@ -92,14 +159,14 @@ impl CentralContext {
     /// If the conversation can't be found, an error will be returned. Other errors are originating
     /// from OpenMls and the KeyStore
     #[cfg_attr(test, crate::idempotent)]
-    pub async fn update_keying_material(&self, id: &ConversationId) -> CryptoResult<MlsCommitBundle> {
+    pub async fn update_keying_material(&self, id: &ConversationId) -> CryptoResult<()> {
         let client = self.mls_client().await?;
-        self.get_conversation(id)
-            .await?
-            .write()
-            .await
+        let conversation = self.get_conversation(id).await?;
+        let mut conversation_guard = conversation.write().await;
+        let commit = conversation_guard
             .update_keying_material(&client, &self.mls_provider().await?, None, None)
-            .await
+            .await?;
+        self.send_and_merge_commit(&mut conversation_guard, commit).await
     }
 
     /// Commits all pending proposals of the group
@@ -113,14 +180,17 @@ impl CentralContext {
     /// # Errors
     /// Errors can be originating from the KeyStore and OpenMls
     #[cfg_attr(test, crate::idempotent)]
-    pub async fn commit_pending_proposals(&self, id: &ConversationId) -> CryptoResult<Option<MlsCommitBundle>> {
+    pub async fn commit_pending_proposals(&self, id: &ConversationId) -> CryptoResult<()> {
         let client = self.mls_client().await?;
-        self.get_conversation(id)
-            .await?
-            .write()
-            .await
+        let conversation = self.get_conversation(id).await?;
+        let mut conversation_guard = conversation.write().await;
+        let commit = conversation_guard
             .commit_pending_proposals(&client, &self.mls_provider().await?)
-            .await
+            .await?;
+        let Some(commit) = commit else {
+            return Ok(());
+        };
+        self.send_and_merge_commit(&mut conversation_guard, commit).await
     }
 }
 
@@ -253,26 +323,26 @@ impl MlsConversation {
         client: &Client,
         backend: &MlsCryptoProvider,
     ) -> CryptoResult<Option<MlsCommitBundle>> {
-        if self.group.pending_proposals().count() > 0 {
-            let signer = &self.find_most_recent_credential_bundle(client).await?.signature_key;
-
-            let (commit, welcome, gi) = self
-                .group
-                .commit_to_pending_proposals(backend, signer)
-                .await
-                .map_err(MlsError::from)?;
-            let group_info = MlsGroupInfoBundle::try_new_full_plaintext(gi.unwrap())?;
-
-            self.persist_group_when_changed(&backend.keystore(), false).await?;
-
-            Ok(Some(MlsCommitBundle {
-                welcome,
-                commit,
-                group_info,
-            }))
-        } else {
-            Ok(None)
+        if self.group.pending_proposals().count() == 0 {
+            return Ok(None);
         }
+
+        let signer = &self.find_most_recent_credential_bundle(client).await?.signature_key;
+
+        let (commit, welcome, gi) = self
+            .group
+            .commit_to_pending_proposals(backend, signer)
+            .await
+            .map_err(MlsError::from)?;
+        let group_info = MlsGroupInfoBundle::try_new_full_plaintext(gi.unwrap())?;
+
+        self.persist_group_when_changed(&backend.keystore(), false).await?;
+
+        Ok(Some(MlsCommitBundle {
+            welcome,
+            commit,
+            group_info,
+        }))
     }
 }
 
@@ -347,6 +417,7 @@ mod tests {
 
     mod add_members {
         use super::*;
+        use std::sync::Arc;
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
@@ -361,15 +432,32 @@ mod tests {
                         .await
                         .unwrap();
                     let bob = bob_central.rand_key_package(&case).await;
-                    let MlsConversationCreationMessage { welcome, .. } = alice_central
+                    // First, abort commit transport
+                    alice_central
+                        .context
+                        .set_transport_callbacks(Some(Arc::<CoreCryptoTransportAbortProvider>::default()))
+                        .await
+                        .unwrap();
+                    alice_central
+                        .context
+                        .add_members_to_conversation(&id, vec![bob.clone()])
+                        .await
+                        .unwrap_err();
+
+                    // commit is not applied
+                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
+
+                    let success_provider = Arc::<CoreCryptoTransportSuccessProvider>::default();
+                    alice_central
+                        .context
+                        .set_transport_callbacks(Some(success_provider.clone()))
+                        .await
+                        .unwrap();
+                    alice_central
                         .context
                         .add_members_to_conversation(&id, vec![bob])
                         .await
                         .unwrap();
-
-                    // before merging, commit is not applied
-                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
-                    alice_central.context.commit_accepted(&id).await.unwrap();
 
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.id, id);
                     assert_eq!(
@@ -382,10 +470,10 @@ mod tests {
                         id
                     );
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
-
+                    let commit = success_provider.latest_commit_bundle().await;
                     bob_central
                         .context
-                        .process_welcome_message(welcome.into(), case.custom_cfg())
+                        .process_welcome_message(commit.welcome.unwrap().into(), case.custom_cfg())
                         .await
                         .unwrap();
                     assert_eq!(
@@ -412,13 +500,18 @@ mod tests {
                         .unwrap();
 
                     let bob = bob_central.rand_key_package(&case).await;
-                    let welcome = alice_central
+                    alice_central
                         .context
                         .add_members_to_conversation(&id, vec![bob])
                         .await
-                        .unwrap()
-                        .welcome;
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                        .unwrap();
+
+                    let welcome = alice_central
+                        .mls_transport
+                        .latest_commit_bundle()
+                        .await
+                        .welcome
+                        .unwrap();
 
                     bob_central
                         .context
@@ -447,13 +540,13 @@ mod tests {
                             .unwrap();
 
                         let bob = bob_central.rand_key_package(&case).await;
-                        let commit_bundle = alice_central
+                        alice_central
                             .context
                             .add_members_to_conversation(&id, vec![bob])
                             .await
                             .unwrap();
+                        let commit_bundle = alice_central.mls_transport.latest_commit_bundle().await;
                         let group_info = commit_bundle.group_info.get_group_info();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
 
                         assert!(guest_central
                             .try_join_from_group_info(&case, &id, group_info, vec![&alice_central])
@@ -483,16 +576,15 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    let MlsCommitBundle { commit, welcome, .. } = alice_central
+                    alice_central
                         .context
                         .remove_members_from_conversation(&id, &[bob_central.get_client_id().await])
                         .await
                         .unwrap();
+                    let MlsCommitBundle { commit, welcome, .. } =
+                        alice_central.mls_transport.latest_commit_bundle().await;
                     assert!(welcome.is_none());
 
-                    // before merging, commit is not applied
-                    assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
-                    alice_central.context.commit_accepted(&id).await.unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
 
                     bob_central
@@ -540,21 +632,16 @@ mod tests {
                             .await
                             .unwrap();
 
-                        let welcome = alice_central
+                        alice_central
                             .context
                             .remove_members_from_conversation(&id, &[bob_central.get_client_id().await])
                             .await
-                            .unwrap()
-                            .welcome;
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                            .unwrap();
+
+                        let welcome = alice_central.mls_transport.latest_welcome_message().await;
 
                         assert!(guest_central
-                            .try_join_from_welcome(
-                                &id,
-                                welcome.unwrap().into(),
-                                case.custom_cfg(),
-                                vec![&alice_central]
-                            )
+                            .try_join_from_welcome(&id, welcome.into(), case.custom_cfg(), vec![&alice_central])
                             .await
                             .is_ok());
                         // because Bob has been removed from the group
@@ -582,13 +669,14 @@ mod tests {
                             .unwrap();
                         alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                        let commit_bundle = alice_central
+                        alice_central
                             .context
                             .remove_members_from_conversation(&id, &[bob_central.get_client_id().await])
                             .await
                             .unwrap();
 
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                        let commit_bundle = alice_central.mls_transport.latest_commit_bundle().await;
+
                         let group_info = commit_bundle.group_info.get_group_info();
 
                         assert!(guest_central
@@ -639,18 +727,10 @@ mod tests {
                         .await;
 
                     // proposing the key update for alice
+                    alice_central.context.update_keying_material(&id).await.unwrap();
                     let MlsCommitBundle { commit, welcome, .. } =
-                        alice_central.context.update_keying_material(&id).await.unwrap();
+                        alice_central.mls_transport.latest_commit_bundle().await;
                     assert!(welcome.is_none());
-
-                    // before merging, commit is not applied
-                    assert!(alice_central
-                        .get_conversation_unchecked(&id)
-                        .await
-                        .encryption_keys()
-                        .contains(&alice_key));
-
-                    alice_central.context.commit_accepted(&id).await.unwrap();
 
                     assert!(!alice_central
                         .get_conversation_unchecked(&id)
@@ -737,16 +817,17 @@ mod tests {
                             .await
                             .unwrap();
 
-                        // performing an update on Alice's key. this should generate a welcome for Charlie
-                        let MlsCommitBundle { commit, welcome, .. } =
-                            alice_central.context.update_keying_material(&id).await.unwrap();
-                        assert!(welcome.is_some());
                         assert!(alice_central
                             .get_conversation_unchecked(&id)
                             .await
                             .encryption_keys()
                             .contains(&alice_key));
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+
+                        // performing an update on Alice's key. this should generate a welcome for Charlie
+                        alice_central.context.update_keying_material(&id).await.unwrap();
+                        let MlsCommitBundle { commit, welcome, .. } =
+                            alice_central.mls_transport.latest_commit_bundle().await;
+                        assert!(welcome.is_some());
                         assert!(!alice_central
                             .get_conversation_unchecked(&id)
                             .await
@@ -825,9 +906,9 @@ mod tests {
                             .await
                             .unwrap();
 
+                        alice_central.context.update_keying_material(&id).await.unwrap();
                         let MlsCommitBundle { commit, welcome, .. } =
-                            alice_central.context.update_keying_material(&id).await.unwrap();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                            alice_central.mls_transport.latest_commit_bundle().await;
 
                         bob_central
                             .context
@@ -866,9 +947,9 @@ mod tests {
                             .unwrap();
                         alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                        let commit_bundle = alice_central.context.update_keying_material(&id).await.unwrap();
-                        let group_info = commit_bundle.group_info.get_group_info();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                        alice_central.context.update_keying_material(&id).await.unwrap();
+                        let group_info = alice_central.mls_transport.latest_group_info().await;
+                        let group_info = group_info.get_group_info();
 
                         assert!(guest_central
                             .try_join_from_group_info(&case, &id, group_info, vec![&alice_central])
@@ -905,15 +986,10 @@ mod tests {
                             .unwrap();
                         assert!(!alice_central.pending_proposals(&id).await.is_empty());
                         assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
-                        let MlsCommitBundle { welcome, .. } = alice_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
                         assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
+                        let welcome = alice_central.mls_transport.latest_commit_bundle().await.welcome;
                         bob_central
                             .context
                             .process_welcome_message(welcome.unwrap().into(), case.custom_cfg())
@@ -923,29 +999,6 @@ mod tests {
                     })
                 },
             )
-            .await;
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        async fn should_return_none_when_there_are_no_pending_proposals(case: TestCase) {
-            run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .context
-                        .new_conversation(&id, case.credential_type, case.cfg.clone())
-                        .await
-                        .unwrap();
-                    assert!(alice_central.pending_proposals(&id).await.is_empty());
-                    assert!(alice_central
-                        .context
-                        .commit_pending_proposals(&id)
-                        .await
-                        .unwrap()
-                        .is_none());
-                })
-            })
             .await;
         }
 
@@ -977,13 +1030,8 @@ mod tests {
                             .await
                             .unwrap();
 
-                        let MlsCommitBundle { commit, .. } = alice_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                        let commit = alice_central.mls_transport.latest_commit_bundle().await.commit;
                         assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
                         bob_central
@@ -1015,13 +1063,9 @@ mod tests {
                         .new_add_proposal(&id, bob_central.get_one_key_package(&case).await)
                         .await
                         .unwrap();
-                    let MlsCommitBundle { welcome, .. } = alice_central
-                        .context
-                        .commit_pending_proposals(&id)
-                        .await
-                        .unwrap()
-                        .unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
+
+                    let welcome = alice_central.mls_transport.latest_commit_bundle().await.welcome;
 
                     bob_central
                         .context
@@ -1053,14 +1097,9 @@ mod tests {
                             .new_add_proposal(&id, bob_central.get_one_key_package(&case).await)
                             .await
                             .unwrap();
-                        let commit_bundle = alice_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
+                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                        let commit_bundle = alice_central.mls_transport.latest_commit_bundle().await;
                         let group_info = commit_bundle.group_info.get_group_info();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
 
                         assert!(guest_central
                             .try_join_from_group_info(&case, &id, group_info, vec![&alice_central])
@@ -1074,8 +1113,6 @@ mod tests {
     }
 
     mod delivery_semantics {
-        use crate::prelude::MlsWirePolicy;
-
         use super::*;
 
         #[apply(all_cred_cipher)]
@@ -1091,12 +1128,12 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    let commit1 = alice_central.context.update_keying_material(&id).await.unwrap().commit;
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit1 = alice_central.mls_transport.latest_commit().await;
                     let commit1 = commit1.to_bytes().unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
-                    let commit2 = alice_central.context.update_keying_material(&id).await.unwrap().commit;
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit2 = alice_central.mls_transport.latest_commit().await;
                     let commit2 = commit2.to_bytes().unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
 
                     // fails when a commit is skipped
                     let out_of_order = bob_central.context.decrypt_message(&id, &commit2).await;
@@ -1119,7 +1156,10 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_allow_dropped_commits(case: TestCase) {
+        async fn should_prevent_replayed_encrypted_handshake_messages(case: TestCase) {
+            if !case.is_pure_ciphertext() {
+                return;
+            }
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1130,83 +1170,55 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    let _alice_commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                    let bob_commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
-                    // Bob commit arrives first and has precedence hence Alice's commit is dropped
+                    let proposal1 = alice_central.context.new_update_proposal(&id).await.unwrap().proposal;
+                    let proposal2 = proposal1.clone();
                     alice_central
+                        .get_conversation_unchecked(&id)
+                        .await
+                        .group
+                        .clear_pending_proposals();
+
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit1 = alice_central.mls_transport.latest_commit().await;
+                    let commit2 = commit1.clone();
+
+                    // replayed encrypted proposal should fail
+                    bob_central
                         .context
-                        .decrypt_message(&id, bob_commit.to_bytes().unwrap())
+                        .decrypt_message(&id, proposal1.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    bob_central.context.commit_accepted(&id).await.unwrap();
+                    assert!(matches!(
+                        bob_central
+                            .context
+                            .decrypt_message(&id, proposal2.to_bytes().unwrap())
+                            .await
+                            .unwrap_err(),
+                        Error::DuplicateMessage
+                    ));
+                    bob_central
+                        .get_conversation_unchecked(&id)
+                        .await
+                        .group
+                        .clear_pending_proposals();
+
+                    // replayed encrypted commit should fail
+                    bob_central
+                        .context
+                        .decrypt_message(&id, commit1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    assert!(matches!(
+                        bob_central
+                            .context
+                            .decrypt_message(&id, commit2.to_bytes().unwrap())
+                            .await
+                            .unwrap_err(),
+                        Error::StaleCommit
+                    ));
                 })
             })
             .await;
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        async fn should_prevent_replayed_encrypted_handshake_messages(case: TestCase) {
-            if case.custom_cfg().wire_policy == MlsWirePolicy::Ciphertext {
-                run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_central
-                            .context
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
-
-                        let proposal1 = alice_central.context.new_update_proposal(&id).await.unwrap().proposal;
-                        let proposal2 = proposal1.clone();
-                        alice_central
-                            .get_conversation_unchecked(&id)
-                            .await
-                            .group
-                            .clear_pending_proposals();
-
-                        let commit1 = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                        let commit2 = commit1.clone();
-
-                        // replayed encrypted proposal should fail
-                        bob_central
-                            .context
-                            .decrypt_message(&id, proposal1.to_bytes().unwrap())
-                            .await
-                            .unwrap();
-                        assert!(matches!(
-                            bob_central
-                                .context
-                                .decrypt_message(&id, proposal2.to_bytes().unwrap())
-                                .await
-                                .unwrap_err(),
-                            CryptoError::DuplicateMessage
-                        ));
-                        bob_central
-                            .get_conversation_unchecked(&id)
-                            .await
-                            .group
-                            .clear_pending_proposals();
-
-                        // replayed encrypted commit should fail
-                        bob_central
-                            .context
-                            .decrypt_message(&id, commit1.to_bytes().unwrap())
-                            .await
-                            .unwrap();
-                        assert!(matches!(
-                            bob_central
-                                .context
-                                .decrypt_message(&id, commit2.to_bytes().unwrap())
-                                .await
-                                .unwrap_err(),
-                            CryptoError::StaleCommit
-                        ));
-                    })
-                })
-                .await;
-            }
         }
     }
 }

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -474,7 +474,8 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    let MlsCommitBundle { commit, .. } = bob_central.context.update_keying_material(&id).await.unwrap();
+                    bob_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = bob_central.mls_transport.latest_commit().await;
                     let MlsConversationDecryptMessage { is_active, .. } = alice_central
                         .context
                         .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -499,11 +500,12 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    let MlsCommitBundle { commit, .. } = bob_central
+                    bob_central
                         .context
                         .remove_members_from_conversation(&id, &[alice_central.get_client_id().await])
                         .await
                         .unwrap();
+                    let commit = bob_central.mls_transport.latest_commit().await;
                     let MlsConversationDecryptMessage { is_active, .. } = alice_central
                         .context
                         .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -534,9 +536,8 @@ mod tests {
 
                     let epoch_before = alice_central.context.conversation_epoch(&id).await.unwrap();
 
-                    let MlsCommitBundle { commit, .. } =
-                        alice_central.context.update_keying_material(&id).await.unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = alice_central.mls_transport.latest_commit().await;
 
                     let decrypted = bob_central
                         .context
@@ -552,173 +553,6 @@ mod tests {
                     alice_central.verify_sender_identity(&case, &decrypted).await;
                 })
             })
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_should_clear_pending_commit(case: TestCase) {
-            run_test_with_client_ids(
-                case.clone(),
-                ["alice", "bob", "charlie", "debbie"],
-                move |[alice_central, bob_central, charlie_central, debbie_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_central
-                            .context
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
-
-                        // Alice creates a commit which will be superseded by Bob's one
-                        let charlie = charlie_central.rand_key_package(&case).await;
-                        let debbie = debbie_central.rand_key_package(&case).await;
-                        alice_central
-                            .context
-                            .add_members_to_conversation(&id, vec![charlie.clone()])
-                            .await
-                            .unwrap();
-                        assert!(alice_central.pending_commit(&id).await.is_some());
-
-                        let add_debbie_commit = bob_central
-                            .context
-                            .add_members_to_conversation(&id, vec![debbie.clone()])
-                            .await
-                            .unwrap()
-                            .commit;
-                        let decrypted = alice_central
-                            .context
-                            .decrypt_message(&id, add_debbie_commit.to_bytes().unwrap())
-                            .await
-                            .unwrap();
-                        // Now Debbie should be in members and not Charlie
-                        let members = alice_central.get_conversation_unchecked(&id).await.members();
-
-                        let dc = debbie.unverified_credential();
-                        let debbie_id = dc.credential.identity();
-                        assert!(members.get(debbie_id).is_some());
-
-                        let cc = charlie.unverified_credential();
-                        let charlie_id = cc.credential.identity();
-                        assert!(members.get(charlie_id).is_none());
-
-                        // Previous commit to add Charlie has been discarded but its proposals will be renewed
-                        assert!(alice_central.pending_commit(&id).await.is_none());
-                        assert!(decrypted.has_epoch_changed)
-                    })
-                },
-            )
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_should_renew_proposals_in_pending_commit(case: TestCase) {
-            run_test_with_client_ids(
-                case.clone(),
-                ["alice", "bob", "charlie"],
-                move |[mut alice_central, bob_central, charlie_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_central
-                            .context
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
-
-                        // Alice will create a commit to add Charlie
-                        // Bob will create a commit which will be accepted first by DS so Alice will decrypt it
-                        // Then Alice will renew the proposal in her pending commit
-                        let charlie = charlie_central.rand_key_package(&case).await;
-
-                        let bob_commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
-                        bob_central.context.commit_accepted(&id).await.unwrap();
-
-                        // Alice propose to add Charlie
-                        alice_central
-                            .context
-                            .add_members_to_conversation(&id, vec![charlie.clone()])
-                            .await
-                            .unwrap();
-                        assert!(alice_central.pending_commit(&id).await.is_some());
-
-                        // But first she receives Bob commit
-                        let MlsConversationDecryptMessage { proposals, delay, .. } = alice_central
-                            .context
-                            .decrypt_message(&id, bob_commit.to_bytes().unwrap())
-                            .await
-                            .unwrap();
-                        // So Charlie has not been added to the group
-                        let cc = charlie.unverified_credential();
-                        let charlie_id = cc.credential.identity();
-                        assert!(alice_central
-                            .get_conversation_unchecked(&id)
-                            .await
-                            .members()
-                            .get(charlie_id)
-                            .is_none());
-                        // Make sure we are suggesting a commit delay
-                        assert!(delay.is_some());
-
-                        // But its proposal to add Charlie has been renewed and is also in store
-                        assert!(!proposals.is_empty());
-                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
-                        assert!(alice_central.pending_commit(&id).await.is_none());
-
-                        // Let's commit this proposal to see if it works
-                        for p in proposals {
-                            // But first, proposals have to be fan out to Bob
-                            bob_central
-                                .context
-                                .decrypt_message(&id, p.proposal.to_bytes().unwrap())
-                                .await
-                                .unwrap();
-                        }
-
-                        let MlsCommitBundle { commit, welcome, .. } = alice_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
-                        alice_central.context.commit_accepted(&id).await.unwrap();
-                        // Charlie is now in the group
-                        assert!(alice_central
-                            .get_conversation_unchecked(&id)
-                            .await
-                            .members()
-                            .get(charlie_id)
-                            .is_some());
-
-                        let decrypted = bob_central
-                            .context
-                            .decrypt_message(&id, commit.to_bytes().unwrap())
-                            .await
-                            .unwrap();
-                        // Bob also has Charlie in the group
-                        let cc = charlie.unverified_credential();
-                        let charlie_id = cc.credential.identity();
-                        assert!(bob_central
-                            .get_conversation_unchecked(&id)
-                            .await
-                            .members()
-                            .get(charlie_id)
-                            .is_some());
-                        assert!(decrypted.has_epoch_changed);
-
-                        // Charlie can join with the Welcome from renewed Add proposal
-                        let id = charlie_central
-                            .context
-                            .process_welcome_message(welcome.unwrap().into(), case.custom_cfg())
-                            .await
-                            .unwrap()
-                            .id;
-                        assert!(charlie_central.try_talk_to(&id, &alice_central).await.is_ok());
-                    })
-                },
-            )
             .await
         }
 
@@ -751,8 +585,8 @@ mod tests {
                             .await
                             .unwrap();
 
-                        let MlsCommitBundle { commit, .. } =
-                            bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let MlsConversationDecryptMessage {
                             proposals,
                             delay,
@@ -793,8 +627,8 @@ mod tests {
                         // Alice will create a proposal to add Charlie
                         // Bob will create a commit which Alice will decrypt
                         // Then Alice will renew her proposal
-                        let bob_commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let bob_commit = bob_central.mls_transport.latest_commit().await;
                         let commit_epoch = bob_commit.epoch().unwrap();
 
                         // Alice propose to add Charlie
@@ -834,12 +668,8 @@ mod tests {
                             .await
                             .unwrap();
                         assert_eq!(bob_central.pending_proposals(&id).await.len(), 1);
-                        let MlsCommitBundle { commit, .. } = bob_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
+                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let decrypted = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -854,7 +684,6 @@ mod tests {
                             .is_some());
 
                         // Bob also has Charlie in the group
-                        bob_central.context.commit_accepted(&id).await.unwrap();
                         assert!(bob_central
                             .get_conversation_unchecked(&id)
                             .await
@@ -906,8 +735,8 @@ mod tests {
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
-                        let MlsCommitBundle { commit, .. } =
-                            bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let alice_renewed_proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -935,7 +764,8 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    let commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = alice_central.mls_transport.latest_commit().await;
 
                     let sender_client_id = bob_central
                         .context
@@ -1035,13 +865,7 @@ mod tests {
 
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                         // if 'decrypt_message' is not durable the commit won't contain the add proposal
-                        bob_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
                         assert!(!decrypted.has_epoch_changed);
 
@@ -1143,11 +967,6 @@ mod tests {
                         .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
                         .await
                         .unwrap();
-                    bob_central
-                        .context
-                        .merge_pending_group_from_external_commit(&id)
-                        .await
-                        .unwrap();
 
                     // fails because of Forward Secrecy
                     let decrypt = bob_central.context.decrypt_message(&id, &encrypted).await;
@@ -1171,8 +990,8 @@ mod tests {
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
                     // only Alice will change epoch without notifying Bob
-                    let commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = alice_central.mls_transport.latest_commit().await;
 
                     // Now in epoch 2 Alice will encrypt a message
                     let msg = b"Hello bob";
@@ -1299,8 +1118,8 @@ mod tests {
 
                     // Move group's epoch forward by self updating
                     for _ in 0..MAX_PAST_EPOCHS {
-                        let commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                        alice_central.context.commit_accepted(&id).await.unwrap();
+                        alice_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = alice_central.mls_transport.latest_commit().await;
                         bob_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -1312,8 +1131,8 @@ mod tests {
                     assert_eq!(decrypt.app_msg.unwrap(), b"Hello Bob");
 
                     // Moving the epochs once more should cause an error
-                    let commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = alice_central.mls_transport.latest_commit().await;
                     bob_central
                         .context
                         .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -1356,18 +1175,16 @@ mod tests {
                         .group
                         .clear_pending_proposals();
                     let old_commit = alice_central
-                        .context
-                        .update_keying_material(&id)
+                        .create_unmerged_commit(&id)
                         .await
-                        .unwrap()
                         .commit
                         .to_bytes()
                         .unwrap();
                     alice_central.context.clear_pending_commit(&id).await.unwrap();
 
                     // Now let's jump to next epoch
-                    let commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = alice_central.mls_transport.latest_commit().await;
                     bob_central
                         .context
                         .decrypt_message(&id, commit.to_bytes().unwrap())

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -42,7 +42,7 @@ use crate::{
         ClientId, ConversationId, MlsConversation,
     },
     prelude::{E2eiConversationState, MlsProposalBundle, WireIdentity},
-    CoreCryptoCallbacks, CryptoError, CryptoResult, MlsError,
+    CryptoError, CryptoResult, MlsError,
 };
 
 /// Represents the potential items a consumer might require after passing us an encrypted message we
@@ -124,7 +124,6 @@ impl MlsConversation {
         parent_conv: Option<&GroupStoreValue<MlsConversation>>,
         client: &Client,
         backend: &MlsCryptoProvider,
-        callbacks: Option<&dyn CoreCryptoCallbacks>,
         restore_pending: bool,
     ) -> CryptoResult<MlsConversationDecryptMessage> {
         let message = match self.parse_message(backend, message.clone()).await {
@@ -196,9 +195,6 @@ impl MlsConversation {
                 }
             }
             ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-                self.validate_external_commit(&staged_commit, sender_client_id, parent_conv, backend, callbacks)
-                    .await?;
-
                 self.validate_commit(&staged_commit, backend).await?;
 
                 #[allow(clippy::needless_collect)] // false positive
@@ -245,7 +241,7 @@ impl MlsConversation {
 
                 let buffered_messages = if restore_pending {
                     if let Some(pm) = self
-                        .restore_pending_messages(client, backend, callbacks, parent_conv, false)
+                        .restore_pending_messages(client, backend, parent_conv, false)
                         .await?
                     {
                         info!(group_id = Obfuscated::from(&self.id); "Clearing all buffered messages for conversation");
@@ -278,9 +274,6 @@ impl MlsConversation {
                 }
             }
             ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
-                self.validate_external_proposal(&proposal, parent_conv, callbacks)
-                    .await?;
-
                 info!(
                     group_id = Obfuscated::from(&self.id),
                     sender = Obfuscated::from(proposal.sender());
@@ -427,8 +420,6 @@ impl CentralContext {
             return self.handle_when_group_is_pending(id, message).await;
         };
         let parent_conversation = self.get_parent_conversation(&conversation).await?;
-        let guard = self.callbacks().await?;
-        let callbacks = guard.as_ref().map(|boxed| boxed.as_ref());
         let client = &self.mls_client().await?;
         let decrypt_message = conversation
             .write()
@@ -438,7 +429,6 @@ impl CentralContext {
                 parent_conversation.as_ref(),
                 client,
                 &self.mls_provider().await?,
-                callbacks,
                 true,
             )
             .await;
@@ -462,12 +452,7 @@ impl CentralContext {
 mod tests {
     use wasm_bindgen_test::*;
 
-    use crate::{
-        mls::conversation::config::MAX_PAST_EPOCHS,
-        prelude::MlsCommitBundle,
-        test_utils::{ValidationCallbacks, *},
-        CryptoError,
-    };
+    use crate::{mls::conversation::config::MAX_PAST_EPOCHS, prelude::MlsCommitBundle, test_utils::*, CryptoError};
 
     use super::*;
 
@@ -967,7 +952,6 @@ mod tests {
 
     mod external_proposal {
         use super::*;
-        use std::sync::Arc;
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
@@ -1008,107 +992,6 @@ mod tests {
                         assert!(decrypted.app_msg.is_none());
                         assert!(decrypted.delay.is_some());
                         assert!(!decrypted.has_epoch_changed)
-                    })
-                },
-            )
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        async fn cannot_decrypt_proposal_no_callback(case: TestCase) {
-            run_test_with_client_ids(
-                case.clone(),
-                ["alice", "bob", "alice2"],
-                move |[alice_central, bob_central, alice2_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-
-                        alice_central
-                            .context
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
-
-                        let epoch = alice_central.get_conversation_unchecked(&id).await.group.epoch();
-                        let message = alice2_central
-                            .context
-                            .new_external_add_proposal(id.clone(), epoch, case.ciphersuite(), case.credential_type)
-                            .await
-                            .unwrap();
-
-                        alice_central.context.set_callbacks(None).await.unwrap();
-                        let error = alice_central
-                            .context
-                            .decrypt_message(&id, &message.to_bytes().unwrap())
-                            .await
-                            .unwrap_err();
-
-                        assert!(matches!(error, CryptoError::CallbacksNotSet));
-
-                        bob_central.context.set_callbacks(None).await.unwrap();
-                        let error = bob_central
-                            .context
-                            .decrypt_message(&id, &message.to_bytes().unwrap())
-                            .await
-                            .unwrap_err();
-
-                        assert!(matches!(error, CryptoError::CallbacksNotSet));
-                    })
-                },
-            )
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        async fn cannot_decrypt_proposal_validation(case: TestCase) {
-            run_test_with_client_ids(
-                case.clone(),
-                ["alice", "bob", "alice2"],
-                move |[alice_central, bob_central, alice2_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_central
-                            .context
-                            .set_callbacks(Some(Arc::new(ValidationCallbacks {
-                                client_is_existing_group_user: false,
-                                ..Default::default()
-                            })))
-                            .await
-                            .unwrap();
-
-                        alice_central
-                            .context
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
-
-                        let epoch = alice_central.get_conversation_unchecked(&id).await.group.epoch();
-                        let external_proposal = alice2_central
-                            .context
-                            .new_external_add_proposal(id.clone(), epoch, case.ciphersuite(), case.credential_type)
-                            .await
-                            .unwrap();
-
-                        let error = alice_central
-                            .context
-                            .decrypt_message(&id, &external_proposal.to_bytes().unwrap())
-                            .await
-                            .unwrap_err();
-
-                        assert!(matches!(error, CryptoError::UnauthorizedExternalAddProposal));
-
-                        bob_central.context.set_callbacks(None).await.unwrap();
-                        let error = bob_central
-                            .context
-                            .decrypt_message(&id, &external_proposal.to_bytes().unwrap())
-                            .await
-                            .unwrap_err();
-
-                        assert!(matches!(error, CryptoError::CallbacksNotSet));
                     })
                 },
             )

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -65,11 +65,11 @@ mod tests {
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
                     // an commit to verify that we can still detect wrong epoch correctly
-                    let unknown_commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
+                    let unknown_commit = alice_central.create_unmerged_commit(&id).await.commit;
                     alice_central.context.clear_pending_commit(&id).await.unwrap();
 
-                    let commit = alice_central.context.update_keying_material(&id).await.unwrap().commit;
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    let commit = alice_central.mls_transport.latest_commit().await;
 
                     // decrypt once ... ok
                     bob_central
@@ -113,10 +113,8 @@ mod tests {
 
                 // an external commit to verify that we can still detect wrong epoch correctly
                 let unknown_ext_commit = bob_central
-                    .context
-                    .join_by_external_commit(gi.clone(), case.custom_cfg(), case.credential_type)
+                    .create_unmerged_external_commit(gi.clone(), case.custom_cfg(), case.credential_type)
                     .await
-                    .unwrap()
                     .commit;
                 bob_central
                     .context
@@ -124,17 +122,12 @@ mod tests {
                     .await
                     .unwrap();
 
-                let ext_commit = bob_central
+                bob_central
                     .context
                     .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
                     .await
-                    .unwrap()
-                    .commit;
-                bob_central
-                    .context
-                    .merge_pending_group_from_external_commit(&id)
-                    .await
                     .unwrap();
+                let ext_commit = bob_central.mls_transport.latest_commit().await;
 
                 // decrypt once ... ok
                 alice_central
@@ -192,7 +185,6 @@ mod tests {
 
                 // advance Bob's epoch to trigger failure
                 bob_central.context.commit_pending_proposals(&id).await.unwrap();
-                bob_central.context.commit_accepted(&id).await.unwrap();
 
                 // Epoch has advanced so we cannot detect duplicates anymore
                 let decryption = bob_central
@@ -241,7 +233,6 @@ mod tests {
 
                 // advance alice's epoch
                 alice_central.context.commit_pending_proposals(&id).await.unwrap();
-                alice_central.context.commit_accepted(&id).await.unwrap();
 
                 // Epoch has advanced so we cannot detect duplicates anymore
                 let decryption = alice_central

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -312,13 +312,12 @@ impl CentralContext {
 #[cfg(test)]
 mod tests {
     use crate::e2e_identity::rotate::tests::all::failsafe_ctx;
+    use std::sync::Arc;
 
     use wasm_bindgen_test::*;
 
     use crate::{
-        prelude::{
-            ClientIdentifier, MlsCentralConfiguration, MlsConversationCreationMessage, INITIAL_KEYING_MATERIAL_COUNT,
-        },
+        prelude::{ClientIdentifier, MlsCentralConfiguration, INITIAL_KEYING_MATERIAL_COUNT},
         test_utils::*,
         CoreCrypto,
     };
@@ -370,14 +369,11 @@ mod tests {
                     .unwrap();
 
                 let bob = bob_central.rand_key_package(&case).await;
-                let MlsConversationCreationMessage { welcome, .. } = alice_central
+                alice_central
                     .context
                     .add_members_to_conversation(&id, vec![bob])
                     .await
                     .unwrap();
-                // before merging, commit is not applied
-                assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
-                alice_central.context.commit_accepted(&id).await.unwrap();
 
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.id, id);
                 assert_eq!(
@@ -391,6 +387,7 @@ mod tests {
                 );
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
+                let welcome = alice_central.mls_transport.latest_welcome_message().await;
                 bob_central
                     .context
                     .process_welcome_message(welcome.into(), case.custom_cfg())
@@ -471,6 +468,7 @@ mod tests {
                     let context = ClientContext {
                         context: friend_context,
                         central,
+                        mls_transport: Arc::<CoreCryptoTransportSuccessProvider>::default(),
                         x509_test_chain: x509_test_chain_arc.clone(),
                     };
                     bob_and_friends.push(context);
@@ -483,14 +481,12 @@ mod tests {
                     bob_and_friends_kps.push(c.rand_key_package(&case).await);
                 }
 
-                let MlsConversationCreationMessage { welcome, .. } = alice_central
+                alice_central
                     .context
                     .add_members_to_conversation(&id, bob_and_friends_kps)
                     .await
                     .unwrap();
-                // before merging, commit is not applied
-                assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
-                alice_central.context.commit_accepted(&id).await.unwrap();
+                let welcome = alice_central.mls_transport.latest_welcome_message().await;
 
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.id, id);
                 assert_eq!(

--- a/crypto/src/mls/conversation/orphan_welcome.rs
+++ b/crypto/src/mls/conversation/orphan_welcome.rs
@@ -32,15 +32,16 @@ mod tests {
                     .unwrap();
 
                 // Alice invites Bob with a KeyPackage...
-                let welcome = alice_central
+                alice_central
                     .context
                     .add_members_to_conversation(&id, vec![bob])
                     .await
-                    .unwrap()
-                    .welcome;
+                    .unwrap();
 
                 // ...Bob deletes locally (with the associated private key) before processing the Welcome
                 bob_central.context.delete_keypackages(&[bob_kp_ref]).await.unwrap();
+
+                let welcome = alice_central.mls_transport.latest_welcome_message().await;
 
                 // in that case a dedicated error is thrown for clients to identify this case
                 // and rejoin with an external commit

--- a/crypto/src/mls/conversation/proposal.rs
+++ b/crypto/src/mls/conversation/proposal.rs
@@ -159,7 +159,7 @@ mod tests {
     use openmls::prelude::SignaturePublicKey;
     use wasm_bindgen_test::*;
 
-    use crate::{prelude::MlsCommitBundle, test_utils::*};
+    use crate::test_utils::*;
 
     use super::*;
 
@@ -198,13 +198,9 @@ mod tests {
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        let MlsCommitBundle { commit, welcome, .. } = bob_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap();
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
+                        let welcome = bob_central.mls_transport.latest_welcome_message().await;
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
                         // if 'new_proposal' wasn't durable this would fail because proposal would
@@ -219,7 +215,7 @@ mod tests {
                         charlie_central
                             .try_join_from_welcome(
                                 &id,
-                                welcome.unwrap().into(),
+                                welcome.into(),
                                 case.custom_cfg(),
                                 vec![&alice_central, &bob_central],
                             )
@@ -268,14 +264,8 @@ mod tests {
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        let commit = bob_central
-                            .context
-                            .commit_pending_proposals(&id)
-                            .await
-                            .unwrap()
-                            .unwrap()
-                            .commit;
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                         // if 'new_proposal' wasn't durable this would fail because proposal would
@@ -330,21 +320,9 @@ mod tests {
                         .decrypt_message(&id, proposal.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    let commit = bob_central
-                        .context
-                        .commit_pending_proposals(&id)
-                        .await
-                        .unwrap()
-                        .unwrap()
-                        .commit;
+                    bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                    let commit = bob_central.mls_transport.latest_commit().await;
 
-                    // before merging, commit is not applied
-                    assert!(bob_central
-                        .get_conversation_unchecked(&id)
-                        .await
-                        .encryption_keys()
-                        .contains(&alice_key));
-                    bob_central.context.commit_accepted(&id).await.unwrap();
                     assert!(!bob_central
                         .get_conversation_unchecked(&id)
                         .await
@@ -402,7 +380,6 @@ mod tests {
                         .unwrap();
                     bob_central.context.commit_pending_proposals(&id).await.unwrap();
                     // epoch++
-                    bob_central.context.commit_accepted(&id).await.unwrap();
 
                     // fails when we try to decrypt a proposal for past epoch
                     let past_proposal = bob_central

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -191,8 +191,8 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Bob hasn't Alice's proposal but creates a commit
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
 
                         let proposals = alice_central
                             .context
@@ -205,9 +205,8 @@ mod tests {
                         assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
                         // It should also renew the proposal when in pending_commit
-                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
-                        assert!(alice_central.pending_commit(&id).await.is_some());
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -240,11 +239,12 @@ mod tests {
                             .unwrap();
                         alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                        alice_central.context.update_keying_material(&id).await.unwrap();
+                        alice_central.create_unmerged_commit(&id).await;
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // but Bob creates a commit meanwhile
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
 
                         let proposals = alice_central
                             .context
@@ -288,8 +288,8 @@ mod tests {
                             .await
                             .unwrap();
 
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
 
                         // Bob's commit has Alice's proposal
                         let proposals = alice_central
@@ -302,17 +302,14 @@ mod tests {
                         assert!(alice_central.pending_proposals(&id).await.is_empty());
                         assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
-                        // Same if proposal is also in pending commit
                         let proposal = alice_central.context.new_update_proposal(&id).await.unwrap().proposal;
-                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
-                        assert!(alice_central.pending_commit(&id).await.is_some());
                         bob_central
                             .context
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -357,12 +354,8 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Charlie does not have other proposals, it creates a commit
-                        let commit = charlie_central
-                            .context
-                            .update_keying_material(&id)
-                            .await
-                            .unwrap()
-                            .commit;
+                        charlie_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = charlie_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -404,12 +397,12 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         let charlie = charlie_central.rand_key_package(&case).await;
-                        let commit = bob_central
+                        bob_central
                             .context
                             .add_members_to_conversation(&id, vec![charlie])
                             .await
-                            .unwrap()
-                            .commit;
+                            .unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -447,16 +440,16 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Here Alice also creates a commit
-                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                        alice_central.commit_pending_proposals_unmerged(&id).await;
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         let charlie = charlie_central.rand_key_package(&case).await;
-                        let commit = bob_central
+                        bob_central
                             .context
                             .add_members_to_conversation(&id, vec![charlie])
                             .await
-                            .unwrap()
-                            .commit;
+                            .unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -507,12 +500,8 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // But Charlie will commit meanwhile
-                        let commit = charlie_central
-                            .context
-                            .update_keying_material(&id)
-                            .await
-                            .unwrap()
-                            .commit;
+                        charlie_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = charlie_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -551,8 +540,8 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // But meanwhile Bob will create a commit without Alice's proposal
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
-                        bob_central.context.commit_accepted(&id).await.unwrap();
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -564,9 +553,10 @@ mod tests {
                         assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
                         // And same should happen when proposal is in pending commit
-                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                        alice_central.commit_pending_proposals_unmerged(&id).await;
                         assert!(alice_central.pending_commit(&id).await.is_some());
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -588,8 +578,8 @@ mod tests {
         pub async fn renews_pending_commit_when_valid_commit_doesnt_add_same(case: TestCase) {
             run_test_with_client_ids(
                 case.clone(),
-                ["alice", "bob", "charlie"],
-                move |[mut alice_central, bob_central, charlie_central]| {
+                ["alice", "bob"],
+                move |[mut alice_central, bob_central]| {
                     Box::pin(async move {
                         let id = conversation_id();
                         alice_central
@@ -600,16 +590,12 @@ mod tests {
                         alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
                         // Alice commits adding Charlie
-                        let charlie = charlie_central.rand_key_package(&case).await;
-                        alice_central
-                            .context
-                            .add_members_to_conversation(&id, vec![charlie])
-                            .await
-                            .unwrap();
+                        alice_central.create_unmerged_commit(&id).await;
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // But meanwhile Bob will create a commit
-                        let commit = bob_central.context.update_keying_material(&id).await.unwrap().commit;
+                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -656,12 +642,12 @@ mod tests {
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
-                        let commit = bob_central
+                        bob_central
                             .context
                             .remove_members_from_conversation(&id, &[charlie_central.get_client_id().await])
                             .await
-                            .unwrap()
-                            .commit;
+                            .unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -710,12 +696,8 @@ mod tests {
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
-                        let commit = charlie_central
-                            .context
-                            .update_keying_material(&id)
-                            .await
-                            .unwrap()
-                            .commit;
+                        charlie_central.context.update_keying_material(&id).await.unwrap();
+                        let commit = charlie_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -760,12 +742,12 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Whereas Bob wants to remove Debbie
-                        let commit = bob_central
+                        bob_central
                             .context
                             .remove_members_from_conversation(&id, &[debbie_central.get_client_id().await])
                             .await
-                            .unwrap()
-                            .commit;
+                            .unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -803,18 +785,19 @@ mod tests {
                         // Alice wants to remove Charlie
                         alice_central
                             .context
-                            .remove_members_from_conversation(&id, &[charlie_central.get_client_id().await])
+                            .new_remove_proposal(&id, charlie_central.get_client_id().await)
                             .await
                             .unwrap();
+                        alice_central.commit_pending_proposals_unmerged(&id).await;
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // Whereas Bob wants to remove Debbie
-                        let commit = bob_central
+                        bob_central
                             .context
                             .remove_members_from_conversation(&id, &[debbie_central.get_client_id().await])
                             .await
-                            .unwrap()
-                            .commit;
+                            .unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())
@@ -855,17 +838,15 @@ mod tests {
                             .new_remove_proposal(&id, charlie_central.get_client_id().await)
                             .await
                             .unwrap();
-                        alice_central.context.commit_pending_proposals(&id).await.unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
-                        assert!(alice_central.pending_commit(&id).await.is_some());
+                        alice_central.commit_pending_proposals_unmerged(&id).await;
 
                         // Whereas Bob wants to remove Debbie
-                        let commit = bob_central
+                        bob_central
                             .context
                             .remove_members_from_conversation(&id, &[debbie_central.get_client_id().await])
                             .await
-                            .unwrap()
-                            .commit;
+                            .unwrap();
+                        let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
                             .decrypt_message(&id, commit.to_bytes().unwrap())

--- a/crypto/src/mls/conversation/welcome.rs
+++ b/crypto/src/mls/conversation/welcome.rs
@@ -143,7 +143,7 @@ impl MlsConversation {
 mod tests {
     use wasm_bindgen_test::*;
 
-    use crate::{prelude::MlsConversationCreationMessage, test_utils::*};
+    use crate::test_utils::*;
 
     use super::*;
 
@@ -167,12 +167,13 @@ mod tests {
                     .await
                     .unwrap();
 
-                let MlsConversationCreationMessage { welcome, .. } = alice_central
+                alice_central
                     .context
                     .add_members_to_conversation(&id, vec![bob])
                     .await
                     .unwrap();
 
+                let welcome = alice_central.mls_transport.latest_welcome_message().await;
                 // Bob accepts the welcome message, and as such, it should prune the used keypackage from the store
                 bob_central
                     .context
@@ -202,13 +203,13 @@ mod tests {
                     .await
                     .unwrap();
                 let bob = bob_central.rand_key_package(&case).await;
-                let welcome = alice_central
+                alice_central
                     .context
                     .add_members_to_conversation(&id, vec![bob])
                     .await
-                    .unwrap()
-                    .welcome;
+                    .unwrap();
 
+                let welcome = alice_central.mls_transport.latest_welcome_message().await;
                 // Meanwhile Bob creates a conversation with the exact same id as the one he's trying to join
                 bob_central
                     .context

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -407,6 +407,7 @@ mod tests {
             let charlie_context = ClientContext {
                 context: charlie_transaction,
                 central: charlie_central,
+                mls_transport: Arc::<CoreCryptoTransportSuccessProvider>::default(),
                 x509_test_chain: Arc::new(Some(x509_test_chain)),
             };
 
@@ -514,6 +515,8 @@ mod tests {
         )?;
 
         let creator_central = MlsCentral::try_new(creator_cfg).await?;
+        let creator_transport = Arc::<CoreCryptoTransportSuccessProvider>::default();
+        creator_central.provide_transport(creator_transport.clone()).await;
         let cc = CoreCrypto::from(creator_central);
         let creator_transaction = cc.new_transaction().await?;
         let creator_central = cc.mls;
@@ -524,6 +527,7 @@ mod tests {
         let creator_client_context = ClientContext {
             context: creator_transaction.clone(),
             central: creator_central,
+            mls_transport: creator_transport.clone(),
             x509_test_chain: Arc::new(x509_test_chain.cloned()),
         };
 
@@ -546,6 +550,8 @@ mod tests {
         )?;
 
         let guest_central = MlsCentral::try_new(guest_cfg).await?;
+        let guest_transport = Arc::<CoreCryptoTransportSuccessProvider>::default();
+        guest_central.provide_transport(guest_transport.clone()).await;
         let cc = CoreCrypto::from(guest_central);
         let guest_transaction = cc.new_transaction().await?;
         let guest_central = cc.mls;
@@ -567,6 +573,7 @@ mod tests {
         let guest_client_context = ClientContext {
             context: guest_transaction.clone(),
             central: guest_central,
+            mls_transport: guest_transport.clone(),
             x509_test_chain: Arc::new(x509_test_chain.cloned()),
         };
 

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -14,10 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use mls_crypto_provider::MlsCryptoProvider;
-use openmls::prelude::{
-    group_info::VerifiableGroupInfo, CredentialType, MlsGroup, MlsMessageOut, Proposal, Sender, StagedCommit,
-};
+use openmls::prelude::{group_info::VerifiableGroupInfo, MlsGroup, MlsMessageOut};
 use openmls_traits::OpenMlsCryptoProvider;
 use tls_codec::Serialize;
 
@@ -28,13 +25,12 @@ use core_crypto_keystore::{
 };
 
 use crate::{
-    e2e_identity::{conversation_state::compute_state, init_certificates::NewCrlDistributionPoint},
-    group_store::GroupStoreValue,
+    e2e_identity::init_certificates::NewCrlDistributionPoint,
     mls::credential::crl::{extract_crl_uris_from_group, get_new_crl_distribution_points},
     prelude::{
-        decrypt::MlsBufferedConversationDecryptMessage, id::ClientId, ConversationId, CoreCryptoCallbacks, CryptoError,
-        CryptoResult, E2eiConversationState, MlsCiphersuite, MlsConversation, MlsConversationConfiguration,
-        MlsCredentialType, MlsCustomConfiguration, MlsError, MlsGroupInfoBundle,
+        decrypt::MlsBufferedConversationDecryptMessage, ConversationId, CryptoError, CryptoResult, MlsCiphersuite,
+        MlsConversation, MlsConversationConfiguration, MlsCredentialType, MlsCustomConfiguration, MlsError,
+        MlsGroupInfoBundle,
     },
 };
 
@@ -229,88 +225,9 @@ impl CentralContext {
     }
 }
 
-impl MlsConversation {
-    pub(crate) async fn validate_external_commit(
-        &self,
-        commit: &StagedCommit,
-        sender: ClientId,
-        parent_conversation: Option<&GroupStoreValue<MlsConversation>>,
-        backend: &MlsCryptoProvider,
-        callbacks: Option<&dyn CoreCryptoCallbacks>,
-    ) -> CryptoResult<()> {
-        // i.e. has this commit been created by [MlsCentral::join_by_external_commit] ?
-        let is_external_init = commit.queued_proposals().any(|p| {
-            matches!(p.sender(), Sender::NewMemberCommit) && matches!(p.proposal(), Proposal::ExternalInit(_))
-        });
-
-        if is_external_init {
-            let callbacks = callbacks.ok_or(CryptoError::CallbacksNotSet)?;
-            // first let's verify the sender belongs to an user already in the MLS group
-            let existing_clients = self.members_in_next_epoch();
-            let parent_clients = if let Some(parent_conv) = parent_conversation {
-                Some(
-                    parent_conv
-                        .read()
-                        .await
-                        .group
-                        .members()
-                        .map(|kp| kp.credential.identity().to_vec().into())
-                        .collect(),
-                )
-            } else {
-                None
-            };
-            if !callbacks
-                .client_is_existing_group_user(
-                    self.id.clone(),
-                    sender.clone(),
-                    existing_clients.clone(),
-                    parent_clients,
-                )
-                .await
-            {
-                return Err(CryptoError::UnauthorizedExternalCommit);
-            }
-            // then verify that the user this client belongs to has the right role (is allowed)
-            // to perform such operation
-            if !callbacks
-                .user_authorize(self.id.clone(), sender, existing_clients)
-                .await
-            {
-                return Err(CryptoError::UnauthorizedExternalCommit);
-            }
-        }
-
-        if backend.authentication_service().is_env_setup().await {
-            let credentials: Vec<_> = commit
-                .add_proposals()
-                .filter_map(|add_proposal| {
-                    let credential = add_proposal.add_proposal().key_package().leaf_node().credential();
-
-                    matches!(credential.credential_type(), CredentialType::X509).then(|| credential.clone())
-                })
-                .collect();
-            let state = compute_state(
-                self.ciphersuite(),
-                credentials.iter(),
-                MlsCredentialType::X509,
-                backend.authentication_service().borrow().await.as_ref(),
-            )
-            .await;
-            if state != E2eiConversationState::Verified {
-                // FIXME: Uncomment when PKI env can be seeded - the computation is still done to assess performance and impact of the validations. Tracking issue: WPB-9665
-                // return Err(CryptoError::InvalidCertificateChain);
-            }
-        }
-
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use openmls::prelude::*;
-    use std::sync::Arc;
     use wasm_bindgen_test::*;
 
     use core_crypto_keystore::{CryptoKeystoreError, CryptoKeystoreMls, MissingKeyErrorKind};
@@ -628,94 +545,6 @@ mod tests {
                 })
             },
         )
-        .await
-    }
-
-    #[apply(all_cred_cipher)]
-    #[wasm_bindgen_test]
-    async fn should_fail_when_sender_user_not_in_group(case: TestCase) {
-        run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-
-                alice_central
-                    .context
-                    .set_callbacks(Some(Arc::new(ValidationCallbacks {
-                        client_is_existing_group_user: false,
-                        ..Default::default()
-                    })))
-                    .await
-                    .unwrap();
-
-                alice_central
-                    .context
-                    .new_conversation(&id, case.credential_type, case.cfg.clone())
-                    .await
-                    .unwrap();
-
-                // export Alice group info
-                let group_info = alice_central.get_group_info(&id).await;
-
-                // Bob tries to join Alice's group
-                let MlsConversationInitBundle { commit, .. } = bob_central
-                    .context
-                    .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
-                    .await
-                    .unwrap();
-                let alice_accepts_ext_commit = alice_central
-                    .context
-                    .decrypt_message(&id, &commit.to_bytes().unwrap())
-                    .await;
-                assert!(matches!(
-                    alice_accepts_ext_commit.unwrap_err(),
-                    CryptoError::UnauthorizedExternalCommit
-                ))
-            })
-        })
-        .await
-    }
-
-    #[apply(all_cred_cipher)]
-    #[wasm_bindgen_test]
-    async fn should_fail_when_sender_lacks_role(case: TestCase) {
-        run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
-            Box::pin(async move {
-                let id = conversation_id();
-
-                alice_central
-                    .context
-                    .set_callbacks(Some(Arc::new(ValidationCallbacks {
-                        user_authorize: false,
-                        ..Default::default()
-                    })))
-                    .await
-                    .unwrap();
-
-                alice_central
-                    .context
-                    .new_conversation(&id, case.credential_type, case.cfg.clone())
-                    .await
-                    .unwrap();
-
-                // export Alice group info
-                let group_info = alice_central.get_group_info(&id).await;
-
-                // Bob tries to join Alice's group
-                let MlsConversationInitBundle { commit, .. } = bob_central
-                    .context
-                    .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
-                    .await
-                    .unwrap();
-                let alice_accepts_ext_commit = alice_central
-                    .context
-                    .decrypt_message(&id, &commit.to_bytes().unwrap())
-                    .await;
-                assert!(matches!(
-                    alice_accepts_ext_commit.unwrap_err(),
-                    CryptoError::UnauthorizedExternalCommit
-                ))
-            })
-        })
         .await
     }
 

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -26,6 +26,7 @@ use core_crypto_keystore::{
 
 use crate::{
     e2e_identity::init_certificates::NewCrlDistributionPoint,
+    mls,
     mls::credential::crl::{extract_crl_uris_from_group, get_new_crl_distribution_points},
     prelude::{
         decrypt::MlsBufferedConversationDecryptMessage, ConversationId, CryptoError, CryptoResult, MlsCiphersuite,
@@ -35,6 +36,7 @@ use crate::{
 };
 
 use crate::context::CentralContext;
+use crate::prelude::{MlsCommitBundle, WelcomeBundle};
 
 /// Returned when a commit is created
 #[derive(Debug)]
@@ -128,20 +130,35 @@ impl CentralContext {
         let crl_new_distribution_points =
             get_new_crl_distribution_points(&mls_provider, extract_crl_uris_from_group(&group)?).await?;
 
+        let new_group_id = group.group_id().to_vec();
+
         mls_provider
             .key_store()
             .mls_pending_groups_save(
-                group.group_id().as_slice(),
+                new_group_id.as_slice(),
                 &core_crypto_keystore::ser(&group)?,
                 &serialized_cfg,
                 None,
             )
             .await?;
 
-        Ok(MlsConversationInitBundle {
-            conversation_id: group.group_id().to_vec(),
+        let commit_bundle = MlsCommitBundle {
+            welcome: None,
             commit,
             group_info,
+        };
+
+        match self.send_commit(commit_bundle).await {
+            Ok(()) => self.merge_pending_group_from_external_commit(&new_group_id).await?,
+            Err(e @ mls::conversation::Error::MessageRejected { .. }) => {
+                self.clear_pending_group_from_external_commit(&new_group_id).await?;
+                return Err(RecursiveError::mls_conversation("sending commit")(e).into());
+            }
+            Err(e) => return Err(RecursiveError::mls_conversation("sending commit")(e).into()),
+        };
+
+        Ok(WelcomeBundle {
+            id: new_group_id,
             crl_new_distribution_points,
         })
     }
@@ -155,7 +172,7 @@ impl CentralContext {
     /// # Errors
     /// Errors resulting from OpenMls, the KeyStore calls and deserialization
     #[cfg_attr(test, crate::dispotent)]
-    pub async fn merge_pending_group_from_external_commit(
+    pub(crate) async fn merge_pending_group_from_external_commit(
         &self,
         id: &ConversationId,
     ) -> CryptoResult<Option<Vec<MlsBufferedConversationDecryptMessage>>> {
@@ -209,8 +226,9 @@ impl CentralContext {
     /// # Errors
     /// Errors resulting from the KeyStore calls
     #[cfg_attr(test, crate::dispotent)]
-    pub async fn clear_pending_group_from_external_commit(&self, id: &ConversationId) -> CryptoResult<()> {
-        Ok(self.keystore().await?.mls_pending_groups_delete(id).await?)
+    pub(crate) async fn clear_pending_group_from_external_commit(&self, id: &ConversationId) -> CryptoResult<()> {
+        self.keystore().await?.mls_pending_groups_delete(id).await?;
+        Ok(())
     }
 
     pub(crate) async fn pending_group_exists(&self, id: &ConversationId) -> CryptoResult<bool> {
@@ -232,8 +250,10 @@ mod tests {
 
     use core_crypto_keystore::{CryptoKeystoreError, CryptoKeystoreMls, MissingKeyErrorKind};
 
-    use crate::prelude::MlsConversationConfiguration;
-    use crate::{prelude::MlsConversationInitBundle, test_utils::*, CryptoError};
+    use crate::{
+        prelude::{MlsConversationConfiguration, WelcomeBundle},
+        test_utils::*,
+    };
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -256,16 +276,10 @@ mod tests {
                     let group_info = alice_central.get_group_info(&id).await;
 
                     // Bob tries to join Alice's group
-                    let MlsConversationInitBundle {
-                        conversation_id: group_id,
-                        commit: external_commit,
-                        ..
-                    } = bob_central
-                        .context
-                        .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
+                    let external_commit = bob_central
+                        .create_unmerged_external_commit(group_info.clone(), case.custom_cfg(), case.credential_type)
                         .await
-                        .unwrap();
-                    assert_eq!(group_id.as_slice(), &id);
+                        .commit;
 
                     // Alice acks the request and adds the new member
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
@@ -305,7 +319,7 @@ mod tests {
                     ));
 
                     // Ensure it's durable i.e. MLS group has been persisted
-                    bob_central.context.drop_and_restore(&group_id).await;
+                    bob_central.context.drop_and_restore(&id).await;
                     assert!(bob_central.try_talk_to(&id, &alice_central).await.is_ok());
                 })
             },
@@ -330,25 +344,25 @@ mod tests {
 
                 // Bob tries to join Alice's group
                 bob_central
-                    .context
-                    .join_by_external_commit(group_info.clone(), case.custom_cfg(), case.credential_type)
-                    .await
-                    .unwrap();
+                    .create_unmerged_external_commit(group_info.clone(), case.custom_cfg(), case.credential_type)
+                    .await;
                 // BUT for some reason the Delivery Service will reject this external commit
                 // e.g. another commit arrived meanwhile and the [GroupInfo] is no longer valid
+                // But bob doesn't receive the rejection message, so the commit is still pending
 
                 // Retrying
-                let MlsConversationInitBundle {
-                    conversation_id,
-                    commit: external_commit,
-                    ..
+                let WelcomeBundle {
+                    id: conversation_id, ..
                 } = bob_central
                     .context
                     .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
                     .await
                     .unwrap();
                 assert_eq!(conversation_id.as_slice(), &id);
+                assert!(bob_central.context.get_conversation(&id).await.is_ok());
+                assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
+                let external_commit = bob_central.mls_transport.latest_commit().await;
                 // Alice decrypts the external commit and adds Bob
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
                 alice_central
@@ -358,14 +372,6 @@ mod tests {
                     .unwrap();
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
-                // And Bob can merge its external commit
-                bob_central
-                    .context
-                    .merge_pending_group_from_external_commit(&id)
-                    .await
-                    .unwrap();
-                assert!(bob_central.context.get_conversation(&id).await.is_ok());
-                assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                 assert!(alice_central.try_talk_to(&id, &bob_central).await.is_ok());
             })
         })
@@ -386,18 +392,16 @@ mod tests {
 
                 let group_info = alice_central.get_group_info(&id).await;
                 // try to make an external join into Alice's group
-                let MlsConversationInitBundle {
-                    commit: external_commit,
-                    ..
-                } = bob_central
+                bob_central
                     .context
                     .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
                     .await
                     .unwrap();
 
+                let external_commit = bob_central.mls_transport.latest_commit().await;
+
                 // Alice creates a new commit before receiving the external join
                 alice_central.context.update_keying_material(&id).await.unwrap();
-                alice_central.context.commit_accepted(&id).await.unwrap();
 
                 // receiving the external join with outdated epoch should fail because of
                 // the wrong epoch
@@ -428,11 +432,6 @@ mod tests {
                 alice_central
                     .context
                     .join_by_external_commit(group_info.clone(), case.custom_cfg(), case.credential_type)
-                    .await
-                    .unwrap();
-                alice_central
-                    .context
-                    .merge_pending_group_from_external_commit(&id)
                     .await
                     .unwrap();
             })
@@ -479,15 +478,15 @@ mod tests {
                     let group_info = alice_central.get_group_info(&id).await;
 
                     // Bob tries to join Alice's group
-                    let MlsConversationInitBundle {
-                        commit: bob_external_commit,
-                        group_info,
-                        ..
-                    } = bob_central
+                    bob_central
                         .context
                         .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
                         .await
                         .unwrap();
+
+                    let bob_external_commit = bob_central.mls_transport.latest_commit().await;
+                    assert!(bob_central.context.get_conversation(&id).await.is_ok());
+                    assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                     // Alice decrypts the commit, Bob's in !
                     alice_central
@@ -496,27 +495,18 @@ mod tests {
                         .await
                         .unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
-
-                    // Bob merges the commit, he's also in !
-                    bob_central
-                        .context
-                        .merge_pending_group_from_external_commit(&id)
-                        .await
-                        .unwrap();
-                    assert!(bob_central.context.get_conversation(&id).await.is_ok());
-                    assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     assert!(alice_central.try_talk_to(&id, &bob_central).await.is_ok());
 
                     // Now charlie wants to join with the [GroupInfo] from Bob's external commit
+                    let group_info = bob_central.mls_transport.latest_group_info().await;
                     let bob_gi = group_info.get_group_info();
-                    let MlsConversationInitBundle {
-                        commit: charlie_external_commit,
-                        ..
-                    } = charlie_central
+                    charlie_central
                         .context
                         .join_by_external_commit(bob_gi, case.custom_cfg(), case.credential_type)
                         .await
                         .unwrap();
+
+                    let charlie_external_commit = charlie_central.mls_transport.latest_commit().await;
 
                     // Both Alice & Bob decrypt the commit
                     alice_central
@@ -532,12 +522,7 @@ mod tests {
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 3);
                     assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
-                    // Charlie merges the commit, he's also in !
-                    charlie_central
-                        .context
-                        .merge_pending_group_from_external_commit(&id)
-                        .await
-                        .unwrap();
+                    // Charlie is also in!
                     assert!(charlie_central.context.get_conversation(&id).await.is_ok());
                     assert_eq!(charlie_central.get_conversation_unchecked(&id).await.members().len(), 3);
                     assert!(charlie_central.try_talk_to(&id, &alice_central).await.is_ok());
@@ -648,13 +633,13 @@ mod tests {
                     .unwrap();
 
                 let bob = bob_central.rand_key_package(&case).await;
-                let welcome = alice_central
+                alice_central
                     .context
                     .add_members_to_conversation(&id, vec![bob])
                     .await
-                    .unwrap()
-                    .welcome;
+                    .unwrap();
 
+                let welcome = alice_central.mls_transport.latest_welcome_message().await;
                 // erroneous call
                 let conflict_welcome = bob_central
                     .context
@@ -690,7 +675,6 @@ mod tests {
                         .add_members_to_conversation(&id, vec![invalid_kp.into()])
                         .await
                         .unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
 
                     let elapsed = start.elapsed();
                     // Give time to the certificate to expire
@@ -736,10 +720,8 @@ mod tests {
 
                 let gi = alice_central.get_group_info(&id).await;
                 bob_central
-                    .context
-                    .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
-                    .await
-                    .unwrap();
+                    .create_unmerged_external_commit(gi, case.custom_cfg(), case.credential_type)
+                    .await;
                 bob_central
                     .context
                     .merge_pending_group_from_external_commit(&id)

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -149,7 +149,7 @@ impl CentralContext {
 mod tests {
     use wasm_bindgen_test::*;
 
-    use crate::{prelude::MlsCommitBundle, prelude::*, test_utils::*};
+    use crate::{prelude::*, test_utils::*};
 
     wasm_bindgen_test_configure!(run_in_browser);
 
@@ -169,17 +169,12 @@ mod tests {
                         .unwrap();
                     let bob_kp = bob_central.get_one_key_package(&case).await;
                     alice_central.context.new_add_proposal(&id, bob_kp).await.unwrap();
-                    let MlsCommitBundle { welcome, .. } = alice_central
-                        .context
-                        .commit_pending_proposals(&id)
-                        .await
-                        .unwrap()
-                        .unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                    let welcome = alice_central.mls_transport.latest_welcome_message().await;
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     let new_id = bob_central
                         .context
-                        .process_welcome_message(welcome.unwrap().into(), case.custom_cfg())
+                        .process_welcome_message(welcome.into(), case.custom_cfg())
                         .await
                         .unwrap()
                         .id;
@@ -214,7 +209,6 @@ mod tests {
                         .unwrap();
                     central.context.new_update_proposal(&id).await.unwrap();
                     central.context.commit_pending_proposals(&id).await.unwrap();
-                    central.context.commit_accepted(&id).await.unwrap();
                     let after = central
                         .get_conversation_unchecked(&id)
                         .await
@@ -256,15 +250,10 @@ mod tests {
                         .decrypt_message(&id, remove_proposal.proposal.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    let MlsCommitBundle { commit, .. } = alice_central
-                        .context
-                        .commit_pending_proposals(&id)
-                        .await
-                        .unwrap()
-                        .unwrap();
-                    alice_central.context.commit_accepted(&id).await.unwrap();
+                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
 
+                    let commit = alice_central.mls_transport.latest_commit().await;
                     bob_central
                         .context
                         .decrypt_message(&id, commit.to_bytes().unwrap())

--- a/crypto/src/test_utils/context.rs
+++ b/crypto/src/test_utils/context.rs
@@ -14,11 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+use crate::group_store::GroupStore;
+use crate::prelude::{MlsCommitBundle, MlsGroupInfoBundle, WelcomeBundle};
+use crate::test_utils::ClientContext;
+use crate::{
+    e2e_identity::{
+        device_status::DeviceStatus,
+        id::{QualifiedE2eiClientId, WireQualifiedClientId},
+    },
+    mls::credential::{ext::CredentialExt, CredentialBundle},
+    prelude::{
+        CertificateBundle, Client, ClientId, ConversationId, MlsCiphersuite, MlsConversation,
+        MlsConversationConfiguration, MlsConversationDecryptMessage, MlsCredentialType, MlsCustomConfiguration,
+        MlsError, WireIdentity,
+    },
+    test_utils::{x509::X509Certificate, MessageExt, TestCase},
+};
+use crate::{CryptoError, CryptoResult};
 use core_crypto_keystore::connection::FetchFromDatabase;
 use core_crypto_keystore::entities::{
     EntityFindParams, MlsCredential, MlsEncryptionKeyPair, MlsHpkePrivateKey, MlsKeyPackage, MlsSignatureKeyPair,
 };
+use core_crypto_keystore::CryptoKeystoreMls;
 use mls_crypto_provider::MlsCryptoProvider;
+use openmls::group::MlsGroup;
 use openmls::prelude::{
     group_info::VerifiableGroupInfo, Credential, CredentialWithKey, CryptoConfig, ExternalSender, HpkePublicKey,
     KeyPackage, KeyPackageIn, LeafNodeIndex, Lifetime, MlsMessageIn, QueuedProposal, SignaturePublicKey, StagedCommit,
@@ -30,24 +49,13 @@ use tls_codec::{Deserialize, Serialize};
 use wire_e2e_identity::prelude::WireIdentityReader;
 use x509_cert::der::Encode;
 
-use crate::group_store::GroupStore;
-use crate::test_utils::ClientContext;
-use crate::{
-    e2e_identity::{
-        device_status::DeviceStatus,
-        id::{QualifiedE2eiClientId, WireQualifiedClientId},
-    },
-    mls::credential::{ext::CredentialExt, CredentialBundle},
-    prelude::{
-        CertificateBundle, Client, ClientId, ConversationId, CryptoError, CryptoResult, MlsCiphersuite,
-        MlsConversation, MlsConversationConfiguration, MlsConversationDecryptMessage, MlsConversationInitBundle,
-        MlsCredentialType, MlsCustomConfiguration, MlsError, WireIdentity,
-    },
-    test_utils::{x509::X509Certificate, MessageExt, TestCase},
-};
-
 #[allow(clippy::redundant_static_lifetimes)]
 pub const TEAM: &'static str = "world";
+
+pub struct RotateAllResult {
+    pub(crate) conversation_ids_and_commits: Vec<(ConversationId, MlsCommitBundle)>,
+    pub(crate) new_key_packages: Vec<KeyPackage>,
+}
 
 impl ClientContext {
     pub async fn get_one_key_package(&self, case: &TestCase) -> KeyPackage {
@@ -180,7 +188,8 @@ impl ClientContext {
         let size_before = self.get_conversation_unchecked(id).await.members().len();
 
         let kps = others.iter().map(|(_, kp)| kp).cloned().collect::<Vec<_>>();
-        let welcome = self.context.add_members_to_conversation(id, kps).await?.welcome;
+        self.context.add_members_to_conversation(id, kps).await?;
+        let welcome = self.mls_transport.latest_commit_bundle().await.welcome.unwrap();
 
         for (other, ..) in &others {
             other
@@ -189,7 +198,6 @@ impl ClientContext {
                 .await?;
         }
 
-        self.context.commit_accepted(id).await?;
         assert_eq!(
             self.get_conversation_unchecked(id).await.members().len(),
             size_before + N
@@ -215,17 +223,15 @@ impl ClientContext {
     ) -> CryptoResult<()> {
         use tls_codec::Serialize as _;
 
-        let MlsConversationInitBundle {
-            conversation_id,
-            commit,
-            ..
+        let WelcomeBundle {
+            id: conversation_id, ..
         } = self
             .context
             .join_by_external_commit(group_info, case.custom_cfg(), case.credential_type)
             .await?;
-        self.context
-            .merge_pending_group_from_external_commit(&conversation_id)
-            .await?;
+
+        let commit = self.mls_transport.latest_commit().await;
+
         assert_eq!(conversation_id.as_slice(), id.as_slice());
         for other in others {
             let commit = commit.tls_serialize_detached().map_err(MlsError::from)?;
@@ -476,7 +482,7 @@ impl ClientContext {
             .unwrap()
     }
 
-    pub async fn rotate_credential(
+    pub async fn save_new_credential(
         &self,
         case: &TestCase,
         handle: &str,
@@ -499,6 +505,134 @@ impl ClientContext {
                 case.signature_scheme(),
                 new_cert,
             )
+            .await
+            .unwrap()
+    }
+
+    pub(crate) async fn create_key_packages_and_update_credential_in_all_conversations(
+        &self,
+        cb: &CredentialBundle,
+        cipher_suite: MlsCiphersuite,
+        key_package_count: usize,
+    ) -> CryptoResult<RotateAllResult> {
+        let keystore = self.context.keystore().await?;
+        let all_conversations = self.context.mls_groups().await?.get_fetch_all(&keystore).await?;
+        let mut conversation_ids_and_commits = Vec::with_capacity(all_conversations.len());
+        for conv in all_conversations {
+            let id = conv.read().await.id().clone();
+            self.context.e2ei_rotate(&id, None).await?;
+            let commit = self.mls_transport.latest_commit_bundle().await;
+            conversation_ids_and_commits.push((id, commit));
+        }
+        let new_key_packages = self
+            .client()
+            .await
+            .generate_new_keypackages(&self.central.mls_backend, cipher_suite, cb, key_package_count)
+            .await?;
+        Ok(RotateAllResult {
+            conversation_ids_and_commits,
+            new_key_packages,
+        })
+    }
+
+    /// Creates a commit but don't merge it immediately (e.g, because the app crashes before he receives the success response from the ds via MlsTransport api)
+    pub(crate) async fn create_unmerged_commit(&self, id: &ConversationId) -> MlsCommitBundle {
+        self.context
+            .get_conversation(&id)
+            .await
+            .unwrap()
+            .write()
+            .await
+            .update_keying_material(&self.client().await, &self.central.mls_backend, None, None)
+            .await
+            .unwrap()
+    }
+
+    pub(crate) async fn commit_pending_proposals_unmerged(&self, id: &ConversationId) -> MlsCommitBundle {
+        self.context
+            .get_conversation(&id)
+            .await
+            .unwrap()
+            .write()
+            .await
+            .commit_pending_proposals(&self.client().await, &self.central.mls_backend)
+            .await
+            .expect("comitting pending proposals")
+            .expect("expect committing pending proposals to produce a commit")
+    }
+
+    pub(crate) async fn create_unmerged_external_commit(
+        &self,
+        group_info: VerifiableGroupInfo,
+        custom_cfg: MlsCustomConfiguration,
+        credential_type: MlsCredentialType,
+    ) -> MlsCommitBundle {
+        let client = self.client().await;
+
+        let cs: MlsCiphersuite = group_info.ciphersuite().into();
+        let mls_provider = &self.central.mls_backend;
+        let cb = client
+            .get_most_recent_or_create_credential_bundle(&mls_provider, cs.signature_algorithm(), credential_type)
+            .await
+            .unwrap();
+
+        let serialized_cfg = serde_json::to_vec(&custom_cfg).unwrap();
+
+        let configuration = MlsConversationConfiguration {
+            ciphersuite: cs,
+            custom: custom_cfg,
+            ..Default::default()
+        };
+
+        let (group, commit, group_info) = MlsGroup::join_by_external_commit(
+            mls_provider,
+            &cb.signature_key,
+            None,
+            group_info,
+            &configuration.as_openmls_default_configuration().unwrap(),
+            &[],
+            cb.to_mls_credential_with_key(),
+        )
+        .await
+        .unwrap();
+
+        // We should always have ratchet tree extension turned on hence GroupInfo should always be present
+        let group_info = group_info.unwrap();
+        let group_info = MlsGroupInfoBundle::try_new_full_plaintext(group_info).unwrap();
+
+        let new_group_id = group.group_id().to_vec();
+
+        mls_provider
+            .key_store()
+            .mls_pending_groups_save(
+                new_group_id.as_slice(),
+                &core_crypto_keystore::ser(&group).unwrap(),
+                &serialized_cfg,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let commit_bundle = MlsCommitBundle {
+            welcome: None,
+            commit,
+            group_info,
+        };
+
+        commit_bundle
+    }
+
+    /// Creates a commit but don't merge it immediately (e.g, because the app crashes before he receives the success response from the ds via MlsTransport api)
+    pub(crate) async fn create_unmerged_e2ei_rotate_commit(
+        &self,
+        id: &ConversationId,
+        cb: &CredentialBundle,
+    ) -> MlsCommitBundle {
+        let client = self.client().await;
+        let conversation = self.context.get_conversation(id).await.unwrap();
+        let mut conversation_guard = conversation.write().await;
+        conversation_guard
+            .e2ei_rotate(&self.central.mls_backend, &client, Some(cb))
             .await
             .unwrap()
     }

--- a/crypto/src/test_utils/fixtures.rs
+++ b/crypto/src/test_utils/fixtures.rs
@@ -17,6 +17,7 @@
 pub use crate::prelude::{
     MlsCiphersuite, MlsConversationConfiguration, MlsCredentialType, MlsCustomConfiguration, MlsWirePolicy,
 };
+use crate::test_utils::ClientContext;
 pub use openmls_traits::types::SignatureScheme;
 pub use rstest::*;
 pub use rstest_reuse::{self, *};
@@ -80,7 +81,8 @@ pub use rstest_reuse::{self, *};
                 ..Default::default()
             },
             ..Default::default()
-        }
+        },
+        contexts: vec![],
     }),
 )]
 #[allow(non_snake_case)]
@@ -90,6 +92,7 @@ pub fn all_cred_cipher(case: TestCase) {}
 pub struct TestCase {
     pub credential_type: MlsCredentialType,
     pub cfg: MlsConversationConfiguration,
+    pub contexts: Vec<ClientContext>,
 }
 
 impl TestCase {
@@ -100,6 +103,7 @@ impl TestCase {
                 ciphersuite: cs.into(),
                 ..Default::default()
             },
+            ..Default::default()
         }
     }
 
@@ -119,6 +123,7 @@ impl TestCase {
         Self {
             credential_type: MlsCredentialType::X509,
             cfg: MlsConversationConfiguration::default(),
+            contexts: vec![],
         }
     }
 
@@ -140,6 +145,7 @@ impl Default for TestCase {
         Self {
             credential_type: MlsCredentialType::Basic,
             cfg: MlsConversationConfiguration::default(),
+            contexts: vec![],
         }
     }
 }

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -541,12 +541,15 @@ pub struct CoreCryptoTransportSuccessProvider {
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl MlsTransport for CoreCryptoTransportSuccessProvider {
-    async fn send_commit_bundle(&self, commit_bundle: MlsCommitBundle) -> CryptoResult<MlsTransportResponse> {
+    async fn send_commit_bundle(
+        &self,
+        commit_bundle: MlsCommitBundle,
+    ) -> Result<MlsTransportResponse, Box<dyn std::error::Error>> {
         self.latest_commit_bundle.write().await.replace(commit_bundle);
         Ok(MlsTransportResponse::Success)
     }
 
-    async fn send_message(&self, mls_message: Vec<u8>) -> CryptoResult<MlsTransportResponse> {
+    async fn send_message(&self, mls_message: Vec<u8>) -> Result<MlsTransportResponse, Box<dyn std::error::Error>> {
         self.latest_message.write().await.replace(mls_message);
         Ok(MlsTransportResponse::Success)
     }
@@ -574,13 +577,16 @@ pub struct CoreCryptoTransportAbortProvider;
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl MlsTransport for CoreCryptoTransportAbortProvider {
-    async fn send_commit_bundle(&self, _commit_bundle: MlsCommitBundle) -> CryptoResult<MlsTransportResponse> {
+    async fn send_commit_bundle(
+        &self,
+        _commit_bundle: MlsCommitBundle,
+    ) -> Result<MlsTransportResponse, Box<dyn std::error::Error>> {
         Ok(MlsTransportResponse::Abort {
             reason: "abort provider always aborts!".to_string(),
         })
     }
 
-    async fn send_message(&self, _mls_message: Vec<u8>) -> CryptoResult<MlsTransportResponse> {
+    async fn send_message(&self, _mls_message: Vec<u8>) -> Result<MlsTransportResponse, Box<dyn std::error::Error>> {
         Ok(MlsTransportResponse::Abort {
             reason: "abort provider always aborts!".to_string(),
         })


### PR DESCRIPTION
# The Process So Far

1. Started with the final commit in the list, the one which adds the test case for 15810. 
2. It doesn't compile due to changed / missing functions. 
3. Looked up the commits which added / changed the relevant functions.
4. For each such commit:
    1. cherry-pick that commit
    2. fix merge conflicts across multiple files
    3. Rebase to insert the commit earlier so that there is some kind of logical ordering.
5. GOTO 2

## Why I'm giving up on this approach

This was the basic approach I wanted to take last Friday and Monday. It's the obvious approach to this problem! But it has issues of its own:

- It's extremely time-consuming
- It ends up recursively adding large portions of mostly-unrelated code to the codebase
- It ends up accidentally backporting key 4.x features such as the mls transport provider to 3.x
- As we do work on the PR level, not the commit level, it also is extremely likely to accidentally miss some work which is logically necessary for an earlier feature, but not implemented in the particular commit-set that we've cherry-picked

This is up as a sort of proof of work to remind me not to try to do this again, because the first 2 failed attempts were not enough apparently. We should close this issue and delete this cursed branch as soon as we accomplish the goal of backporting commit buffering through other means.