### PR TITLE
fix: backport commit buffering (attempt 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "blocking",
  "cfg-if",
  "core-crypto-keystore",
+ "core-crypto-macros",
  "core-foundation 0.10.0",
  "criterion",
  "fluvio-wasm-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,19 @@ members = [
     "keystore",
     "keystore-dump",
     "mls-provider",
-    "interop"
-, "decode"]
+    "interop",
+    "decode",
+]
 exclude = [
     "extras/webdriver-installation",
-    "extras/keystore-regression-versions"
+    "extras/keystore-regression-versions",
 ]
 resolver = "2"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wasm_bindgen_unstable_test_coverage)',
+] }
 
 [workspace.dependencies]
 async-lock = "3.4"
@@ -26,7 +32,12 @@ const_format = "0.2"
 core-crypto = { path = "crypto" }
 core-crypto-keystore = { path = "keystore" }
 core-crypto-macros = { path = "crypto-macros" }
-derive_more = { version = "0.99", features = ["from", "into", "deref", "deref_mut"] }
+derive_more = { version = "0.99", features = [
+    "from",
+    "into",
+    "deref",
+    "deref_mut",
+] }
 futures-util = "0.3"
 hex = "0.4"
 idb = "0.6"
@@ -37,7 +48,7 @@ log-reload = "0.1.0"
 mls-crypto-provider = { path = "mls-provider" }
 pem = "3.0"
 rand = { version = "0.8", features = ["getrandom"] }
-rexie = "0.6.1"  # TODO: remove once migration tests have been moved to rexie
+rexie = "0.6.1" # TODO: remove once migration tests have been moved to rexie
 schnellru = "0.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -16,9 +16,17 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 required-features = ["uniffi/cli"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["proteus"]
-proteus = ["core-crypto/proteus", "core-crypto/cryptobox-migrate", "dep:proteus-wasm", "dep:core-crypto-keystore"]
+proteus = [
+    "core-crypto/proteus",
+    "core-crypto/cryptobox-migrate",
+    "dep:proteus-wasm",
+    "dep:core-crypto-keystore",
+]
 
 [dependencies]
 thiserror.workspace = true
@@ -31,7 +39,7 @@ log.workspace = true
 log-reload.workspace = true
 serde_json.workspace = true
 proteus-wasm = { workspace = true, optional = true }
-core-crypto-keystore = { workspace = true, optional = true}
+core-crypto-keystore = { workspace = true, optional = true }
 
 # see https://github.com/RustCrypto/hashes/issues/404
 [target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")))'.dependencies]
@@ -68,7 +76,9 @@ wasm-bindgen-test = "0.3"
 wasm-opt = false
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+wasm-opt = [
+    "-Os",
+    "--enable-mutable-globals",
+    "--enable-threads",
+    "--detect-features",
+]

--- a/crypto-macros/Cargo.toml
+++ b/crypto-macros/Cargo.toml
@@ -9,6 +9,9 @@ license = "GPL-3.0-only"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 syn = { version = "2", features = ["full"] }
 quote = "1"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -11,10 +11,25 @@ publish = false
 name = "core_crypto"
 crate-type = ["lib", "cdylib"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["proteus", "cryptobox-migrate"]
-proteus = ["dep:proteus-wasm", "dep:proteus-traits", "core-crypto-keystore/proteus-keystore"]
-cryptobox-migrate = ["proteus", "proteus-wasm?/cryptobox-identity", "dep:async-fs", "dep:futures-lite", "dep:rexie", "dep:idb", "dep:base64"]
+proteus = [
+    "dep:proteus-wasm",
+    "dep:proteus-traits",
+    "core-crypto-keystore/proteus-keystore",
+]
+cryptobox-migrate = [
+    "proteus",
+    "proteus-wasm?/cryptobox-identity",
+    "dep:async-fs",
+    "dep:futures-lite",
+    "dep:rexie",
+    "dep:idb",
+    "dep:base64",
+]
 # for test/bench all ciphersuites
 test-all-cipher = []
 # execute benches with also real db to better see overhead
@@ -58,7 +73,10 @@ proteus-traits = { workspace = true, optional = true }
 sha2 = "0.10.8"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-sysinfo = { version = "0.32", default-features = false, features = ["apple-app-store", "system"] }
+sysinfo = { version = "0.32", default-features = false, features = [
+    "apple-app-store",
+    "system",
+] }
 async-fs = { version = "2.1", optional = true }
 futures-lite = { version = "2.3", optional = true }
 
@@ -105,7 +123,12 @@ version = "0.5"
 features = ["async_std", "html_reports"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]
+wasm-opt = [
+    "-Os",
+    "--enable-mutable-globals",
+    "--enable-threads",
+    "--detect-features",
+]
 
 [[bench]]
 name = "key_package"

--- a/crypto/src/error.rs
+++ b/crypto/src/error.rs
@@ -134,6 +134,11 @@ pub enum CryptoError {
     /// Incoming message is from a prior epoch
     #[error("Incoming message is from a prior epoch")]
     StaleMessage,
+    /// Incoming message is a commit for which we have not yet received all the proposals.
+    ///
+    /// Buffering until all proposals have arrived.
+    #[error("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.")]
+    BufferedCommit,
     /// Incoming message is from an epoch too far in the future to buffer.
     #[error("Incoming message is from an epoch too far in the future to buffer.")]
     WrongEpoch,

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -412,4 +412,225 @@ mod tests {
             .await
         }
     }
+
+    /// Replicating [WPB-15810]
+    ///
+    /// [WPB-15810]: https://wearezeta.atlassian.net/browse/WPB-15810
+    #[apply(all_cred_cipher)]
+    async fn wpb_15810(case: TestCase) {
+        use openmls::{
+            group::GroupId,
+            prelude::{ExternalProposal, SenderExtensionIndex},
+        };
+
+        if case.is_pure_ciphertext() {
+            // The use case tested here requires inspecting your own commit.
+            // Openmls does not support this currently when protocol messages are encrypted.
+            return;
+        }
+        run_test_with_client_ids(
+            case.clone(),
+            ["external_0", "new_member", "member_27", "observer", "114", "115"],
+            move |[external_0, new_member, member_27, observer, member_114, member_115]| {
+                Box::pin(async move {
+                    // scenario start: everyone except "new_member" is in the conversation
+                    let conv_id = conversation_id();
+
+                    // set up external_0 as the backend / delivery service
+                    let signature_key = external_0.client_signature_key(&case).await.as_slice().to_vec();
+                    let mut config = case.cfg.clone();
+                    observer
+                        .context
+                        .set_raw_external_senders(&mut config, vec![signature_key])
+                        .await
+                        .unwrap();
+
+                    // create and initialize the conversation
+                    observer
+                        .context
+                        .new_conversation(&conv_id, case.credential_type, config)
+                        .await
+                        .unwrap();
+
+                    // everyone else except new_member joins (also except observer, who created it)
+                    observer
+                        .invite_all(&case, &conv_id, [&member_114, &member_115, &member_27])
+                        .await
+                        .unwrap();
+
+                    // Everyone should agree on the overall state here, to wit: the group consists of everyone
+                    // except "new_member", and "external_0", and no messages have been sent.
+                    // At this point only the observer is going to receive messages, because that shouldn't impact group state.
+
+                    // external 0 sends a proposal to remove 114
+                    let leaf_of_114 = observer.index_of(&conv_id, member_114.get_client_id().await).await;
+                    let sender_index = SenderExtensionIndex::new(0);
+                    let sc = case.signature_scheme();
+                    let ct = case.credential_type;
+                    let cb = external_0.find_most_recent_credential_bundle(sc, ct).await.unwrap();
+                    let group_id = GroupId::from_slice(&conv_id[..]);
+                    let epoch = observer.get_conversation_unchecked(&conv_id).await.group.epoch();
+                    let proposal_remove_114_1 = ExternalProposal::new_remove(
+                        leaf_of_114,
+                        group_id.clone(),
+                        epoch,
+                        &cb.signature_key,
+                        sender_index,
+                    )
+                    .unwrap();
+
+                    // now bump the epoch in external_0: the new member has joined
+                    let new_member_join_commit = new_member
+                        .context
+                        .join_by_external_commit(
+                            observer.get_group_info(&conv_id).await,
+                            case.custom_cfg(),
+                            case.credential_type,
+                        )
+                        .await
+                        .unwrap()
+                        .commit;
+
+                    new_member
+                        .context
+                        .merge_pending_group_from_external_commit(&conv_id)
+                        .await
+                        .unwrap();
+
+                    // also create the same proposal with the epoch increased by 1
+                    let leaf_of_114 = new_member.index_of(&conv_id, member_114.get_client_id().await).await;
+                    let proposal_remove_114_2 = ExternalProposal::new_remove(
+                        leaf_of_114,
+                        group_id.clone(),
+                        (epoch.as_u64() + 1).into(),
+                        &cb.signature_key,
+                        sender_index,
+                    )
+                    .unwrap();
+
+                    // now our observer receives these messages out of order
+                    println!("observer executing first proposal");
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    println!("observer executing second proposal");
+                    let result = observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { message_epoch: 2 }
+                    ));
+                    println!("executing commit adding new user");
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &new_member_join_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // now the new member receives the messages in order
+                    println!("new_member executing first proposal");
+                    assert!(matches!(
+                        new_member
+                            .context
+                            .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                            .await
+                            .unwrap_err(),
+                        CryptoError::StaleProposal,
+                    ));
+                    println!("new_member executing second proposal");
+                    new_member
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // now let's switch to the perspective of member 27
+                    // they have observed exactly one of the "remove 114" proposals,
+                    // plus a "remove 115" proposal. We can assume that they observe the 2nd
+                    // "remove 114" proposal because they advanced the epoch correctly when
+                    // the new member was added.
+                    let leaf_of_115 = observer.index_of(&conv_id, member_115.get_client_id().await).await;
+                    let epoch = observer.get_conversation_unchecked(&conv_id).await.group.epoch();
+                    let proposal_remove_115 =
+                        ExternalProposal::new_remove(leaf_of_115, group_id, epoch, &cb.signature_key, sender_index)
+                            .unwrap();
+
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_1.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    let result = member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_114_2.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        CryptoError::BufferedFutureMessage { message_epoch: 2 }
+                    ));
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &new_member_join_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    let remove_two_members_commit = member_27
+                        .context
+                        .commit_pending_proposals(&conv_id)
+                        .await
+                        .unwrap() // result, for errors
+                        .unwrap() // option, in case no proposals
+                        .commit;
+
+                    // member 27 applies its own commit
+                    member_27
+                        .context
+                        .decrypt_message(&conv_id, remove_two_members_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // In this case, note that observer receives the proposal before the commit.
+                    // This is the straightforward ordering and easy to deal with.
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+                    observer
+                        .context
+                        .decrypt_message(&conv_id, &remove_two_members_commit.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // In this case, new_member receives the commit before the proposal. This means that
+                    // the commit has to be buffered until the proposal it references is received.
+                    let result = new_member
+                        .context
+                        .decrypt_message(&conv_id, &remove_two_members_commit.to_bytes().unwrap())
+                        .await;
+                    assert!(matches!(result.unwrap_err(), CryptoError::BufferedCommit));
+                    new_member
+                        .context
+                        .decrypt_message(&conv_id, &proposal_remove_115.to_bytes().unwrap())
+                        .await
+                        .unwrap();
+
+                    // And communication is possible
+                    observer.try_talk_to(&conv_id, &new_member).await.unwrap();
+                    observer.try_talk_to(&conv_id, &member_27).await.unwrap();
+                    new_member.try_talk_to(&conv_id, &member_27).await.unwrap();
+                })
+            },
+        )
+        .await
+    }
 }

--- a/decode/Cargo.toml
+++ b/decode/Cargo.toml
@@ -3,7 +3,10 @@ name = "decode"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
-proteus-wasm = { workspace = true,  features = ["serde"]}
+proteus-wasm = { workspace = true, features = ["serde"] }
 base64 = { workspace = true }

--- a/extras/keystore-regression-versions/Cargo.toml
+++ b/extras/keystore-regression-versions/Cargo.toml
@@ -13,4 +13,3 @@ rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 cfg-if = "1"
 indicatif = { version = "0.17", features = ["futures"] }
-

--- a/extras/webdriver-installation/Cargo.toml
+++ b/extras/webdriver-installation/Cargo.toml
@@ -20,7 +20,12 @@ url = "2.3"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock", "wasmbind", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "std",
+    "clock",
+    "wasmbind",
+    "serde",
+] }
 semver = { version = "1.0", features = ["serde"] }
 tempfile = "3.3"
 futures-util = "0.3"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -12,8 +12,11 @@ proteus = [
     "dep:proteus-wasm",
     "dep:tempfile",
     "core-crypto/cryptobox-migrate",
-    "core-crypto/proteus"
+    "core-crypto/proteus",
 ]
+
+[lints]
+workspace = true
 
 [dependencies]
 color-eyre = "0.6"
@@ -49,4 +52,3 @@ warp = { version = "0.3", default-features = false }
 webdriver-installation = { path = "../extras/webdriver-installation" }
 fantoccini = "0.21"
 proteus-wasm = { workspace = true, optional = true }
-

--- a/keystore-dump/Cargo.toml
+++ b/keystore-dump/Cargo.toml
@@ -5,10 +5,12 @@ version = "3.0.2"
 edition = "2021"
 license = "GPL-3.0-only"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 color-eyre = "0.6"
-
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 core-crypto-keystore = { workspace = true, features = ["serde"] }
@@ -28,7 +30,11 @@ openmls_basic_credential.workspace = true
 openmls_x509_credential.workspace = true
 tls_codec.workspace = true
 
-chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+    "serde",
+] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.proteus-wasm]
 workspace = true

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -19,10 +19,17 @@ harness = false
 name = "write"
 harness = false
 
+[lints]
+workspace = true
+
 [features]
 default = ["proteus-keystore"]
 proteus-keystore = ["dep:proteus-traits"]
-ios-wal-compat = ["dep:security-framework", "dep:security-framework-sys", "dep:core-foundation"]
+ios-wal-compat = [
+    "dep:security-framework",
+    "dep:security-framework-sys",
+    "dep:core-foundation",
+]
 idb-regression-test = []
 log-queries = ["rusqlite/trace"]
 serde = ["dep:serde"]
@@ -65,7 +72,7 @@ features = [
     "limits",
     "unlock_notify",
     "uuid",
-    "functions"
+    "functions",
 ]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.refinery]

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -45,6 +45,7 @@ async-lock.workspace = true
 postcard = { version = "1.0", default-features = false, features = ["use-std"] }
 sha2.workspace = true
 serde_json.workspace = true
+core-crypto-macros.workspace = true
 
 # iOS specific things
 security-framework = { version = "3.0", optional = true }
@@ -111,7 +112,10 @@ rstest = "0.23"
 rstest_reuse = "0.7"
 async-std = { workspace = true, features = ["attributes"] }
 futures-lite = "2.3"
-core-crypto-keystore = { path = ".", features = ["idb-regression-test", "log-queries"] }
+core-crypto-keystore = { path = ".", features = [
+    "idb-regression-test",
+    "log-queries",
+] }
 pretty_env_logger = "0.5"
 proteus-wasm = { workspace = true }
 
@@ -120,4 +124,9 @@ version = "0.5"
 features = ["async_futures", "html_reports"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Os", "--enable-mutable-globals", "--enable-threads", "--detect-features"]
+wasm-opt = [
+    "-Os",
+    "--enable-mutable-globals",
+    "--enable-threads",
+    "--detect-features",
+]

--- a/keystore/src/connection/platform/generic/migrations/V14__buffered_commits.sql
+++ b/keystore/src/connection/platform/generic/migrations/V14__buffered_commits.sql
@@ -1,0 +1,4 @@
+CREATE TABLE mls_buffered_commits (
+    conversation_id_hex TEXT UNIQUE,
+    commit_data BLOB
+);

--- a/keystore/src/entities/mls.rs
+++ b/keystore/src/entities/mls.rs
@@ -89,6 +89,48 @@ pub struct MlsPendingMessage {
     pub message: Vec<u8>,
 }
 
+/// Entity representing a buffered commit.
+///
+/// There should always exist either 0 or 1 of these in the store per conversation.
+/// Commits are buffered if not all proposals they reference have yet been received.
+///
+/// We don't automatically zeroize on drop because the commit data is still encrypted at this point;
+/// it is not risky to leave it in memory.
+#[derive(Debug, Clone, PartialEq, Eq, Zeroize, core_crypto_macros::Entity)]
+#[cfg_attr(
+    any(target_family = "wasm", feature = "serde"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct MlsBufferedCommit {
+    // we'd ideally just call this field `conversation_id`, but as of right now the
+    // Entity macro does not yet support id columns not named `id`
+    #[id(hex, column = "conversation_id_hex")]
+    conversation_id: Vec<u8>,
+    commit_data: Vec<u8>,
+}
+
+impl MlsBufferedCommit {
+    /// Create a new `Self` from conversation id and the commit data.
+    pub fn new(conversation_id: Vec<u8>, commit_data: Vec<u8>) -> Self {
+        Self {
+            conversation_id,
+            commit_data,
+        }
+    }
+
+    pub fn conversation_id(&self) -> &[u8] {
+        &self.conversation_id
+    }
+
+    pub fn commit_data(&self) -> &[u8] {
+        &self.commit_data
+    }
+
+    pub fn into_commit_data(self) -> Vec<u8> {
+        self.commit_data
+    }
+}
+
 /// Entity representing a persisted `Credential`
 #[derive(Debug, Clone, PartialEq, Eq, Zeroize)]
 #[zeroize(drop)]

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -35,6 +35,8 @@ pub enum MissingKeyErrorKind {
     MlsPskBundle,
     #[error("MLS CredentialBundle")]
     MlsCredential,
+    #[error("MLS Buffered Commit")]
+    MlsBufferedCommit,
     #[error("MLS Persisted Group")]
     MlsGroup,
     #[error("MLS Persisted Pending Group")]

--- a/keystore/src/transaction/dynamic_dispatch.rs
+++ b/keystore/src/transaction/dynamic_dispatch.rs
@@ -4,9 +4,9 @@
 use crate::connection::TransactionWrapper;
 use crate::entities::{
     ConsumerData, E2eiAcmeCA, E2eiCrl, E2eiEnrollment, E2eiIntermediateCert, E2eiRefreshToken, EntityBase,
-    EntityTransactionExt, MlsCredential, MlsEncryptionKeyPair, MlsEpochEncryptionKeyPair, MlsHpkePrivateKey,
-    MlsKeyPackage, MlsPendingMessage, MlsPskBundle, MlsSignatureKeyPair, PersistedMlsGroup, PersistedMlsPendingGroup,
-    StringEntityId, UniqueEntity,
+    EntityTransactionExt, MlsBufferedCommit, MlsCredential, MlsEncryptionKeyPair, MlsEpochEncryptionKeyPair,
+    MlsHpkePrivateKey, MlsKeyPackage, MlsPendingMessage, MlsPskBundle, MlsSignatureKeyPair, PersistedMlsGroup,
+    PersistedMlsPendingGroup, StringEntityId, UniqueEntity,
 };
 #[cfg(feature = "proteus-keystore")]
 use crate::entities::{ProteusIdentity, ProteusPrekey, ProteusSession};
@@ -22,6 +22,7 @@ pub enum Entity {
     EncryptionKeyPair(MlsEncryptionKeyPair),
     EpochEncryptionKeyPair(MlsEpochEncryptionKeyPair),
     MlsCredential(MlsCredential),
+    MlsBufferedCommit(MlsBufferedCommit),
     PersistedMlsGroup(PersistedMlsGroup),
     PersistedMlsPendingGroup(PersistedMlsPendingGroup),
     MlsPendingMessage(MlsPendingMessage),
@@ -47,6 +48,7 @@ pub enum EntityId {
     EncryptionKeyPair(Vec<u8>),
     EpochEncryptionKeyPair(Vec<u8>),
     MlsCredential(Vec<u8>),
+    MlsBufferedCommit(Vec<u8>),
     PersistedMlsGroup(Vec<u8>),
     PersistedMlsPendingGroup(Vec<u8>),
     MlsPendingMessage(Vec<u8>),
@@ -73,6 +75,7 @@ impl EntityId {
             EntityId::EncryptionKeyPair(vec) => vec.as_slice().into(),
             EntityId::EpochEncryptionKeyPair(vec) => vec.as_slice().into(),
             EntityId::MlsCredential(vec) => vec.as_slice().into(),
+            EntityId::MlsBufferedCommit(vec) => vec.as_slice().into(),
             EntityId::PersistedMlsGroup(vec) => vec.as_slice().into(),
             EntityId::PersistedMlsPendingGroup(vec) => vec.as_slice().into(),
             EntityId::MlsPendingMessage(vec) => vec.as_slice().into(),
@@ -98,6 +101,7 @@ impl EntityId {
             MlsPskBundle::COLLECTION_NAME => Ok(Self::PskBundle(id.into())),
             MlsEncryptionKeyPair::COLLECTION_NAME => Ok(Self::EncryptionKeyPair(id.into())),
             MlsEpochEncryptionKeyPair::COLLECTION_NAME => Ok(Self::EpochEncryptionKeyPair(id.into())),
+            MlsBufferedCommit::COLLECTION_NAME => Ok(Self::MlsBufferedCommit(id.into())),
             PersistedMlsGroup::COLLECTION_NAME => Ok(Self::PersistedMlsGroup(id.into())),
             PersistedMlsPendingGroup::COLLECTION_NAME => Ok(Self::PersistedMlsPendingGroup(id.into())),
             MlsCredential::COLLECTION_NAME => Ok(Self::MlsCredential(id.into())),
@@ -125,6 +129,7 @@ impl EntityId {
             EntityId::EncryptionKeyPair(_) => MlsEncryptionKeyPair::COLLECTION_NAME,
             EntityId::EpochEncryptionKeyPair(_) => MlsEpochEncryptionKeyPair::COLLECTION_NAME,
             EntityId::MlsCredential(_) => MlsCredential::COLLECTION_NAME,
+            EntityId::MlsBufferedCommit(_) => MlsBufferedCommit::COLLECTION_NAME,
             EntityId::PersistedMlsGroup(_) => PersistedMlsGroup::COLLECTION_NAME,
             EntityId::PersistedMlsPendingGroup(_) => PersistedMlsPendingGroup::COLLECTION_NAME,
             EntityId::MlsPendingMessage(_) => MlsPendingMessage::COLLECTION_NAME,
@@ -154,6 +159,7 @@ pub async fn execute_save(tx: &TransactionWrapper<'_>, entity: &Entity) -> Crypt
         Entity::EncryptionKeyPair(mls_encryption_key_pair) => mls_encryption_key_pair.save(tx).await,
         Entity::EpochEncryptionKeyPair(mls_epoch_encryption_key_pair) => mls_epoch_encryption_key_pair.save(tx).await,
         Entity::MlsCredential(mls_credential) => mls_credential.save(tx).await,
+        Entity::MlsBufferedCommit(mls_pending_commit) => mls_pending_commit.save(tx).await,
         Entity::PersistedMlsGroup(persisted_mls_group) => persisted_mls_group.save(tx).await,
         Entity::PersistedMlsPendingGroup(persisted_mls_pending_group) => persisted_mls_pending_group.save(tx).await,
         Entity::MlsPendingMessage(mls_pending_message) => mls_pending_message.save(tx).await,
@@ -180,6 +186,7 @@ pub async fn execute_delete(tx: &TransactionWrapper<'_>, entity_id: &EntityId) -
         id @ EntityId::EncryptionKeyPair(_) => MlsEncryptionKeyPair::delete(tx, id.as_id()).await,
         id @ EntityId::EpochEncryptionKeyPair(_) => MlsEpochEncryptionKeyPair::delete(tx, id.as_id()).await,
         id @ EntityId::MlsCredential(_) => MlsCredential::delete(tx, id.as_id()).await,
+        id @ EntityId::MlsBufferedCommit(_) => MlsBufferedCommit::delete(tx, id.as_id()).await,
         id @ EntityId::PersistedMlsGroup(_) => PersistedMlsGroup::delete(tx, id.as_id()).await,
         id @ EntityId::PersistedMlsPendingGroup(_) => PersistedMlsPendingGroup::delete(tx, id.as_id()).await,
         id @ EntityId::MlsPendingMessage(_) => MlsPendingMessage::delete(tx, id.as_id()).await,

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 name = "mls_crypto_provider"
 crate-type = ["lib", "cdylib"]
 
+[lints]
+workspace = true
+
 [features]
 default = []
 raw-rand-access = [] # TESTING ONLY


### PR DESCRIPTION
# What's new in this PR

- Backports the commit-buffering mechanics from #907 to the 3.x branch.
- Closes #914

# Unresolved design decisions

Should we make the unbuffered commit error public? On some target platforms, but not all, adding a variant to the error enum is a breaking change. 

If we decide to do this, we also need to cherry-pick fbb365facb794cb495f51515dfd9ca448f6d1845 into this PR.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
