### PR TITLE
chore: disable logging on CI which is very verbose

### DIFF
--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -59,7 +59,7 @@ fn run_test() -> Result<()> {
     use tokio::net::{TcpListener, TcpStream};
 
     color_eyre::install()?;
-    if std::env::var("RUST_LOG").is_ok() || std::env::var("CI").is_ok() {
+    if std::env::var("RUST_LOG").is_ok() {
         femme::start();
     }
 


### PR DESCRIPTION
# What's new in this PR

Disable logging on CI which is very verbose.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
