### PR TITLE
chore: more CI improvements

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -42,12 +42,7 @@ jobs:
         uses: gradle/actions/wrapper-validation@v4
       - uses: actions/download-artifact@v4
         with:
-          name: android-target-${{ github.run_id }}
-          path: target
-      - uses: actions/download-artifact@v4
-        with:
-          name: android-${{ github.run_id }}
-          path: crypto-ffi/bindings
+          name: android
       - name: enable kvm group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -14,22 +14,20 @@ jobs:
   build-android:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - task: android-armv7
+            target: armv7-linux-androideabi
+          - task: android-armv8
+            target: aarch64-linux-android
+          - task: android-x86
+            target: x86_64-linux-android
     steps:
       - uses: actions/checkout@v4
-      - name: set up jdk 17
-        uses: actions/setup-java@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          java-version: "17"
-          distribution: "adopt"
-      - name: gradle setup
-        uses: gradle/actions/setup-gradle@v4
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
-      - name: "setup rust"
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
-        with:
-          rustflags: ''
-          target: "armv7-linux-androideabi,aarch64-linux-android,x86_64-linux-android"
+          target: ${{ matrix.target }}
       - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - name: setup android sdk
@@ -41,18 +39,65 @@ jobs:
           ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/25.2.9519653
         run: |
           cd crypto-ffi
-          cargo make android
+          cargo make ${{ matrix.task }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-target-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/libcore_crypto_ffi.*
+          retention-days: 1
+
+  package-android:
+    if: github.repository == 'wireapp/core-crypto'
+    runs-on: ubuntu-latest
+    needs: build-android
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up jdk 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "adopt"
+      - name: gradle setup
+        uses: gradle/actions/setup-gradle@v4
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+      - name: setup cargo-make
+        uses: davidB/rust-cargo-make@v1
+      - name: setup android sdk
+        uses: android-actions/setup-android@v3
+      - name: install ndk 25
+        run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
+
+      - name: download armv7-linux-androideabi binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: android-target-armv7-linux-androideabi
+          path: target/armv7-linux-androideabi/release
+
+      - name: download aarch64-linux-android binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: android-target-aarch64-linux-android
+          path: target/aarch64-linux-android/release
+
+      - name: download x86_64-linux-android binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: android-target-x86_64-linux-android
+          path: target/x86_64-linux-android/release
+
+      - name: generate bindings
+        run: |
+          cd crypto-ffi
+          cargo make bindings-kotlin-android
       - name: build package
         run: |
           cd crypto-ffi/bindings
           ./gradlew android:build -x lint -x lintRelease
       - uses: actions/upload-artifact@v4
         with:
-          name: android-target-${{ github.run_id }}
-          path: target/*android*
-          retention-days: 1
-      - uses: actions/upload-artifact@v4
-        with:
-          name: android-${{ github.run_id }}
-          path: crypto-ffi/bindings
+          name: android
+          path: |
+            crypto-ffi/bindings
+            target/*android*
           retention-days: 1

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-ios:
+    if: github.repository == 'wireapp/core-crypto'
     runs-on: self-hosted
     strategy:
       matrix:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -16,27 +16,18 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        task:
-          - ios-device
-          - ios-simulator-x86
-          - ios-simulator-arm
+        include:
+          - task: ios-device
+            target: aarch64-apple-ios
+          - task: ios-simulator-x86
+            target: x86_64-apple-ios
+          - task: ios-simulator-arm
+            target: aarch64-apple-ios-sim
     steps:
       - uses: actions/checkout@v4
-
-      - name: determine rust target
-        id: rust-target
-        run: |
-          if [[ "${{ matrix.task }}" == "ios-device" ]]; then
-            echo "target=aarch64-apple-ios" >> $GITHUB_ENV
-          elif [[ "${{ matrix.task }}" == "ios-simulator-x86" ]]; then
-            echo "target=x86_64-apple-ios" >> $GITHUB_ENV
-          elif [[ "${{ matrix.task }}" == "ios-simulator-arm" ]]; then
-            echo "target=aarch64-apple-ios-sim" >> $GITHUB_ENV
-          fi
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: ${{ env.target }}
+          target: ${{ matrix.target }}
 
       - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1

--- a/.github/workflows/build-jvm-linux.yml
+++ b/.github/workflows/build-jvm-linux.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build-jvm:
     if: github.repository == 'wireapp/core-crypto'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -45,12 +45,7 @@ jobs:
         run: echo "y" | sdkmanager --install "ndk;25.2.9519653"
       - uses: actions/download-artifact@v4
         with:
-          name: android-target-${{ github.run_id }}
-          path: target
-      - uses: actions/download-artifact@v4
-        with:
-          name: android-${{ github.run_id }}
-          path: crypto-ffi/bindings
+          name: android
       - name: publish package
         run: |
           cd crypto-ffi/bindings

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -72,7 +72,7 @@ jobs:
       - name: build artifacts
         run: |
           cd crypto-ffi
-          cargo make compile-ffi-kotlin-jvm
+          cargo make bindings-kotlin-jvm
       - name: gradle setup
         uses: gradle/actions/setup-gradle@v4
       - name: validate gradle wrapper

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -101,7 +101,7 @@ args = ["run", "--cwd", "bindings/js", "build"]
 
 ##################################### FFI #####################################
 
-[tasks.compile-ffi-swift]
+[tasks._bindings-swift]
 command = "cargo"
 args = [
     "run",
@@ -115,13 +115,13 @@ args = [
     "--library", "../target/release/deps/libcore_crypto_ffi.${LIBRARY_EXTENSION}"
 ]
 
-[tasks.ffi-swift]
-dependencies = ["compile-ffi-swift"]
+[tasks.bindings-swift]
+dependencies = ["_bindings-swift"]
 script = '''
     mv ./bindings/swift/WireCoreCrypto/WireCoreCrypto/core_crypto_ffi.swift ./bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
 '''
 
-[tasks.compile-ffi-kotlin-android]
+[tasks.bindings-kotlin-android]
 command = "cargo"
 args = [
     "run",
@@ -136,7 +136,7 @@ args = [
     "--library", "../target/release/deps/libcore_crypto_ffi.${LIBRARY_EXTENSION}"
 ]
 
-[tasks.compile-ffi-kotlin-jvm]
+[tasks.bindings-kotlin-jvm]
 command = "cargo"
 args = [
     "run",
@@ -150,11 +150,11 @@ args = [
     "--library", "../target/release/deps/libcore_crypto_ffi.${LIBRARY_EXTENSION}"
 ]
 
-[tasks.ffi-kotlin]
-dependencies = ["compile-ffi-kotlin-android", "compile-ffi-kotlin-jvm"]
+[tasks.bindings-kotlin]
+dependencies = ["bindings-kotlin-android", "bindings-kotlin-jvm"]
 
-[tasks.ffi]
-dependencies = ["ffi-swift", "ffi-kotlin"]
+[tasks.bindings]
+dependencies = ["bindings-swift", "bindings-kotlin"]
 
 ##################################### iOS #####################################
 
@@ -162,14 +162,14 @@ dependencies = ["ffi-swift", "ffi-kotlin"]
 plugin = "detect-release"
 
 [tasks.ios-device]
-dependencies = ["ffi-swift"]
+dependencies = ["bindings-swift"]
 env = { "IPHONEOS_DEPLOYMENT_TARGET"="16.0" }
 condition = { platforms = ["mac"] }
 command = "cargo"
 args = ["rustc", "--target", "aarch64-apple-ios", "--crate-type=cdylib", "--crate-type=staticlib", "--release", "--locked", "--", "-C", "strip=symbols"]
 
 [tasks.ios-simulator-x86]
-dependencies = ["ffi-swift"]
+dependencies = ["bindings-swift"]
 condition = { platforms = ["mac"] }
 command = "cargo"
 args = [
@@ -184,7 +184,7 @@ args = [
 ]
 
 [tasks.ios-simulator-arm]
-dependencies = ["ffi-swift"]
+dependencies = ["bindings-swift"]
 # override CFLAGS to fix ring compilation
 env = { "CRATE_CC_NO_DEFAULTS" = 1, "TARGET_CFLAGS" = { script = ["echo \"--target=arm64-apple-ios14.0.0-simulator -mios-simulator-version-min=14.0 -isysroot `xcrun --show-sdk-path --sdk iphonesimulator`\""] } }
 condition = { platforms = ["mac"] }
@@ -230,7 +230,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["compile-ffi-kotlin-android", "android-env"]
+dependencies = ["bindings-kotlin-android", "android-env"]
 
 [tasks.android-armv8]
 command = "cargo"
@@ -244,7 +244,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["compile-ffi-kotlin-android", "android-env"]
+dependencies = ["bindings-kotlin-android", "android-env"]
 
 [tasks.android-x86]
 command = "cargo"
@@ -260,7 +260,7 @@ args = [
     "-l", "static=clang_rt.builtins-x86_64-android",
     "-L", "${CLANG_RT_DIR}"
 ]
-dependencies = ["compile-ffi-kotlin-android", "android-env"]
+dependencies = ["bindings-kotlin-android", "android-env"]
 
 [tasks.android]
 dependencies = ["android-armv7", "android-armv8", "android-x86"]
@@ -279,7 +279,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["compile-ffi-kotlin-jvm"]
+dependencies = ["bindings-kotlin-jvm"]
 condition = { platforms = ["mac"] }
 
 [tasks.jvm-aarch64-darwin]
@@ -294,7 +294,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["compile-ffi-kotlin-jvm"]
+dependencies = ["bindings-kotlin-jvm"]
 condition = { platforms = ["mac"] }
 
 [tasks.jvm-x86-linux]
@@ -309,7 +309,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["compile-ffi-kotlin-jvm"]
+dependencies = ["bindings-kotlin-jvm"]
 condition = { platforms = ["linux"] }
 
 [tasks.jvm-darwin]

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -230,7 +230,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["bindings-kotlin-android", "android-env"]
+dependencies = ["android-env"]
 
 [tasks.android-armv8]
 command = "cargo"
@@ -244,7 +244,7 @@ args = [
     "--",
     "-C", "strip=symbols"
 ]
-dependencies = ["bindings-kotlin-android", "android-env"]
+dependencies = ["android-env"]
 
 [tasks.android-x86]
 command = "cargo"
@@ -260,7 +260,7 @@ args = [
     "-l", "static=clang_rt.builtins-x86_64-android",
     "-L", "${CLANG_RT_DIR}"
 ]
-dependencies = ["bindings-kotlin-android", "android-env"]
+dependencies = ["android-env"]
 
 [tasks.android]
 dependencies = ["android-armv7", "android-armv8", "android-x86"]

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -492,7 +492,7 @@ impl UniffiCustomTypeConverter for Ciphersuites {
 
     fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
         val.iter().try_fold(Self(vec![]), |mut acc, c| -> uniffi::Result<Self> {
-            let cs = core_crypto::prelude::CiphersuiteName::try_from(*c).map(Into::into)?;
+            let cs = core_crypto::prelude::CiphersuiteName::try_from(*c)?;
             acc.0.push(cs);
             Ok(acc)
         })

--- a/crypto-ffi/src/wasm/context/proteus.rs
+++ b/crypto-ffi/src/wasm/context/proteus.rs
@@ -232,7 +232,7 @@ impl CoreCryptoContext {
         let context = self.inner.clone();
 
         proteus_impl! {{
-            context.proteus_fingerprint().await.map_err(CoreCryptoError::from).map(Into::into)
+            context.proteus_fingerprint().await.map_err(CoreCryptoError::from)
         } or throw WasmCryptoResult<_> }
     }
 
@@ -247,7 +247,6 @@ impl CoreCryptoContext {
                 .proteus_fingerprint_local(&session_id)
                 .await
                 .map_err(CoreCryptoError::from)
-                .map(Into::into)
         } or throw WasmCryptoResult<_> }
     }
 
@@ -259,7 +258,7 @@ impl CoreCryptoContext {
 
         proteus_impl! {{
             context.proteus_fingerprint_remote(&session_id).await
-                .map_err(CoreCryptoError::from).map(Into::into)
+                .map_err(CoreCryptoError::from)
         } or throw WasmCryptoResult<_> }
     }
 
@@ -269,7 +268,7 @@ impl CoreCryptoContext {
     pub fn proteus_fingerprint_prekeybundle(prekey: Box<[u8]>) -> WasmCryptoResult<String> {
         proteus_impl!({
             core_crypto::proteus::ProteusCentral::fingerprint_prekeybundle(&prekey)
-                .map_err(Into::into).map(Into::into)
+                .map_err(Into::into)
         } or throw WasmCryptoResult<_>)
     }
 

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -1708,7 +1708,7 @@ impl CoreCrypto {
         let central = self.inner.clone();
 
         proteus_impl! {{
-            central.proteus_fingerprint().await.map_err(CoreCryptoError::from).map(Into::into)
+            central.proteus_fingerprint().await.map_err(CoreCryptoError::from)
         } or throw WasmCryptoResult<_> }
     }
 
@@ -1724,7 +1724,6 @@ impl CoreCrypto {
                 .proteus_fingerprint_local(&session_id)
                 .await
                 .map_err(CoreCryptoError::from)
-                .map(Into::into)
         } or throw WasmCryptoResult<_> }
     }
 
@@ -1737,7 +1736,7 @@ impl CoreCrypto {
 
         proteus_impl! {{
             central.proteus_fingerprint_remote(&session_id).await
-                .map_err(CoreCryptoError::from).map(Into::into)
+                .map_err(CoreCryptoError::from)
         } or throw WasmCryptoResult<_> }
     }
 
@@ -1748,7 +1747,7 @@ impl CoreCrypto {
     pub fn proteus_fingerprint_prekeybundle(prekey: Box<[u8]>) -> WasmCryptoResult<String> {
         proteus_impl!({
             core_crypto::proteus::ProteusCentral::fingerprint_prekeybundle(&prekey)
-                .map_err(Into::into).map(Into::into)
+                .map_err(Into::into)
         } or throw WasmCryptoResult<_>)
     }
 

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -58,7 +58,6 @@ impl MlsConversation {
 
                     Result::<_, MlsError>::Ok(acc)
                 })
-                .map_err(MlsError::from)
                 .unwrap_or_default();
 
             // Post-commit visualization of the number of members after remove proposals

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -195,7 +195,7 @@ impl crate::clients::EmulatedProteusClient for CoreCryptoFfiClient {
     async fn init(&mut self) -> Result<()> {
         self.cc
             .transaction(TransactionHelper::new(move |context| async move {
-                context.proteus_init().await.map_err(Into::into)
+                context.proteus_init().await
             }))
             .await?;
         Ok(())


### PR DESCRIPTION
This PR splits parallelizes Android builds, and makes each target-specific job upload its own artifact.
A new job, `package-android` is introduced that waits for target-specific jobs to complete, generates
bindings and calls gradle to make the final package.

There are also a few smaller things like renaming of bindings-related tasks.