### PR TITLE
chore: distribute CoreCrypto for iOS via Swift Package Manager - WPB-11043

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.0
+
+import Foundation
+import PackageDescription
+
+let package = Package(
+    name: "WireCoreCrypto",
+    platforms: [.iOS(.v16), .macOS(.v12)],
+    products: [
+        .library(
+            name: "WireCoreCrypto",
+            targets: ["WireCoreCrypto"]
+        )
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "WireCoreCrypto",
+            url: "https://github.com/wireapp/core-crypto/releases/download/v3.1.0/WireCoreCrypto.xcframework.zip",
+            checksum: "3bb569dc7041f5e062abab2fb8a1b175e850d61978deb17150bc52bfe20302d3"
+        )
+    ]
+)


### PR DESCRIPTION
# What's new in this PR

This PR adds a Package.swift file to allow iOS app to use binary via SPM. Currently it points to 3.1.0. 

Note: this probably needs some work to be updated via CC's CI to calculate checksum and update the version.

Note 2: as a first step this file is hosted for now in wire-ios repo. See https://github.com/wireapp/wire-ios/pull/2548

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
