### PR TITLE
refactor: move `clear_pending_proposal`, `clear_pending_commit` to `ConversationGuard` [WPB-15588]

### DIFF
--- a/crypto/src/mls/conversation/conversation_guard/merge.rs
+++ b/crypto/src/mls/conversation/conversation_guard/merge.rs
@@ -1,0 +1,227 @@
+//! A MLS group can be merged (aka committed) when it has a pending commit. The latter is a commit
+//! we created which is still waiting to be "committed". By doing so, we will apply all the
+//! modifications present in the commit to the ratchet tree and also persist the new group in the
+//! keystore. Like this, even if the application crashes we will be able to restore.
+//!
+//! This table summarizes when a MLS group can be merged:
+//!
+//! | can be merged ?   | 0 pend. Commit | 1 pend. Commit |
+//! |-------------------|----------------|----------------|
+//! | 0 pend. Proposal  | ❌              | ✅              |
+//! | 1+ pend. Proposal | ❌              | ✅              |
+
+use openmls::prelude::MlsGroupStateError;
+
+use super::{ConversationGuard, Result};
+use crate::{
+    MlsError,
+    mls::conversation::{ConversationWithMls as _, Error},
+    prelude::MlsProposalRef,
+};
+
+impl ConversationGuard {
+    /// Allows to remove a pending (uncommitted) proposal. Use this when backend rejects the proposal
+    /// you just sent e.g. if permissions have changed meanwhile.
+    ///
+    /// **CAUTION**: only use this when you had an explicit response from the Delivery Service
+    /// e.g. 403 or 409. Do not use otherwise e.g. 5xx responses, timeout etc..
+    ///
+    /// # Arguments
+    /// * `conversation_id` - the group/conversation id
+    /// * `proposal_ref` - unique proposal identifier which is present in [crate::prelude::MlsProposalBundle]
+    ///   and returned from all operation creating a proposal
+    ///
+    /// # Errors
+    /// When the conversation is not found or the proposal reference does not identify a proposal
+    /// in the local pending proposal store
+    pub async fn clear_pending_proposal(&mut self, proposal_ref: MlsProposalRef) -> Result<()> {
+        let keystore = self.mls_provider().await?.keystore();
+        let mut conversation = self.conversation_mut().await;
+        conversation
+            .group
+            .remove_pending_proposal(&keystore, &proposal_ref)
+            .await
+            .map_err(|mls_group_state_error| match mls_group_state_error {
+                MlsGroupStateError::PendingProposalNotFound => Error::PendingProposalNotFound(proposal_ref),
+                _ => MlsError::wrap("removing pending proposal")(mls_group_state_error).into(),
+            })?;
+        conversation.persist_group_when_changed(&keystore, true).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openmls::prelude::Proposal;
+    use wasm_bindgen_test::*;
+
+    use crate::test_utils::*;
+
+    use super::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    mod clear_pending_proposal {
+        use super::*;
+
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_remove_proposal(case: TestCase) {
+            run_test_with_client_ids(
+                case.clone(),
+                ["alice", "bob", "charlie"],
+                move |[mut alice_central, bob_central, charlie_central]| {
+                    Box::pin(async move {
+                        let id = conversation_id();
+                        alice_central
+                            .context
+                            .new_conversation(&id, case.credential_type, case.cfg.clone())
+                            .await
+                            .unwrap();
+                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+
+                        let charlie_kp = charlie_central.get_one_key_package(&case).await;
+                        let add_ref = alice_central
+                            .context
+                            .new_add_proposal(&id, charlie_kp)
+                            .await
+                            .unwrap()
+                            .proposal_ref;
+
+                        let remove_ref = alice_central
+                            .context
+                            .new_remove_proposal(&id, bob_central.get_client_id().await)
+                            .await
+                            .unwrap()
+                            .proposal_ref;
+
+                        let update_ref = alice_central
+                            .context
+                            .new_update_proposal(&id)
+                            .await
+                            .unwrap()
+                            .proposal_ref;
+
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 3);
+                        alice_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .clear_pending_proposal(add_ref)
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 2);
+                        assert!(
+                            !alice_central
+                                .pending_proposals(&id)
+                                .await
+                                .into_iter()
+                                .any(|p| matches!(p.proposal(), Proposal::Add(_)))
+                        );
+
+                        alice_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .clear_pending_proposal(remove_ref)
+                            .await
+                            .unwrap();
+                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
+                        assert!(
+                            !alice_central
+                                .pending_proposals(&id)
+                                .await
+                                .into_iter()
+                                .any(|p| matches!(p.proposal(), Proposal::Remove(_)))
+                        );
+
+                        alice_central
+                            .context
+                            .conversation_guard(&id)
+                            .await
+                            .unwrap()
+                            .clear_pending_proposal(update_ref)
+                            .await
+                            .unwrap();
+                        assert!(alice_central.pending_proposals(&id).await.is_empty());
+                        assert!(
+                            !alice_central
+                                .pending_proposals(&id)
+                                .await
+                                .into_iter()
+                                .any(|p| matches!(p.proposal(), Proposal::Update(_)))
+                        );
+                    })
+                },
+            )
+            .await
+        }
+
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_fail_when_proposal_ref_not_found(case: TestCase) {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .context
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    assert!(alice_central.pending_proposals(&id).await.is_empty());
+                    let any_ref = MlsProposalRef::from(vec![0; case.ciphersuite().hash_length()]);
+                    let clear = alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_proposal(any_ref.clone())
+                        .await;
+                    assert!(
+                        matches!(clear.unwrap_err(), Error::PendingProposalNotFound(prop_ref) if prop_ref == any_ref)
+                    )
+                })
+            })
+            .await
+        }
+
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_clean_associated_key_material(case: TestCase) {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[mut cc]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    cc.context
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    assert!(cc.pending_proposals(&id).await.is_empty());
+
+                    let init = cc.context.count_entities().await;
+
+                    let proposal_ref = cc.context.new_update_proposal(&id).await.unwrap().proposal_ref;
+                    assert_eq!(cc.pending_proposals(&id).await.len(), 1);
+
+                    cc.context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_proposal(proposal_ref)
+                        .await
+                        .unwrap();
+                    assert!(cc.pending_proposals(&id).await.is_empty());
+
+                    // This whole flow should be idempotent.
+                    // Here we verify that we are indeed deleting the `EncryptionKeyPair` created
+                    // for the Update proposal
+                    let after_clear_proposal = cc.context.count_entities().await;
+                    assert_eq!(init, after_clear_proposal);
+                })
+            })
+            .await
+        }
+    }
+}

--- a/crypto/src/mls/conversation/conversation_guard/merge.rs
+++ b/crypto/src/mls/conversation/conversation_guard/merge.rs
@@ -1,14 +1,15 @@
-//! A MLS group can be merged (aka committed) when it has a pending commit. The latter is a commit
-//! we created which is still waiting to be "committed". By doing so, we will apply all the
-//! modifications present in the commit to the ratchet tree and also persist the new group in the
-//! keystore. Like this, even if the application crashes we will be able to restore.
-//!
-//! This table summarizes when a MLS group can be merged:
-//!
-//! | can be merged ?   | 0 pend. Commit | 1 pend. Commit |
-//! |-------------------|----------------|----------------|
-//! | 0 pend. Proposal  | ❌              | ✅              |
-//! | 1+ pend. Proposal | ❌              | ✅              |
+//! A MLS group is a distributed object scattered across many parties. We use a Delivery Service
+//! to orchestrate those parties. So when we create a commit, a mutable operation, it has to be
+//! validated by the Delivery Service. But it might occur that another group member did the
+//! exact same thing at the same time. So if we arrive second in this race, we must "rollback" the commit
+//! we created and accept ("merge") the other one.
+//! A client would
+//! * Create a commit
+//! * Send the commit to the Delivery Service
+//! * When Delivery Service responds
+//!     * 200 OK --> use [CentralContext::commit_accepted] to merge the commit
+//!     * 409 CONFLICT --> do nothing. [CentralContext::decrypt_message] will restore the proposals not committed
+//!     * 5xx --> retry
 
 use openmls::prelude::MlsGroupStateError;
 
@@ -47,6 +48,31 @@ impl ConversationGuard {
             })?;
         conversation.persist_group_when_changed(&keystore, true).await?;
         Ok(())
+    }
+
+    /// Allows to remove a pending commit. Use this when backend rejects the commit
+    /// you just sent e.g. if permissions have changed meanwhile.
+    ///
+    /// **CAUTION**: only use this when you had an explicit response from the Delivery Service
+    /// e.g. 403. Do not use otherwise e.g. 5xx responses, timeout etc..
+    /// **DO NOT** use when Delivery Service responds 409, pending state will be renewed
+    /// in [CentralContext::decrypt_message]
+    ///
+    /// # Arguments
+    /// * `conversation_id` - the group/conversation id
+    ///
+    /// # Errors
+    /// When the conversation is not found or there is no pending commit
+    pub(crate) async fn clear_pending_commit(&mut self) -> Result<()> {
+        let keystore = self.mls_provider().await?.keystore();
+        let mut conversation = self.conversation_mut().await;
+        if conversation.group.pending_commit().is_some() {
+            conversation.group.clear_pending_commit();
+            conversation.persist_group_when_changed(&keystore, true).await?;
+            Ok(())
+        } else {
+            Err(Error::PendingCommitNotFound)
+        }
     }
 }
 
@@ -219,6 +245,100 @@ mod tests {
                     // for the Update proposal
                     let after_clear_proposal = cc.context.count_entities().await;
                     assert_eq!(init, after_clear_proposal);
+                })
+            })
+            .await
+        }
+    }
+
+    mod clear_pending_commit {
+        use super::*;
+
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_remove_commit(case: TestCase) {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .context
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    assert!(alice_central.pending_commit(&id).await.is_none());
+
+                    alice_central.create_unmerged_commit(&id).await;
+                    assert!(alice_central.pending_commit(&id).await.is_some());
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await
+                        .unwrap();
+                    assert!(alice_central.pending_commit(&id).await.is_none());
+                })
+            })
+            .await
+        }
+
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_fail_when_pending_commit_absent(case: TestCase) {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    alice_central
+                        .context
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    assert!(alice_central.pending_commit(&id).await.is_none());
+                    let clear = alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await;
+                    assert!(matches!(clear.unwrap_err(), Error::PendingCommitNotFound))
+                })
+            })
+            .await
+        }
+
+        #[apply(all_cred_cipher)]
+        #[wasm_bindgen_test]
+        pub async fn should_clean_associated_key_material(case: TestCase) {
+            run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
+                Box::pin(async move {
+                    let id = conversation_id();
+                    cc.context
+                        .new_conversation(&id, case.credential_type, case.cfg.clone())
+                        .await
+                        .unwrap();
+                    assert!(cc.pending_commit(&id).await.is_none());
+
+                    let init = cc.context.count_entities().await;
+
+                    cc.create_unmerged_commit(&id).await;
+                    assert!(cc.pending_commit(&id).await.is_some());
+
+                    cc.context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await
+                        .unwrap();
+                    assert!(cc.pending_commit(&id).await.is_none());
+
+                    // This whole flow should be idempotent.
+                    // Here we verify that we are indeed deleting the `EncryptionKeyPair` created
+                    // for the Update commit
+                    let after_clear_commit = cc.context.count_entities().await;
+                    assert_eq!(init, after_clear_commit);
                 })
             })
             .await

--- a/crypto/src/mls/conversation/conversation_guard/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/mod.rs
@@ -66,9 +66,7 @@ impl ConversationGuard {
                 conversation.commit_accepted(&backend).await
             }
             Err(e @ Error::MessageRejected { .. }) => {
-                let backend = self.mls_provider().await?;
-                let mut conversation = self.inner.write().await;
-                conversation.clear_pending_commit(&backend).await?;
+                self.clear_pending_commit().await?;
                 Err(e)
             }
             Err(e) => Err(e),

--- a/crypto/src/mls/conversation/conversation_guard/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/mod.rs
@@ -1,5 +1,6 @@
 mod commit;
 mod encrypt;
+mod merge;
 
 use async_lock::{RwLockReadGuard, RwLockWriteGuard};
 use openmls::prelude::group_info::GroupInfo;

--- a/crypto/src/mls/conversation/decrypt.rs
+++ b/crypto/src/mls/conversation/decrypt.rs
@@ -1512,7 +1512,14 @@ mod tests {
                         .commit
                         .to_bytes()
                         .unwrap();
-                    alice_central.context.clear_pending_commit(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await
+                        .unwrap();
 
                     // Now let's jump to next epoch
                     alice_central

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -69,7 +69,14 @@ mod tests {
 
                     // an commit to verify that we can still detect wrong epoch correctly
                     let unknown_commit = alice_central.create_unmerged_commit(&id).await.commit;
-                    alice_central.context.clear_pending_commit(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await
+                        .unwrap();
 
                     alice_central
                         .context

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -12,18 +12,15 @@
 //!
 
 use core_crypto_keystore::entities::MlsEncryptionKeyPair;
-use openmls::prelude::MlsGroupStateError;
 use openmls_traits::OpenMlsCryptoProvider;
 
 use mls_crypto_provider::MlsCryptoProvider;
 
 use super::{Error, Result};
-use crate::{
-    MlsError, RecursiveError,
-    context::CentralContext,
-    mls::{ConversationId, MlsConversation},
-    prelude::MlsProposalRef,
-};
+use crate::{MlsError, context::CentralContext, mls::MlsConversation};
+
+#[cfg(test)]
+use crate::{RecursiveError, mls::ConversationId};
 
 /// Abstraction over a MLS group capable of merging a commit
 impl MlsConversation {
@@ -45,24 +42,6 @@ impl MlsConversation {
             let _ = backend.key_store().remove::<MlsEncryptionKeyPair, _>(ek).await;
         }
 
-        Ok(())
-    }
-
-    /// see [CentralContext::clear_pending_proposal]
-    #[cfg_attr(test, crate::durable)]
-    pub async fn clear_pending_proposal(
-        &mut self,
-        proposal_ref: MlsProposalRef,
-        backend: &MlsCryptoProvider,
-    ) -> Result<()> {
-        self.group
-            .remove_pending_proposal(backend.key_store(), &proposal_ref)
-            .await
-            .map_err(|e| match e {
-                MlsGroupStateError::PendingProposalNotFound => Error::PendingProposalNotFound(proposal_ref),
-                _ => MlsError::wrap("removing pending proposal")(e).into(),
-            })?;
-        self.persist_group_when_changed(&backend.keystore(), true).await?;
         Ok(())
     }
 
@@ -92,39 +71,6 @@ impl MlsConversation {
 ///     * 409 CONFLICT --> do nothing. [CentralContext::decrypt_message] will restore the proposals not committed
 ///     * 5xx --> retry
 impl CentralContext {
-    /// Allows to remove a pending (uncommitted) proposal. Use this when backend rejects the proposal
-    /// you just sent e.g. if permissions have changed meanwhile.
-    ///
-    /// **CAUTION**: only use this when you had an explicit response from the Delivery Service
-    /// e.g. 403 or 409. Do not use otherwise e.g. 5xx responses, timeout etc..
-    ///
-    /// # Arguments
-    /// * `conversation_id` - the group/conversation id
-    /// * `proposal_ref` - unique proposal identifier which is present in [crate::prelude::MlsProposalBundle]
-    ///   and returned from all operation creating a proposal
-    ///
-    /// # Errors
-    /// When the conversation is not found or the proposal reference does not identify a proposal
-    /// in the local pending proposal store
-    pub async fn clear_pending_proposal(
-        &self,
-        conversation_id: &ConversationId,
-        proposal_ref: MlsProposalRef,
-    ) -> Result<()> {
-        self.get_conversation(conversation_id)
-            .await?
-            .write()
-            .await
-            .clear_pending_proposal(
-                proposal_ref,
-                &self
-                    .mls_provider()
-                    .await
-                    .map_err(RecursiveError::root("getting mls provider"))?,
-            )
-            .await
-    }
-
     /// Allows to remove a pending commit. Use this when backend rejects the commit
     /// you just sent e.g. if permissions have changed meanwhile.
     ///
@@ -157,7 +103,6 @@ impl CentralContext {
 
 #[cfg(test)]
 mod tests {
-    use openmls::prelude::Proposal;
     use wasm_bindgen_test::*;
 
     use crate::test_utils::*;
@@ -256,165 +201,6 @@ mod tests {
 
                     let final_count = alice_central.context.count_entities().await;
                     assert_eq!(initial_count, final_count);
-                })
-            })
-            .await
-        }
-    }
-
-    mod clear_pending_proposal {
-        use super::*;
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        pub async fn should_remove_proposal(case: TestCase) {
-            run_test_with_client_ids(
-                case.clone(),
-                ["alice", "bob", "charlie"],
-                move |[mut alice_central, bob_central, charlie_central]| {
-                    Box::pin(async move {
-                        let id = conversation_id();
-                        alice_central
-                            .context
-                            .new_conversation(&id, case.credential_type, case.cfg.clone())
-                            .await
-                            .unwrap();
-                        alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
-                        assert!(alice_central.pending_proposals(&id).await.is_empty());
-
-                        let charlie_kp = charlie_central.get_one_key_package(&case).await;
-                        let add_ref = alice_central
-                            .context
-                            .new_add_proposal(&id, charlie_kp)
-                            .await
-                            .unwrap()
-                            .proposal_ref;
-
-                        let remove_ref = alice_central
-                            .context
-                            .new_remove_proposal(&id, bob_central.get_client_id().await)
-                            .await
-                            .unwrap()
-                            .proposal_ref;
-
-                        let update_ref = alice_central
-                            .context
-                            .new_update_proposal(&id)
-                            .await
-                            .unwrap()
-                            .proposal_ref;
-
-                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 3);
-                        alice_central
-                            .context
-                            .clear_pending_proposal(&id, add_ref)
-                            .await
-                            .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 2);
-                        assert!(
-                            !alice_central
-                                .pending_proposals(&id)
-                                .await
-                                .into_iter()
-                                .any(|p| matches!(p.proposal(), Proposal::Add(_)))
-                        );
-
-                        alice_central
-                            .context
-                            .clear_pending_proposal(&id, remove_ref)
-                            .await
-                            .unwrap();
-                        assert_eq!(alice_central.pending_proposals(&id).await.len(), 1);
-                        assert!(
-                            !alice_central
-                                .pending_proposals(&id)
-                                .await
-                                .into_iter()
-                                .any(|p| matches!(p.proposal(), Proposal::Remove(_)))
-                        );
-
-                        alice_central
-                            .context
-                            .clear_pending_proposal(&id, update_ref)
-                            .await
-                            .unwrap();
-                        assert!(alice_central.pending_proposals(&id).await.is_empty());
-                        assert!(
-                            !alice_central
-                                .pending_proposals(&id)
-                                .await
-                                .into_iter()
-                                .any(|p| matches!(p.proposal(), Proposal::Update(_)))
-                        );
-                    })
-                },
-            )
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        pub async fn should_fail_when_conversation_not_found(case: TestCase) {
-            use crate::{LeafError, mls};
-
-            run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    let simple_ref = MlsProposalRef::from(vec![0; case.ciphersuite().hash_length()]);
-                    let clear = alice_central.context.clear_pending_proposal(&id, simple_ref).await;
-                    assert!(matches!(clear.unwrap_err(), mls::conversation::error::Error::Leaf(LeafError::ConversationNotFound(conv_id)) if conv_id == id))
-                })
-            })
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        pub async fn should_fail_when_proposal_ref_not_found(case: TestCase) {
-            run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    alice_central
-                        .context
-                        .new_conversation(&id, case.credential_type, case.cfg.clone())
-                        .await
-                        .unwrap();
-                    assert!(alice_central.pending_proposals(&id).await.is_empty());
-                    let any_ref = MlsProposalRef::from(vec![0; case.ciphersuite().hash_length()]);
-                    let clear = alice_central.context.clear_pending_proposal(&id, any_ref.clone()).await;
-                    assert!(
-                        matches!(clear.unwrap_err(), Error::PendingProposalNotFound(prop_ref) if prop_ref == any_ref)
-                    )
-                })
-            })
-            .await
-        }
-
-        #[apply(all_cred_cipher)]
-        #[wasm_bindgen_test]
-        pub async fn should_clean_associated_key_material(case: TestCase) {
-            run_test_with_client_ids(case.clone(), ["alice"], move |[mut cc]| {
-                Box::pin(async move {
-                    let id = conversation_id();
-                    cc.context
-                        .new_conversation(&id, case.credential_type, case.cfg.clone())
-                        .await
-                        .unwrap();
-                    assert!(cc.pending_proposals(&id).await.is_empty());
-
-                    let init = cc.context.count_entities().await;
-
-                    let proposal_ref = cc.context.new_update_proposal(&id).await.unwrap().proposal_ref;
-                    assert_eq!(cc.pending_proposals(&id).await.len(), 1);
-
-                    cc.context.clear_pending_proposal(&id, proposal_ref).await.unwrap();
-                    assert!(cc.pending_proposals(&id).await.is_empty());
-
-                    // This whole flow should be idempotent.
-                    // Here we verify that we are indeed deleting the `EncryptionKeyPair` created
-                    // for the Update proposal
-                    let after_clear_proposal = cc.context.count_entities().await;
-                    assert_eq!(init, after_clear_proposal);
                 })
             })
             .await

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -235,7 +235,14 @@ mod tests {
                     // create a first commit then discard it from the store to be able to create a second one
                     let unmerged_commit = alice_central.create_unmerged_commit(&id).await.commit;
                     assert!(alice_central.pending_commit(&id).await.is_some());
-                    alice_central.context.clear_pending_commit(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await
+                        .unwrap();
                     assert!(alice_central.pending_commit(&id).await.is_none());
 
                     // create another commit for the sole purpose of having it in the store
@@ -274,7 +281,14 @@ mod tests {
                     assert!(alice_central.pending_commit(&id).await.is_some());
 
                     // then delete the pending commit
-                    alice_central.context.clear_pending_commit(&id).await.unwrap();
+                    alice_central
+                        .context
+                        .conversation_guard(&id)
+                        .await
+                        .unwrap()
+                        .clear_pending_commit()
+                        .await
+                        .unwrap();
                     assert!(alice_central.pending_commit(&id).await.is_none());
 
                     let decrypt_self = alice_central


### PR DESCRIPTION
# What's new in this PR

title

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
