### PR TITLE
chore: implement `ConversationGuard` [WPB-15577]

### DIFF
--- a/crypto/src/e2e_identity/identity.rs
+++ b/crypto/src/e2e_identity/identity.rs
@@ -139,7 +139,7 @@ impl MlsCentral {
             .refresh_time_of_interest()
             .await;
         let conversation = self
-            .get_conversation(conversation_id)
+            .get_raw_conversation(conversation_id)
             .await
             .map_err(RecursiveError::mls_conversation("getting conversation by id"))?;
         conversation.get_device_identities(
@@ -164,7 +164,7 @@ impl MlsCentral {
             .refresh_time_of_interest()
             .await;
         let conversation = self
-            .get_conversation(conversation_id)
+            .get_raw_conversation(conversation_id)
             .await
             .map_err(RecursiveError::mls_conversation("getting conversation by id"))?;
         conversation.get_user_identities(

--- a/crypto/src/mls/conversation/conversation_guard.rs
+++ b/crypto/src/mls/conversation/conversation_guard.rs
@@ -1,0 +1,63 @@
+// this isssue is about creating this helper struct,
+// but we'll see the dead code warning until we actually use it in follow-up work
+#![expect(dead_code)]
+
+use async_lock::{RwLockReadGuard, RwLockWriteGuard};
+use mls_crypto_provider::MlsCryptoProvider;
+
+use crate::{context::CentralContext, group_store::GroupStoreValue, RecursiveError};
+
+use super::{commit::MlsCommitBundle, Error, MlsConversation, Result};
+
+/// A Conversation Guard wraps a `GroupStoreValue<MlsConversation>`.
+///
+/// By doing so, it permits mutable accesses to the conversation. This in turn
+/// means that we don't have to duplicate the entire `MlsConversation` API
+/// on `CentralContext`.
+pub(crate) struct ConversationGuard {
+    inner: GroupStoreValue<MlsConversation>,
+    central_context: CentralContext,
+}
+
+impl ConversationGuard {
+    pub(crate) fn new(inner: GroupStoreValue<MlsConversation>, central_context: CentralContext) -> Self {
+        Self { inner, central_context }
+    }
+
+    pub(crate) async fn conversation(&self) -> RwLockReadGuard<MlsConversation> {
+        self.inner.read().await
+    }
+
+    pub(crate) async fn conversation_mut(&mut self) -> RwLockWriteGuard<MlsConversation> {
+        self.inner.write().await
+    }
+
+    async fn mls_provider(&self) -> Result<MlsCryptoProvider> {
+        self.central_context
+            .mls_provider()
+            .await
+            .map_err(RecursiveError::root("getting mls provider"))
+            .map_err(Into::into)
+    }
+
+    pub(crate) async fn send_and_merge_commit(&mut self, commit: MlsCommitBundle) -> Result<()> {
+        // note we hand over this instance of the guard; when we need a `conversation` guard again,
+        // we'll need to re-fetch it.
+        let conversation = self.inner.write().await;
+        match self.central_context.send_commit(commit, Some(conversation)).await {
+            Ok(false) => Ok(()),
+            Ok(true) => {
+                let backend = self.mls_provider().await?;
+                let mut conversation = self.inner.write().await;
+                conversation.commit_accepted(&backend).await
+            }
+            Err(e @ Error::MessageRejected { .. }) => {
+                let backend = self.mls_provider().await?;
+                let mut conversation = self.inner.write().await;
+                conversation.clear_pending_commit(&backend).await?;
+                Err(e)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/crypto/src/mls/conversation/export.rs
+++ b/crypto/src/mls/conversation/export.rs
@@ -89,7 +89,7 @@ impl MlsCentral {
     /// OpenMls secret generation error or conversation not found
     #[cfg_attr(test, crate::idempotent)]
     pub async fn export_secret_key(&self, conversation_id: &ConversationId, key_length: usize) -> Result<Vec<u8>> {
-        self.get_conversation(conversation_id)
+        self.get_raw_conversation(conversation_id)
             .await?
             .export_secret_key(&self.mls_backend, key_length)
     }
@@ -103,7 +103,7 @@ impl MlsCentral {
     /// if the conversation can't be found
     #[cfg_attr(test, crate::idempotent)]
     pub async fn get_client_ids(&self, conversation_id: &ConversationId) -> Result<Vec<ClientId>> {
-        Ok(self.get_conversation(conversation_id).await?.get_client_ids())
+        Ok(self.get_raw_conversation(conversation_id).await?.get_client_ids())
     }
 }
 

--- a/crypto/src/mls/conversation/external_sender.rs
+++ b/crypto/src/mls/conversation/external_sender.rs
@@ -6,7 +6,7 @@ impl MlsCentral {
     /// Returns the raw public key of the single external sender present in this group.
     /// This should be used to initialize a subconversation
     pub async fn get_external_sender(&self, id: &ConversationId) -> Result<Vec<u8>> {
-        self.get_conversation(id).await?.get_external_sender().await
+        self.get_raw_conversation(id).await?.get_external_sender().await
     }
 }
 

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -260,7 +260,16 @@ impl MlsConversation {
 }
 
 impl MlsCentral {
-    pub(crate) async fn get_conversation(&self, id: &ConversationId) -> Result<MlsConversation> {
+    /// Get a raw `MlsConversation`.
+    ///
+    /// <div class="warning">
+    /// This does _not_ return a [`GroupStoreValue`] and does not support mutating operations on the `MlsConversation`.
+    /// They may appear to work, but changes will not be persisted!
+    /// </div>
+    ///
+    /// Because it operates on the raw conversation type, this may be faster than [`CentralContext::get_conversation`]
+    /// for transient and immutable purposes. For long-lived or mutable purposes, prefer the other method.
+    pub(crate) async fn get_raw_conversation(&self, id: &ConversationId) -> Result<MlsConversation> {
         GroupStore::fetch_from_keystore(id, &self.mls_backend.keystore(), None)
             .await
             .map_err(RecursiveError::root("getting conversation by id"))?

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -277,11 +277,11 @@ impl MlsCentral {
 
     /// Checks if a given conversation id exists locally
     pub async fn conversation_exists(&self, id: &ConversationId) -> Result<bool> {
-        match self.get_conversation(id).await {
+        match self.get_raw_conversation(id).await {
             Ok(_) => Ok(true),
             Err(conversation::Error::Leaf(LeafError::ConversationNotFound(_))) => Ok(false),
             Err(e) => {
-                Err(RecursiveError::mls_conversation("getting confersation by id to check for existence")(e).into())
+                Err(RecursiveError::mls_conversation("getting conversation by id to check for existence")(e).into())
             }
         }
     }
@@ -292,13 +292,14 @@ impl MlsCentral {
     /// If the conversation can't be found
     #[cfg_attr(test, crate::idempotent)]
     pub async fn conversation_epoch(&self, id: &ConversationId) -> Result<u64> {
-        Ok(self
-            .get_conversation(id)
+        let epoch = self
+            .get_raw_conversation(id)
             .await
             .map_err(RecursiveError::mls_conversation("getting conversation"))?
             .group
             .epoch()
-            .as_u64())
+            .as_u64();
+        Ok(epoch)
     }
 
     /// Returns the ciphersuite of a given conversation
@@ -308,7 +309,7 @@ impl MlsCentral {
     #[cfg_attr(test, crate::idempotent)]
     pub async fn conversation_ciphersuite(&self, id: &ConversationId) -> Result<MlsCiphersuite> {
         Ok(self
-            .get_conversation(id)
+            .get_raw_conversation(id)
             .await
             .map_err(RecursiveError::mls_conversation("getting conversation"))?
             .ciphersuite())


### PR DESCRIPTION
# What's new in this PR

Start working on refactoring conversation methods so we don't have to duplicate the whole `Conversation` API on `CentralContext`.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
