### PR TITLE
fix: querying an wire identity is correctly typed in TS bindings [WPB-16047]

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -21,6 +21,8 @@ export { CoreCryptoContext } from "./CoreCryptoContext.js";
 
 export {
     BuildMetadata,
+    WireIdentity,
+    X509Identity,
     setLogger,
     CoreCryptoLogLevel,
     setMaxLogLevel,

--- a/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
@@ -15,7 +15,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
 import * as CoreCryptoFfiTypes from "./core-crypto-ffi.d.js";
-export { BuildMetadata } from "./core-crypto-ffi.d.js";
+export {
+    BuildMetadata,
+    WireIdentity,
+    X509Identity,
+} from "./core-crypto-ffi.d.js";
 
 import {
     CoreCrypto as CoreCryptoFfi,

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -649,6 +649,51 @@ describe("end to end identity", () => {
         );
         expect(conversationState).toBe(E2eiConversationState.NotEnabled);
     });
+
+    it("identities can be queried by client id", async () => {
+        await ccInit(ALICE_ID);
+        await createConversation(ALICE_ID, CONV_ID);
+        const identities = await browser.execute(
+            async (clientName, conversationId) => {
+                const cc = window.ensureCcDefined(clientName);
+                const encoder = new TextEncoder();
+                const identities = await cc.transaction(async (ctx) => {
+                    return await ctx.getDeviceIdentities(
+                        encoder.encode(conversationId),
+                        [encoder.encode(clientName)]
+                    );
+                });
+
+                return identities.pop()?.clientId;
+            },
+            ALICE_ID,
+            CONV_ID
+        );
+        expect(identities).toBe(ALICE_ID);
+    });
+
+    it("identities can be queried by user id", async () => {
+        const ALICE_ID = "LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com";
+        await ccInit(ALICE_ID);
+        await createConversation(ALICE_ID, CONV_ID);
+        const identities = await browser.execute(
+            async (clientName, conversationId) => {
+                const cc = window.ensureCcDefined(clientName);
+                const encoder = new TextEncoder();
+                const identities = await cc.transaction(async (ctx) => {
+                    return await ctx.getUserIdentities(
+                        encoder.encode(conversationId),
+                        ["LcksJb74Tm6N12cDjFy7lQ"]
+                    );
+                });
+
+                return identities.values().next().value?.pop()?.clientId;
+            },
+            ALICE_ID,
+            CONV_ID
+        );
+        expect(identities).toBe(ALICE_ID);
+    });
 });
 
 describe("logger", () => {

--- a/crypto-ffi/src/wasm/context/e2ei.rs
+++ b/crypto-ffi/src/wasm/context/e2ei.rs
@@ -336,7 +336,7 @@ impl CoreCryptoContext {
                     .into_iter()
                     .map(Into::into)
                     .collect::<Vec<WireIdentity>>();
-                WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&identities)?)
+                WasmCryptoResult::Ok(identities.into())
             }
             .err_into(),
         )
@@ -359,7 +359,7 @@ impl CoreCryptoContext {
                 let js_obj = js_sys::Map::new();
                 for (uid, identities) in identities.into_iter() {
                     let uid = js_sys::JsString::from(uid).into();
-                    let identities = serde_wasm_bindgen::to_value(&identities)?;
+                    let identities = JsValue::from(identities);
                     js_obj.set(&uid, &identities);
                 }
                 WasmCryptoResult::Ok(js_obj.into())

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1861,7 +1861,7 @@ impl CoreCrypto {
                     .into_iter()
                     .map(Into::into)
                     .collect::<Vec<WireIdentity>>();
-                WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&identities)?)
+                WasmCryptoResult::Ok(identities.into())
             }
             .err_into(),
         )
@@ -1884,7 +1884,7 @@ impl CoreCrypto {
                 let js_obj = js_sys::Map::new();
                 for (uid, identities) in identities.into_iter() {
                     let uid = js_sys::JsString::from(uid).into();
-                    let identities = serde_wasm_bindgen::to_value(&identities)?;
+                    let identities = JsValue::from(identities);
                     js_obj.set(&uid, &identities);
                 }
                 WasmCryptoResult::Ok(js_obj.into())


### PR DESCRIPTION
# What's new in this PR

Querying an `WireIdentity` using `getDeviceIdentities` or `getUserIdentities` didn't return a type matching the declared `WireIdentity` and on top of that, the `WireIdentity` and `X509Identity` were not publicly exposed.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
