### PR TITLE
fix: don't expose uniffi types in the kotlin bindings [WPB-16300]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
@@ -658,6 +658,10 @@ class CoreCryptoContext(private val cc: com.wire.crypto.uniffi.CoreCryptoContext
         return wrapException { cc.proteusFingerprintRemote(sessionId).toByteArray() }
     }
 
+    suspend fun proteusGetPrekeyFingerprint(prekey: ByteArray): ByteArray {
+        return wrapException { cc.proteusFingerprintPrekeybundle(prekey).toByteArray() }
+    }
+
     suspend fun proteusNewPreKeys(from: Int, count: Int): ArrayList<PreKey> {
         return wrapException {
             from.until(from + count).map {

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/E2EIEnrollment.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/E2EIEnrollment.kt
@@ -79,6 +79,9 @@ data class AcmeChallenge(private val delegate: com.wire.crypto.uniffi.AcmeChalle
     val url: String
         get() = delegate.url
 
+    val target: String
+        get() = delegate.target
+
     val raw: JsonRawData
         get() = delegate.delegate.toUByteArray().asByteArray()
 

--- a/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/MLSTest.kt
@@ -18,8 +18,6 @@
 
 package com.wire.crypto
 
-import com.wire.crypto.uniffi.CommitBundle
-import com.wire.crypto.uniffi.MlsTransportResponse
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
@@ -369,7 +367,7 @@ class  MockMlsTransportSuccessProvider : MockDeliveryService {
 
     override suspend fun getLatestCommitBundle(): CommitBundle = latestCommitBundle!!
 
-    override suspend fun getLatestWelcome(): Welcome = getLatestCommitBundle().welcome!!.toWelcome()
+    override suspend fun getLatestWelcome(): Welcome = getLatestCommitBundle().welcome!!
 
-    override suspend fun getLatestCommit(): MlsMessage = getLatestCommitBundle().commit.toMlsMessage()
+    override suspend fun getLatestCommit(): MlsMessage = getLatestCommitBundle().commit
 }


### PR DESCRIPTION
# What's new in this PR

don't expose uniffi types in the kotlin bindings

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
