### PR TITLE
refactor: move commit-producing APIs to `ConversationGuard` [WPB-15587]

### DIFF
--- a/crypto-ffi/src/generic/context/mod.rs
+++ b/crypto-ffi/src/generic/context/mod.rs
@@ -438,7 +438,12 @@ impl CoreCryptoContext {
 
     /// See [core_crypto::context::CentralContext::update_keying_material]
     pub async fn update_keying_material(&self, conversation_id: Vec<u8>) -> CoreCryptoResult<()> {
-        Ok(self.context.update_keying_material(&conversation_id).await?)
+        self.context
+            .conversation_guard(&conversation_id)
+            .await?
+            .update_key_material()
+            .await
+            .map_err(Into::into)
     }
 
     /// See [core_crypto::context::CentralContext::commit_pending_proposals]

--- a/crypto-ffi/src/generic/context/mod.rs
+++ b/crypto-ffi/src/generic/context/mod.rs
@@ -420,10 +420,12 @@ impl CoreCryptoContext {
         clients: Vec<ClientId>,
     ) -> CoreCryptoResult<()> {
         let clients: Vec<core_crypto::prelude::ClientId> = clients.into_iter().map(|c| c.0).collect();
-        Ok(self
-            .context
-            .remove_members_from_conversation(&conversation_id, &clients)
-            .await?)
+        self.context
+            .conversation_guard(&conversation_id)
+            .await?
+            .remove_members(&clients)
+            .await
+            .map_err(Into::into)
     }
 
     /// See [core_crypto::context::CentralContext::mark_conversation_as_child_of]

--- a/crypto-ffi/src/generic/context/mod.rs
+++ b/crypto-ffi/src/generic/context/mod.rs
@@ -387,7 +387,7 @@ impl CoreCryptoContext {
         Ok(result)
     }
 
-    /// See [core_crypto::context::CentralContext::add_members_to_conversation]
+    /// See [core_crypto::mls::conversation::conversation_guard::ConversationGuard::add_members]
     pub async fn add_clients_to_conversation(
         &self,
         conversation_id: Vec<u8>,
@@ -403,12 +403,14 @@ impl CoreCryptoContext {
             })
             .collect::<CoreCryptoResult<Vec<_>>>()?;
 
-        Ok(self
+        let distribution_points: Option<Vec<_>> = self
             .context
-            .add_members_to_conversation(&conversation_id, key_packages)
-            .await
-            .map(|new_crl_distribution_point| -> Option<Vec<_>> { new_crl_distribution_point.into() })?
-            .into())
+            .conversation_guard(&conversation_id)
+            .await?
+            .add_members(key_packages)
+            .await?
+            .into();
+        Ok(distribution_points.into())
     }
 
     /// See [core_crypto::context::CentralContext::remove_members_from_conversation]

--- a/crypto-ffi/src/generic/context/mod.rs
+++ b/crypto-ffi/src/generic/context/mod.rs
@@ -446,9 +446,14 @@ impl CoreCryptoContext {
             .map_err(Into::into)
     }
 
-    /// See [core_crypto::context::CentralContext::commit_pending_proposals]
+    /// See [core_crypto::mls::conversation::conversation_guard::ConversationGuard::commit_pending_proposals]
     pub async fn commit_pending_proposals(&self, conversation_id: Vec<u8>) -> CoreCryptoResult<()> {
-        Ok(self.context.commit_pending_proposals(&conversation_id).await?)
+        self.context
+            .conversation_guard(&conversation_id)
+            .await?
+            .commit_pending_proposals()
+            .await
+            .map_err(Into::into)
     }
 
     /// see [core_crypto::context::CentralContext::wipe_conversation]

--- a/crypto-ffi/src/wasm/context/mod.rs
+++ b/crypto-ffi/src/wasm/context/mod.rs
@@ -437,7 +437,10 @@ impl CoreCryptoContext {
                     .collect::<Vec<ClientId>>();
 
                 context
-                    .remove_members_from_conversation(&conversation_id, &clients)
+                    .conversation_guard(&conversation_id)
+                    .await
+                    .map_err(CoreCryptoError::from)?
+                    .remove_members(&clients)
                     .await
                     .map_err(CoreCryptoError::from)?;
 

--- a/crypto-ffi/src/wasm/context/mod.rs
+++ b/crypto-ffi/src/wasm/context/mod.rs
@@ -390,7 +390,7 @@ impl CoreCryptoContext {
 
     /// Returns: [`WasmCryptoResult<Option<Vec<String>>>`]
     ///
-    /// see [core_crypto::mls::context::CentralContext::add_members_to_conversation]
+    /// see [core_crypto::mls::conversation::conversation_guard::ConversationGuard::add_members]
     pub fn add_clients_to_conversation(
         &self,
         conversation_id: ConversationId,
@@ -408,7 +408,9 @@ impl CoreCryptoContext {
                     .collect::<CoreCryptoResult<Vec<_>>>()?;
 
                 let new_crl_distribution_point = context
-                    .add_members_to_conversation(&conversation_id, key_packages)
+                    .conversation_guard(&conversation_id)
+                    .await?
+                    .add_members(key_packages)
                     .await?;
                 let new_crl_distribution_point: Option<Vec<String>> = new_crl_distribution_point.into();
                 WasmCryptoResult::Ok(serde_wasm_bindgen::to_value(&new_crl_distribution_point)?)

--- a/crypto-ffi/src/wasm/context/mod.rs
+++ b/crypto-ffi/src/wasm/context/mod.rs
@@ -475,7 +475,10 @@ impl CoreCryptoContext {
         future_to_promise(
             async move {
                 context
-                    .update_keying_material(&conversation_id)
+                    .conversation_guard(&conversation_id)
+                    .await
+                    .map_err(CoreCryptoError::from)?
+                    .update_key_material()
                     .await
                     .map_err(CoreCryptoError::from)?;
                 WasmCryptoResult::Ok(JsValue::UNDEFINED)

--- a/crypto-ffi/src/wasm/context/mod.rs
+++ b/crypto-ffi/src/wasm/context/mod.rs
@@ -494,7 +494,11 @@ impl CoreCryptoContext {
         let context = self.inner.clone();
         future_to_promise(
             async move {
-                context.commit_pending_proposals(&conversation_id).await?;
+                context
+                    .conversation_guard(&conversation_id)
+                    .await?
+                    .commit_pending_proposals()
+                    .await?;
                 WasmCryptoResult::Ok(JsValue::UNDEFINED)
             }
             .err_into(),

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -223,7 +223,15 @@ fn commit_pending_proposals_bench_var_n_proposals(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.commit_pending_proposals(&id).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .commit_pending_proposals()
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },
@@ -258,7 +266,15 @@ fn commit_pending_proposals_bench_var_group_size(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.commit_pending_proposals(&id).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .commit_pending_proposals()
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -178,7 +178,15 @@ fn commit_update_bench(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.update_keying_material(&id).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .update_key_material()
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -106,7 +106,10 @@ fn commit_remove_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         black_box(
                             context
-                                .remove_members_from_conversation(&id, client_ids.as_slice())
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .remove_members(&client_ids)
                                 .await
                                 .unwrap(),
                         );
@@ -141,7 +144,10 @@ fn commit_remove_n_clients_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         black_box(
                             context
-                                .remove_members_from_conversation(&id, client_ids.as_slice())
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .remove_members(client_ids.as_slice())
                                 .await
                                 .unwrap(),
                         );

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -27,7 +27,15 @@ fn commit_add_bench(c: &mut Criterion) {
                     },
                     |(central, id, kps)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.add_members_to_conversation(&id, kps).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .add_members(kps)
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },
@@ -59,7 +67,15 @@ fn commit_add_n_clients_bench(c: &mut Criterion) {
                     },
                     |(central, id, kps)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.add_members_to_conversation(&id, kps).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .add_members(kps)
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },

--- a/crypto/benches/create_group.rs
+++ b/crypto/benches/create_group.rs
@@ -69,7 +69,10 @@ fn join_from_welcome_bench(c: &mut Criterion) {
                             bob_context.finish().await.unwrap();
                             let alice_context = alice_central.new_transaction().await.unwrap();
                             alice_context
-                                .add_members_to_conversation(&id, vec![bob_kp.into()])
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .add_members(vec![bob_kp.into()])
                                 .await
                                 .unwrap();
                             let welcome = delivery_service.latest_welcome_message().await;

--- a/crypto/benches/mls_proteus.rs
+++ b/crypto/benches/mls_proteus.rs
@@ -114,7 +114,15 @@ fn add_client_bench(c: &mut Criterion) {
                     },
                     |(central, id, kps)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.add_members_to_conversation(&id, kps).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .add_members(kps)
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },

--- a/crypto/benches/mls_proteus.rs
+++ b/crypto/benches/mls_proteus.rs
@@ -181,7 +181,10 @@ fn remove_client_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         black_box(
                             context
-                                .remove_members_from_conversation(&id, client_ids.as_slice())
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .remove_members(client_ids.as_slice())
                                 .await
                                 .unwrap(),
                         );

--- a/crypto/benches/mls_proteus.rs
+++ b/crypto/benches/mls_proteus.rs
@@ -248,7 +248,15 @@ fn update_client_bench(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
-                        black_box(context.update_keying_material(&id).await.unwrap());
+                        black_box(
+                            context
+                                .conversation_guard(&id)
+                                .await
+                                .unwrap()
+                                .update_key_material()
+                                .await
+                                .unwrap(),
+                        );
                         context.finish().await.unwrap();
                         black_box(());
                     },

--- a/crypto/benches/utils/mls.rs
+++ b/crypto/benches/utils/mls.rs
@@ -205,7 +205,13 @@ pub async fn add_clients(
 
     let core_crypto = CoreCrypto::from(central.clone());
     let context = core_crypto.new_transaction().await.unwrap();
-    context.add_members_to_conversation(id, key_packages).await.unwrap();
+    context
+        .conversation_guard(id)
+        .await
+        .unwrap()
+        .add_members(key_packages)
+        .await
+        .unwrap();
     let commit_bundle = main_client_delivery_service.latest_commit_bundle().await;
 
     let group_info = commit_bundle.group_info.payload.bytes();
@@ -289,7 +295,10 @@ pub async fn invite(
         .unwrap();
     let other_kp = other_kps.first().unwrap().clone();
     from_context
-        .add_members_to_conversation(id, vec![other_kp.into()])
+        .conversation_guard(id)
+        .await
+        .unwrap()
+        .add_members(vec![other_kp.into()])
         .await
         .unwrap();
     let welcome = delivery_service.latest_welcome_message().await;

--- a/crypto/src/e2e_identity/rotate.rs
+++ b/crypto/src/e2e_identity/rotate.rs
@@ -1034,7 +1034,14 @@ pub(crate) mod tests {
                         .await
                         .unwrap();
 
-                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
 
                     // Finally, Alice merges her commit and verifies her new identity gets applied
                     alice_central

--- a/crypto/src/e2e_identity/rotate.rs
+++ b/crypto/src/e2e_identity/rotate.rs
@@ -1007,7 +1007,14 @@ pub(crate) mod tests {
                     let _rotate_commit = alice_central.create_unmerged_e2ei_rotate_commit(&id, &cb).await;
 
                     // Meanwhile, Bob creates a simple commit
-                    bob_central.context.update_keying_material(&id).await.unwrap();
+                    bob_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     // accepted by the backend
                     let bob_commit = bob_central.mls_transport.latest_commit().await;
 

--- a/crypto/src/mls/buffer_external_commit.rs
+++ b/crypto/src/mls/buffer_external_commit.rs
@@ -315,7 +315,14 @@ mod tests {
                     alice_central.invite_all(&case, &id, [&mut bob_central]).await.unwrap();
 
                     // Alice will never see this commit
-                    bob_central.context.update_keying_material(&id).await.unwrap();
+                    bob_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
 
                     let msg1 = bob_central.context.encrypt_message(&id, "A").await.unwrap();
                     let msg2 = bob_central.context.encrypt_message(&id, "B").await.unwrap();

--- a/crypto/src/mls/buffer_external_commit.rs
+++ b/crypto/src/mls/buffer_external_commit.rs
@@ -207,7 +207,10 @@ mod tests {
                     let charlie = charlie_central.rand_key_package(&case).await;
                     alice_central
                         .context
-                        .add_members_to_conversation(&id, vec![charlie])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .add_members(vec![charlie])
                         .await
                         .unwrap();
                     let commit = alice_central.mls_transport.latest_commit_bundle().await;

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -592,7 +592,14 @@ mod tests {
                         .await
                         .unwrap();
 
-                    member_27.context.commit_pending_proposals(&conv_id).await.unwrap();
+                    member_27
+                        .context
+                        .conversation_guard(&conv_id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     let remove_two_members_commit = member_27.mls_transport.latest_commit().await;
 
                     // In this case, note that observer receives the proposal before the commit.

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -343,7 +343,7 @@ mod tests {
                         .context
                         .conversation_guard(&id)
                         .await
-                        .unwrap
+                        .unwrap()
                         .add_members(vec![debbie])
                         .await
                         .unwrap();

--- a/crypto/src/mls/conversation/buffer_messages.rs
+++ b/crypto/src/mls/conversation/buffer_messages.rs
@@ -207,7 +207,10 @@ mod tests {
                     let charlie = charlie_central.rand_key_package(&case).await;
                     alice_central
                         .context
-                        .add_members_to_conversation(&id, vec![charlie])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .add_members(vec![charlie])
                         .await
                         .unwrap();
                     let commit = alice_central.mls_transport.latest_commit_bundle().await;
@@ -338,7 +341,10 @@ mod tests {
                     let debbie = debbie_central.rand_key_package(&case).await;
                     bob_central
                         .context
-                        .add_members_to_conversation(&id, vec![debbie])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap
+                        .add_members(vec![debbie])
                         .await
                         .unwrap();
                     let commit = bob_central.mls_transport.latest_commit_bundle().await;

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -184,7 +184,7 @@ mod tests {
                         .context
                         .conversation_guard(&id)
                         .await
-                        .unwrap
+                        .unwrap()
                         .add_members(vec![bob])
                         .await
                         .unwrap();

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -182,7 +182,10 @@ mod tests {
                     let bob = bob_central.rand_key_package(&case).await;
                     alice_central
                         .context
-                        .add_members_to_conversation(&id, vec![bob])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap
+                        .add_members(vec![bob])
                         .await
                         .unwrap();
                     let bob_welcome = alice_central.mls_transport.latest_welcome_message().await;
@@ -197,7 +200,10 @@ mod tests {
                     let charlie = charlie_central.rand_key_package(&case).await;
                     alice_central
                         .context
-                        .add_members_to_conversation(&id, vec![charlie])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .add_members(vec![charlie])
                         .await
                         .unwrap();
                     let charlie_welcome_bundle = alice_central.mls_transport.latest_commit_bundle().await;

--- a/crypto/src/mls/conversation/conversation_guard.rs
+++ b/crypto/src/mls/conversation/conversation_guard.rs
@@ -77,7 +77,7 @@ impl ConversationGuard {
 
     fn group_info(group_info: Option<GroupInfo>) -> Result<MlsGroupInfoBundle> {
         let group_info = group_info.ok_or(LeafError::MissingGroupInfo)?;
-        MlsGroupInfoBundle::try_new_full_plaintext(group_info).map_err(Into::into)
+        MlsGroupInfoBundle::try_new_full_plaintext(group_info)
     }
 
     /// Adds new members to the group/conversation

--- a/crypto/src/mls/conversation/conversation_guard.rs
+++ b/crypto/src/mls/conversation/conversation_guard.rs
@@ -200,4 +200,17 @@ impl ConversationGuard {
         drop(conversation);
         self.send_and_merge_commit(commit).await
     }
+
+    /// Commits all pending proposals of the group
+    pub async fn commit_pending_proposals(&mut self) -> Result<()> {
+        let client = self.mls_client().await?;
+        let backend = self.mls_provider().await?;
+        let mut conversation = self.inner.write().await;
+        let commit = conversation.commit_pending_proposals(&client, &backend).await?;
+        drop(conversation);
+        let Some(commit) = commit else {
+            return Ok(());
+        };
+        self.send_and_merge_commit(commit).await
+    }
 }

--- a/crypto/src/mls/conversation/conversation_guard/commit.rs
+++ b/crypto/src/mls/conversation/conversation_guard/commit.rs
@@ -1,3 +1,5 @@
+//! The methods in this module all produce commits.
+
 use openmls::prelude::KeyPackageIn;
 
 use crate::{

--- a/crypto/src/mls/conversation/conversation_guard/commit.rs
+++ b/crypto/src/mls/conversation/conversation_guard/commit.rs
@@ -1,90 +1,17 @@
-use async_lock::{RwLockReadGuard, RwLockWriteGuard};
-use mls_crypto_provider::MlsCryptoProvider;
-use openmls::prelude::{group_info::GroupInfo, KeyPackageIn};
+use openmls::prelude::KeyPackageIn;
 
 use crate::{
-    context::CentralContext,
     e2e_identity::init_certificates::NewCrlDistributionPoint,
-    group_store::GroupStoreValue,
-    mls::credential::crl::{extract_crl_uris_from_credentials, get_new_crl_distribution_points},
-    prelude::{Client, ClientId, MlsGroupInfoBundle},
-    LeafError, MlsError, RecursiveError,
+    mls::{
+        conversation::{commit::MlsCommitBundle, ConversationGuard, Result},
+        credential::crl::{extract_crl_uris_from_credentials, get_new_crl_distribution_points},
+    },
+    prelude::ClientId,
+    MlsError, RecursiveError,
 };
 
-use super::{commit::MlsCommitBundle, Error, MlsConversation, Result};
-
-/// A Conversation Guard wraps a `GroupStoreValue<MlsConversation>`.
-///
-/// By doing so, it permits mutable accesses to the conversation. This in turn
-/// means that we don't have to duplicate the entire `MlsConversation` API
-/// on `CentralContext`.
-pub struct ConversationGuard {
-    inner: GroupStoreValue<MlsConversation>,
-    central_context: CentralContext,
-}
-
 impl ConversationGuard {
-    pub(crate) fn new(inner: GroupStoreValue<MlsConversation>, central_context: CentralContext) -> Self {
-        Self { inner, central_context }
-    }
-
-    // This is dead code for now but we expect it to come alive in near-future work.
-    #[expect(dead_code)]
-    pub(crate) async fn conversation(&self) -> RwLockReadGuard<MlsConversation> {
-        self.inner.read().await
-    }
-
-    pub(crate) async fn conversation_mut(&mut self) -> RwLockWriteGuard<MlsConversation> {
-        self.inner.write().await
-    }
-
-    async fn mls_client(&self) -> Result<Client> {
-        self.central_context
-            .mls_client()
-            .await
-            .map_err(RecursiveError::root("getting mls client"))
-            .map_err(Into::into)
-    }
-
-    async fn mls_provider(&self) -> Result<MlsCryptoProvider> {
-        self.central_context
-            .mls_provider()
-            .await
-            .map_err(RecursiveError::root("getting mls provider"))
-            .map_err(Into::into)
-    }
-
-    pub(crate) async fn send_and_merge_commit(&mut self, commit: MlsCommitBundle) -> Result<()> {
-        // note we hand over this instance of the guard; when we need a `conversation` guard again,
-        // we'll need to re-fetch it.
-        let conversation = self.inner.write().await;
-        match self.central_context.send_commit(commit, Some(conversation)).await {
-            Ok(false) => Ok(()),
-            Ok(true) => {
-                let backend = self.mls_provider().await?;
-                let mut conversation = self.inner.write().await;
-                conversation.commit_accepted(&backend).await
-            }
-            Err(e @ Error::MessageRejected { .. }) => {
-                let backend = self.mls_provider().await?;
-                let mut conversation = self.inner.write().await;
-                conversation.clear_pending_commit(&backend).await?;
-                Err(e)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    fn group_info(group_info: Option<GroupInfo>) -> Result<MlsGroupInfoBundle> {
-        let group_info = group_info.ok_or(LeafError::MissingGroupInfo)?;
-        MlsGroupInfoBundle::try_new_full_plaintext(group_info)
-    }
-
     /// Adds new members to the group/conversation
-    ///
-    /// # Arguments
-    /// * `id` - group/conversation id
-    /// * `members` - members to be added to the group
     pub async fn add_members(&mut self, key_packages: Vec<KeyPackageIn>) -> Result<NewCrlDistributionPoint> {
         let client = self.mls_client().await?;
         let backend = self.mls_provider().await?;

--- a/crypto/src/mls/conversation/conversation_guard/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/mod.rs
@@ -1,0 +1,82 @@
+mod commit;
+
+use async_lock::{RwLockReadGuard, RwLockWriteGuard};
+use mls_crypto_provider::MlsCryptoProvider;
+use openmls::prelude::group_info::GroupInfo;
+
+use crate::{
+    context::CentralContext,
+    group_store::GroupStoreValue,
+    prelude::{Client, MlsGroupInfoBundle},
+    LeafError, RecursiveError,
+};
+
+use super::{commit::MlsCommitBundle, Error, MlsConversation, Result};
+
+/// A Conversation Guard wraps a `GroupStoreValue<MlsConversation>`.
+///
+/// By doing so, it permits mutable accesses to the conversation. This in turn
+/// means that we don't have to duplicate the entire `MlsConversation` API
+/// on `CentralContext`.
+pub struct ConversationGuard {
+    inner: GroupStoreValue<MlsConversation>,
+    central_context: CentralContext,
+}
+
+impl ConversationGuard {
+    pub(crate) fn new(inner: GroupStoreValue<MlsConversation>, central_context: CentralContext) -> Self {
+        Self { inner, central_context }
+    }
+
+    // This is dead code for now but we expect it to come alive in near-future work.
+    #[expect(dead_code)]
+    pub(crate) async fn conversation(&self) -> RwLockReadGuard<MlsConversation> {
+        self.inner.read().await
+    }
+
+    pub(crate) async fn conversation_mut(&mut self) -> RwLockWriteGuard<MlsConversation> {
+        self.inner.write().await
+    }
+
+    async fn mls_client(&self) -> Result<Client> {
+        self.central_context
+            .mls_client()
+            .await
+            .map_err(RecursiveError::root("getting mls client"))
+            .map_err(Into::into)
+    }
+
+    async fn mls_provider(&self) -> Result<MlsCryptoProvider> {
+        self.central_context
+            .mls_provider()
+            .await
+            .map_err(RecursiveError::root("getting mls provider"))
+            .map_err(Into::into)
+    }
+
+    pub(crate) async fn send_and_merge_commit(&mut self, commit: MlsCommitBundle) -> Result<()> {
+        // note we hand over this instance of the guard; when we need a `conversation` guard again,
+        // we'll need to re-fetch it.
+        let conversation = self.inner.write().await;
+        match self.central_context.send_commit(commit, Some(conversation)).await {
+            Ok(false) => Ok(()),
+            Ok(true) => {
+                let backend = self.mls_provider().await?;
+                let mut conversation = self.inner.write().await;
+                conversation.commit_accepted(&backend).await
+            }
+            Err(e @ Error::MessageRejected { .. }) => {
+                let backend = self.mls_provider().await?;
+                let mut conversation = self.inner.write().await;
+                conversation.clear_pending_commit(&backend).await?;
+                Err(e)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn group_info(group_info: Option<GroupInfo>) -> Result<MlsGroupInfoBundle> {
+        let group_info = group_info.ok_or(LeafError::MissingGroupInfo)?;
+        MlsGroupInfoBundle::try_new_full_plaintext(group_info)
+    }
+}

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -667,7 +667,14 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    bob_central.context.update_keying_material(&id).await.unwrap();
+                    bob_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = bob_central.mls_transport.latest_commit().await;
                     let MlsConversationDecryptMessage { is_active, .. } = alice_central
                         .context
@@ -732,7 +739,14 @@ mod tests {
 
                     let epoch_before = alice_central.context.conversation_epoch(&id).await.unwrap();
 
-                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = alice_central.mls_transport.latest_commit().await;
 
                     let decrypted = bob_central
@@ -781,7 +795,14 @@ mod tests {
                             .await
                             .unwrap();
 
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let MlsConversationDecryptMessage {
                             proposals,
@@ -823,7 +844,14 @@ mod tests {
                         // Alice will create a proposal to add Charlie
                         // Bob will create a commit which Alice will decrypt
                         // Then Alice will renew her proposal
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let bob_commit = bob_central.mls_transport.latest_commit().await;
                         let commit_epoch = bob_commit.epoch().unwrap();
 
@@ -928,7 +956,14 @@ mod tests {
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let alice_renewed_proposals = alice_central
                             .context
@@ -957,7 +992,14 @@ mod tests {
                         .unwrap();
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = alice_central.mls_transport.latest_commit().await;
 
                     let sender_client_id = bob_central
@@ -1183,7 +1225,14 @@ mod tests {
                     alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
                     // only Alice will change epoch without notifying Bob
-                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = alice_central.mls_transport.latest_commit().await;
 
                     // Now in epoch 2 Alice will encrypt a message
@@ -1308,7 +1357,14 @@ mod tests {
 
                     // Move group's epoch forward by self updating
                     for _ in 0..MAX_PAST_EPOCHS {
-                        alice_central.context.update_keying_material(&id).await.unwrap();
+                        alice_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = alice_central.mls_transport.latest_commit().await;
                         bob_central
                             .context
@@ -1321,7 +1377,14 @@ mod tests {
                     assert_eq!(decrypt.app_msg.unwrap(), b"Hello Bob");
 
                     // Moving the epochs once more should cause an error
-                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = alice_central.mls_transport.latest_commit().await;
                     bob_central
                         .context
@@ -1373,7 +1436,14 @@ mod tests {
                     alice_central.context.clear_pending_commit(&id).await.unwrap();
 
                     // Now let's jump to next epoch
-                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = alice_central.mls_transport.latest_commit().await;
                     bob_central
                         .context

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -891,7 +891,14 @@ mod tests {
                             .await
                             .unwrap();
                         assert_eq!(bob_central.pending_proposals(&id).await.len(), 1);
-                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let decrypted = alice_central
                             .context
@@ -1100,7 +1107,14 @@ mod tests {
 
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
                         // if 'decrypt_message' is not durable the commit won't contain the add proposal
-                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
                         assert!(!decrypted.has_epoch_changed);
 

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -695,7 +695,10 @@ mod tests {
 
                     bob_central
                         .context
-                        .remove_members_from_conversation(&id, &[alice_central.get_client_id().await])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .remove_members(&[alice_central.get_client_id().await])
                         .await
                         .unwrap();
                     let commit = bob_central.mls_transport.latest_commit().await;

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -70,7 +70,14 @@ mod tests {
                     let unknown_commit = alice_central.create_unmerged_commit(&id).await.commit;
                     alice_central.context.clear_pending_commit(&id).await.unwrap();
 
-                    alice_central.context.update_keying_material(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .update_key_material()
+                        .await
+                        .unwrap();
                     let commit = alice_central.mls_transport.latest_commit().await;
 
                     // decrypt once ... ok

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -193,7 +193,14 @@ mod tests {
                 assert!(matches!(decryption.unwrap_err(), Error::DuplicateMessage));
 
                 // advance Bob's epoch to trigger failure
-                bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                bob_central
+                    .context
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .commit_pending_proposals()
+                    .await
+                    .unwrap();
 
                 // Epoch has advanced so we cannot detect duplicates anymore
                 let decryption = bob_central
@@ -241,7 +248,14 @@ mod tests {
                 assert!(matches!(decryption.unwrap_err(), Error::DuplicateMessage));
 
                 // advance alice's epoch
-                alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                alice_central
+                    .context
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .commit_pending_proposals()
+                    .await
+                    .unwrap();
 
                 // Epoch has advanced so we cannot detect duplicates anymore
                 let decryption = alice_central

--- a/crypto/src/mls/conversation/leaf_node_validation.rs
+++ b/crypto/src/mls/conversation/leaf_node_validation.rs
@@ -73,7 +73,10 @@ mod tests {
 
                         let commit_creation = alice_central
                             .context
-                            .add_members_to_conversation(&id, vec![invalid_kp.into()])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .add_members(vec![invalid_kp.into()])
                             .await;
 
                         let error = commit_creation.unwrap_err();
@@ -171,7 +174,10 @@ mod tests {
 
                         alice_central
                             .context
-                            .add_members_to_conversation(&id, vec![invalid_kp.into()])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .add_members(vec![invalid_kp.into()])
                             .await
                             .unwrap();
                         let commit = alice_central.mls_transport.latest_commit().await;
@@ -220,7 +226,10 @@ mod tests {
                     let invalid_kp = bob_central.new_keypackage(&case, Lifetime::new(expiration_time)).await;
                     alice_central
                         .context
-                        .add_members_to_conversation(&id, vec![invalid_kp.into()])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .add_members(vec![invalid_kp.into()])
                         .await
                         .unwrap();
 

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -245,7 +245,14 @@ mod tests {
                         initial_count.encryption_keypair + 1
                     );
 
-                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
 
                     let final_count = alice_central.context.count_entities().await;
                     assert_eq!(initial_count, final_count);

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -184,7 +184,10 @@ mod tests {
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     alice_central
                         .context
-                        .remove_members_from_conversation(&id, &[bob_central.get_client_id().await])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .remove_members(&[bob_central.get_client_id().await])
                         .await
                         .unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);

--- a/crypto/src/mls/conversation/orphan_welcome.rs
+++ b/crypto/src/mls/conversation/orphan_welcome.rs
@@ -35,7 +35,10 @@ mod tests {
                 // Alice invites Bob with a KeyPackage...
                 alice_central
                     .context
-                    .add_members_to_conversation(&id, vec![bob])
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .add_members(vec![bob])
                     .await
                     .unwrap();
 

--- a/crypto/src/mls/conversation/proposal.rs
+++ b/crypto/src/mls/conversation/proposal.rs
@@ -205,7 +205,14 @@ mod tests {
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let welcome = bob_central.mls_transport.latest_welcome_message().await;
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
@@ -271,7 +278,14 @@ mod tests {
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
@@ -327,7 +341,14 @@ mod tests {
                         .decrypt_message(&id, proposal.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                    bob_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     let commit = bob_central.mls_transport.latest_commit().await;
 
                     assert!(!bob_central
@@ -385,7 +406,14 @@ mod tests {
                         .decrypt_message(&id, &proposal.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    bob_central.context.commit_pending_proposals(&id).await.unwrap();
+                    bob_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     // epoch++
 
                     // fails when we try to decrypt a proposal for past epoch

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -620,7 +620,10 @@ mod tests {
 
                         bob_central
                             .context
-                            .remove_members_from_conversation(&id, &[charlie_central.get_client_id().await])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .remove_members(&[charlie_central.get_client_id().await])
                             .await
                             .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
@@ -720,7 +723,10 @@ mod tests {
                         // Whereas Bob wants to remove Debbie
                         bob_central
                             .context
-                            .remove_members_from_conversation(&id, &[debbie_central.get_client_id().await])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .remove_members(&[debbie_central.get_client_id().await])
                             .await
                             .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
@@ -770,7 +776,10 @@ mod tests {
                         // Whereas Bob wants to remove Debbie
                         bob_central
                             .context
-                            .remove_members_from_conversation(&id, &[debbie_central.get_client_id().await])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .remove_members(&[debbie_central.get_client_id().await])
                             .await
                             .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
@@ -819,7 +828,10 @@ mod tests {
                         // Whereas Bob wants to remove Debbie
                         bob_central
                             .context
-                            .remove_members_from_conversation(&id, &[debbie_central.get_client_id().await])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .remove_members(&[debbie_central.get_client_id().await])
                             .await
                             .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -369,7 +369,10 @@ mod tests {
                         let charlie = charlie_central.rand_key_package(&case).await;
                         bob_central
                             .context
-                            .add_members_to_conversation(&id, vec![charlie])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .add_members(vec![charlie])
                             .await
                             .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
@@ -416,7 +419,10 @@ mod tests {
                         let charlie = charlie_central.rand_key_package(&case).await;
                         bob_central
                             .context
-                            .add_members_to_conversation(&id, vec![charlie])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .add_members(vec![charlie])
                             .await
                             .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -199,7 +199,14 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Bob hasn't Alice's proposal but creates a commit
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
 
                         let proposals = alice_central
@@ -213,7 +220,14 @@ mod tests {
                         assert_eq!(proposals.len(), alice_central.pending_proposals(&id).await.len());
 
                         // It should also renew the proposal when in pending_commit
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -258,7 +272,14 @@ mod tests {
                             .await
                             .unwrap();
 
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
 
                         // Bob's commit has Alice's proposal
@@ -278,7 +299,14 @@ mod tests {
                             .decrypt_message(&id, proposal.to_bytes().unwrap())
                             .await
                             .unwrap();
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -324,7 +352,14 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // Charlie does not have other proposals, it creates a commit
-                        charlie_central.context.update_keying_material(&id).await.unwrap();
+                        charlie_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = charlie_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -476,7 +511,14 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // But Charlie will commit meanwhile
-                        charlie_central.context.update_keying_material(&id).await.unwrap();
+                        charlie_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = charlie_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -516,7 +558,14 @@ mod tests {
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
                         // But meanwhile Bob will create a commit without Alice's proposal
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -531,7 +580,14 @@ mod tests {
                         // And same should happen when proposal is in pending commit
                         alice_central.commit_pending_proposals_unmerged(&id).await;
                         assert!(alice_central.pending_commit(&id).await.is_some());
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -570,7 +626,14 @@ mod tests {
                         assert!(alice_central.pending_commit(&id).await.is_some());
 
                         // But meanwhile Bob will create a commit
-                        bob_central.context.update_keying_material(&id).await.unwrap();
+                        bob_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = bob_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context
@@ -675,7 +738,14 @@ mod tests {
                             .unwrap();
                         assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
 
-                        charlie_central.context.update_keying_material(&id).await.unwrap();
+                        charlie_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .update_key_material()
+                            .await
+                            .unwrap();
                         let commit = charlie_central.mls_transport.latest_commit().await;
                         let proposals = alice_central
                             .context

--- a/crypto/src/mls/conversation/welcome.rs
+++ b/crypto/src/mls/conversation/welcome.rs
@@ -181,7 +181,10 @@ mod tests {
 
                 alice_central
                     .context
-                    .add_members_to_conversation(&id, vec![bob])
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .add_members(vec![bob])
                     .await
                     .unwrap();
 
@@ -217,7 +220,10 @@ mod tests {
                 let bob = bob_central.rand_key_package(&case).await;
                 alice_central
                     .context
-                    .add_members_to_conversation(&id, vec![bob])
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .add_members(vec![bob])
                     .await
                     .unwrap();
 

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -433,7 +433,14 @@ mod tests {
                 let external_commit = bob_central.mls_transport.latest_commit().await;
 
                 // Alice creates a new commit before receiving the external join
-                alice_central.context.update_keying_material(&id).await.unwrap();
+                alice_central
+                    .context
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .update_key_material()
+                    .await
+                    .unwrap();
 
                 // receiving the external join with outdated epoch should fail because of
                 // the wrong epoch

--- a/crypto/src/mls/external_commit.rs
+++ b/crypto/src/mls/external_commit.rs
@@ -683,7 +683,10 @@ mod tests {
                 let bob = bob_central.rand_key_package(&case).await;
                 alice_central
                     .context
-                    .add_members_to_conversation(&id, vec![bob])
+                    .conversation_guard(&id)
+                    .await
+                    .unwrap()
+                    .add_members(vec![bob])
                     .await
                     .unwrap();
 
@@ -724,7 +727,10 @@ mod tests {
                     let invalid_kp = bob_central.new_keypackage(&case, Lifetime::new(expiration_time)).await;
                     alice_central
                         .context
-                        .add_members_to_conversation(&id, vec![invalid_kp.into()])
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .add_members(vec![invalid_kp.into()])
                         .await
                         .unwrap();
 

--- a/crypto/src/mls/external_proposal.rs
+++ b/crypto/src/mls/external_proposal.rs
@@ -162,7 +162,14 @@ mod tests {
                         guest_central.verify_sender_identity(&case, &decrypted).await;
 
                         // simulate commit message reception from server
-                        owner_central.context.commit_pending_proposals(&id).await.unwrap();
+                        owner_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         // guest joined the group
                         assert_eq!(owner_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
@@ -234,7 +241,13 @@ mod tests {
                         .decrypt_message(&id, proposal.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    owner_central.commit_pending_proposals(&id).await.unwrap();
+                    owner_central
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     let commit = owner.mls_transport.latest_commit().await;
 
                     assert_eq!(owner.get_conversation_unchecked(&id).await.members().len(), 1);
@@ -462,7 +475,13 @@ mod tests {
                             .await
                             .unwrap();
 
-                        charlie_central.commit_pending_proposals(&id).await.unwrap();
+                        charlie_central
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         let commit = charlie.mls_transport.latest_commit().await;
                         assert_eq!(charlie.get_conversation_unchecked(&id).await.members().len(), 2);
 
@@ -561,7 +580,13 @@ mod tests {
                             .await
                             .unwrap();
 
-                        charlie_central.commit_pending_proposals(&id).await.unwrap();
+                        charlie_central
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .commit_pending_proposals()
+                            .await
+                            .unwrap();
                         assert_eq!(charlie.get_conversation_unchecked(&id).await.members().len(), 2);
 
                         let commit = charlie.mls_transport.latest_commit().await;

--- a/crypto/src/mls/external_proposal.rs
+++ b/crypto/src/mls/external_proposal.rs
@@ -414,7 +414,10 @@ mod tests {
                         // message and not from configuration
                         let charlie_kp = charlie.rand_key_package(&case).await;
                         alice_central
-                            .add_members_to_conversation(&id, vec![charlie_kp])
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .add_members(vec![charlie_kp])
                             .await
                             .unwrap();
                         let welcome = alice.mls_transport.latest_welcome_message().await;

--- a/crypto/src/mls/proposal.rs
+++ b/crypto/src/mls/proposal.rs
@@ -181,7 +181,14 @@ mod tests {
                         .unwrap();
                     let bob_kp = bob_central.get_one_key_package(&case).await;
                     alice_central.context.new_add_proposal(&id, bob_kp).await.unwrap();
-                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     let welcome = alice_central.mls_transport.latest_welcome_message().await;
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                     let new_id = bob_central
@@ -220,7 +227,14 @@ mod tests {
                         .find_or_first(|_| true)
                         .unwrap();
                     central.context.new_update_proposal(&id).await.unwrap();
-                    central.context.commit_pending_proposals(&id).await.unwrap();
+                    central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     let after = central
                         .get_conversation_unchecked(&id)
                         .await
@@ -264,7 +278,14 @@ mod tests {
                         .decrypt_message(&id, remove_proposal.proposal.to_bytes().unwrap())
                         .await
                         .unwrap();
-                    alice_central.context.commit_pending_proposals(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .commit_pending_proposals()
+                        .await
+                        .unwrap();
                     assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
 
                     let commit = alice_central.mls_transport.latest_commit().await;

--- a/crypto/src/test_utils/context.rs
+++ b/crypto/src/test_utils/context.rs
@@ -200,7 +200,10 @@ impl ClientContext {
 
         let kps = others.iter().map(|(_, kp)| kp).cloned().collect::<Vec<_>>();
         self.context
-            .add_members_to_conversation(id, kps)
+            .conversation_guard(&id)
+            .await
+            .map_err(RecursiveError::mls_conversation("getting conversation by id"))?
+            .add_members(kps)
             .await
             .map_err(RecursiveError::mls_conversation("adding members"))?;
         let welcome = self.mls_transport.latest_commit_bundle().await.welcome.unwrap();

--- a/crypto/src/test_utils/context.rs
+++ b/crypto/src/test_utils/context.rs
@@ -577,10 +577,10 @@ impl ClientContext {
     /// Creates a commit but don't merge it immediately (e.g, because the app crashes before he receives the success response from the ds via MlsTransport api)
     pub(crate) async fn create_unmerged_commit(&self, id: &ConversationId) -> MlsCommitBundle {
         self.context
-            .get_conversation(&id)
+            .conversation_guard(&id)
             .await
             .unwrap()
-            .write()
+            .conversation_mut()
             .await
             .update_keying_material(&self.client().await, &self.central.mls_backend, None, None)
             .await
@@ -589,10 +589,10 @@ impl ClientContext {
 
     pub(crate) async fn commit_pending_proposals_unmerged(&self, id: &ConversationId) -> MlsCommitBundle {
         self.context
-            .get_conversation(&id)
+            .conversation_guard(&id)
             .await
             .unwrap()
-            .write()
+            .conversation_mut()
             .await
             .commit_pending_proposals(&self.client().await, &self.central.mls_backend)
             .await

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -143,7 +143,9 @@ impl EmulatedMlsClient for CoreCryptoNativeClient {
     async fn kick_client(&self, conversation_id: &[u8], client_id: &[u8]) -> Result<()> {
         let transaction = self.cc.new_transaction().await?;
         transaction
-            .remove_members_from_conversation(&conversation_id.to_vec(), &[client_id.to_vec().into()])
+            .conversation_guard(&conversation_id.to_owned())
+            .await?
+            .remove_members(&[client_id.to_owned().into()])
             .await?;
         transaction.finish().await?;
 

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -131,7 +131,9 @@ impl EmulatedMlsClient for CoreCryptoNativeClient {
 
         let kp = KeyPackageIn::tls_deserialize(&mut &kp[..])?;
         transaction
-            .add_members_to_conversation(&conversation_id, vec![kp])
+            .conversation_guard(&conversation_id)
+            .await?
+            .add_members(vec![kp])
             .await?;
         transaction.finish().await?;
 

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -184,7 +184,9 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr) -> Result<()> {
     let spinner = util::RunningProcess::new("[MLS] Step 2: Adding clients to conversation...", true);
 
     transaction
-        .add_members_to_conversation(&conversation_id, key_packages)
+        .conversation_guard(&conversation_id)
+        .await?
+        .add_members(key_packages)
         .await?;
 
     let conversation_add_msg = success_provider.latest_welcome_message().await;


### PR DESCRIPTION
# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
