### PR TITLE
feat: add `EpochObserver` API [WPB-16260]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,9 +920,11 @@ dependencies = [
 name = "core-crypto-ffi"
 version = "4.2.2"
 dependencies = [
+ "async-channel 2.3.1",
  "async-lock",
  "async-trait",
  "cfg-if",
+ "console_error_panic_hook",
  "core-crypto",
  "core-crypto-keystore",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,7 @@ members = [
     "interop",
     "decode",
 ]
-exclude = [
-    "extras/webdriver-installation",
-]
+exclude = ["extras/webdriver-installation"]
 resolver = "2"
 
 [workspace.lints.clippy]
@@ -24,6 +22,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [workspace.dependencies]
+async-channel = "2.3.1"
 async-lock = "3.4"
 async-recursion = "1"
 async-std = "1.13"
@@ -31,6 +30,7 @@ async-trait = "0.1"
 base64 = "0.22"
 bitflags = "2.9"
 cfg-if = "1.0"
+console_error_panic_hook = "0.1.7"
 const_format = "0.2"
 core-crypto = { path = "crypto" }
 core-crypto-keystore = { path = "keystore" }

--- a/README.md
+++ b/README.md
@@ -226,9 +226,12 @@ core-crypto/crypto-ffi/bindings/js$ bun run build
 ```
 
 Run tests:
+
 ```sh
-core-crypto/crypto-ffi/bindings/js$ bun run test
+core-crypto/crypto-ffi/bindings/js$ CC_TEST_LOG_LEVEL=1 bun run test
 ```
+
+Note the `CC_TEST_LOG_LEVEL` environment variable. At 1 it emits browser console logs; at 2 it also emits CoreCrypto logs.
 
 Note that CI will fail if it doesn't like your formatting. This can typically be automtically adjusted with
 

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -61,6 +61,8 @@ serde = { workspace = true, features = ["derive"] }
 js-sys = "0.3"
 web-sys = "0.3"
 strum.workspace = true
+async-channel.workspace = true
+console_error_panic_hook.workspace = true
 
 # UniFFI - Android + iOS bindings - Build support
 [target.'cfg(not(target_family = "wasm"))'.build-dependencies.uniffi]

--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -34,6 +34,7 @@ export type {
     CoreCryptoDeferredParams,
     CoreCryptoParams,
     CoreCryptoLogger,
+    EpochObserver,
 } from "./CoreCryptoInstance.js";
 
 export {

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -27,6 +27,7 @@ import {
 
 import { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 
+
 export class CoreCryptoContext {
     /** @hidden */
     #ctx: CoreCryptoFfiTypes.CoreCryptoContext;

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -27,7 +27,6 @@ import {
 
 import { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 
-
 export class CoreCryptoContext {
     /** @hidden */
     #ctx: CoreCryptoFfiTypes.CoreCryptoContext;

--- a/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
+++ b/crypto-ffi/bindings/js/test/CoreCrypto.test.ts
@@ -954,3 +954,73 @@ describe("Error type mapping", () => {
         );
     });
 });
+
+describe("epoch observer", () => {
+    it("should observe new epochs", async () => {
+        await ccInit(ALICE_ID);
+        const { length, first_id_hex } = await browser.execute(
+            async (clientName, conv_id_str) => {
+                const conv_id = new TextEncoder().encode(conv_id_str);
+
+                // set up the observer. this just keeps a list of all observations.
+                type ObservedEpoch = {
+                    conversationId: Uint8Array;
+                    epoch: number;
+                };
+                class Observer {
+                    observations: ObservedEpoch[];
+                    constructor() {
+                        this.observations = [];
+                    }
+                    async epochChanged(
+                        conversationId: Uint8Array,
+                        epoch: number
+                    ): Promise<void> {
+                        this.observations.push({ conversationId, epoch });
+                    }
+                }
+                const observer = new Observer();
+
+                const cc = window.ensureCcDefined(clientName);
+
+                // create the conversation in one transaction
+                await cc.transaction(async (ctx) => {
+                    await ctx.createConversation(
+                        conv_id,
+                        window.ccModule.CredentialType.Basic
+                    );
+                });
+
+                // register the epoch observer
+                await cc.registerEpochObserver(observer);
+
+                // in another transaction, change the epoch
+                await cc.transaction(async (ctx) => {
+                    await ctx.updateKeyingMaterial(conv_id);
+                });
+
+                // we have to explicitly return non-primitives, as anything passed by reference won't make it out of the browser context
+                const first_id_hex = Array.from(
+                    observer.observations[0].conversationId,
+                    (byte) => {
+                        return ("0" + (byte & 0xff).toString(16)).slice(-2);
+                    }
+                ).join("");
+                return { length: observer.observations.length, first_id_hex };
+            },
+            ALICE_ID,
+            CONV_ID
+        );
+
+        const expect_conversation_id = new TextEncoder().encode(CONV_ID);
+        const expect_conversation_id_hex = Array.from(
+            expect_conversation_id,
+            (byte) => {
+                return ("0" + (byte & 0xff).toString(16)).slice(-2);
+            }
+        ).join("");
+
+        expect(length).toEqual(1);
+        expect(first_id_hex).toEqual(expect_conversation_id_hex);
+    });
+});

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCrypto.kt
@@ -1,5 +1,9 @@
 package com.wire.crypto
 
+import com.wire.crypto.uniffi.EpochObserver
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+
 typealias EnrollmentHandle = ByteArray
 
 /**

--- a/crypto-ffi/src/generic/epoch_observer.rs
+++ b/crypto-ffi/src/generic/epoch_observer.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use core_crypto::prelude::ConversationId;
+
+use crate::{CoreCryptoError, generic::CoreCryptoResult};
+
+use super::CoreCrypto;
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi(flat_error)]
+pub enum EpochChangedReportingError {
+    #[error("panic or otherwise unexpected error from foreign code")]
+    Ffi(#[from] uniffi::UnexpectedUniFFICallbackError),
+}
+
+/// An `EpochObserver` is notified whenever a conversation's epoch changes.
+#[uniffi::export(with_foreign)]
+#[async_trait]
+pub trait EpochObserver: Send + Sync {
+    /// This function will be called every time a conversation's epoch changes.
+    ///
+    /// The `epoch` parameter is the new epoch.
+    ///
+    /// <div class="warning">
+    /// This function must not block! Foreign implementors of this inteface can
+    /// spawn a task indirecting the notification, or (unblocking) send the notification
+    /// on some kind of channel, or anything else, as long as the operation completes
+    /// quickly.
+    /// </div>
+    ///
+    /// Though the signature includes an error type, that error is only present because
+    /// it is required by `uniffi` in order to handle panics. This function should suppress
+    /// and ignore internal errors instead of propagating them, to the maximum extent possible.
+    async fn epoch_changed(
+        &self,
+        conversation_id: ConversationId,
+        epoch: u64,
+    ) -> Result<(), EpochChangedReportingError>;
+}
+
+/// This shim bridges the public `EpochObserver` interface with the internal one defined by `core-crypto`.
+///
+/// This is slightly unfortunate, as it introduces an extra layer of indirection before a change notice can
+/// actually reach its foreign target. However, the orphan rule prevents us from just tying the two traits
+/// together directly, so this is the straightforward way to accomplish that.
+struct ObserverShim(Arc<dyn EpochObserver>);
+
+#[async_trait]
+impl core_crypto::mls::EpochObserver for ObserverShim {
+    async fn epoch_changed(&self, conversation_id: ConversationId, epoch: u64) {
+        // We want to ignore all errors arising from the change notice function.
+        // It should be purely fire-and-forget.
+        let _ = self.0.epoch_changed(conversation_id, epoch).await;
+    }
+}
+
+#[uniffi::export]
+impl CoreCrypto {
+    /// Add an epoch observer to this client.
+    ///
+    /// This function should be called 0 or 1 times in a client's lifetime.
+    /// If called when an epoch observer already exists, this will return an error.
+    pub async fn register_epoch_observer(&self, epoch_observer: Arc<dyn EpochObserver>) -> CoreCryptoResult<()> {
+        let shim = Arc::new(ObserverShim(epoch_observer));
+        self.central
+            .register_epoch_observer(shim)
+            .await
+            .map_err(CoreCryptoError::generic())
+    }
+}

--- a/crypto-ffi/src/generic/mod.rs
+++ b/crypto-ffi/src/generic/mod.rs
@@ -41,6 +41,7 @@ use core_crypto::{
 };
 
 pub mod context;
+mod epoch_observer;
 
 #[allow(dead_code)]
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -665,6 +666,8 @@ pub struct BufferedDecryptedMessage {
     pub is_active: bool,
     pub commit_delay: Option<u64>,
     pub sender_client_id: Option<ClientId>,
+    /// Deprecated: this member will be removed in the future. Prefer using the `EpochObserver` interface.
+    #[deprecated = "This member will be removed in the future. Prefer using the `EpochObserver` interface."]
     pub has_epoch_changed: bool,
     pub identity: WireIdentity,
     pub crl_new_distribution_points: Option<Vec<String>>,
@@ -689,6 +692,7 @@ impl TryFrom<MlsConversationDecryptMessage> for DecryptedMessage {
             })
             .transpose()?;
 
+        #[expect(deprecated)]
         Ok(Self {
             message: from.app_msg,
             proposals,
@@ -713,6 +717,7 @@ impl TryFrom<MlsBufferedConversationDecryptMessage> for BufferedDecryptedMessage
             .map(ProposalBundle::try_from)
             .collect::<CoreCryptoResult<Vec<_>>>()?;
 
+        #[expect(deprecated)]
         Ok(Self {
             message: from.app_msg,
             proposals,

--- a/crypto-ffi/src/wasm/epoch_observer.rs
+++ b/crypto-ffi/src/wasm/epoch_observer.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use core_crypto::prelude::ConversationId;
+use log::kv;
+use wasm_bindgen::prelude::*;
+
+use crate::{InternalError, wasm::CoreCryptoResult};
+
+use super::CoreCrypto;
+
+#[wasm_bindgen]
+extern "C" {
+    /// An `EpochObserver` is notified whenever a conversation's epoch changes.
+    pub type EpochObserver;
+
+    /// Receivers of this callback should return _fast_, and delegate any real work to other tasks.
+    ///
+    /// Buffering of epoch change notifications is very limited, and notifications will be silently
+    /// dropped if the buffer is full.
+    #[wasm_bindgen(structural, method, catch)]
+    pub async fn epoch_changed(
+        this: &EpochObserver,
+        conversation_id: ConversationId,
+        epoch: u64,
+    ) -> Result<(), JsValue>;
+}
+
+/// This shim bridges the public `EpochObserver` interface with the internal one defined by `core-crypto`.
+///
+/// The shim must be `Send + Sync` in order to implement `core_crypto::mls::EpochObserver`, which means
+/// that it cannot simply wrap the `EpochObserver` duck type that Js gives us; `JsValue` instances are
+/// very intentionally _not_ `Sync` or `Send`.
+///
+/// Luckily, we have a mechanism to connect unrelated structs without wrapping: channels! So we'll give
+/// this shim the sender, and then spawn a task to ensure that the messages on the channel get passed
+/// back to the JS side.
+struct ObserverShim(async_channel::Sender<(ConversationId, u64)>);
+
+#[async_trait]
+impl core_crypto::mls::EpochObserver for ObserverShim {
+    async fn epoch_changed(&self, conversation_id: ConversationId, epoch: u64) {
+        // if this channel is full or disconnected, drop the message
+        let _ = self.0.try_send((conversation_id, epoch));
+    }
+}
+
+#[wasm_bindgen]
+impl CoreCrypto {
+    /// Add an epoch observer to this client.
+    ///
+    /// This function should be called 0 or 1 times in a client's lifetime.
+    /// If called when an epoch observer already exists, this will return an error.
+    pub async fn register_epoch_observer(&self, epoch_observer: EpochObserver) -> CoreCryptoResult<()> {
+        let (tx, rx) = async_channel::bounded(1);
+        let shim = Arc::new(ObserverShim(tx));
+        wasm_bindgen_futures::spawn_local(async move {
+            while let Ok((conversation_id, epoch)) = rx.recv().await {
+                if let Err(err) = epoch_observer.epoch_changed(conversation_id, epoch).await {
+                    // we don't _care_ if an error is thrown by the the notification function, per se,
+                    // but this would probably be useful information for downstream debugging efforts
+                    //
+                    // Can't use the `Obfuscate` thing to log the group as it's private, so ignore group id and epoch
+                    log::warn!(
+                        err = LoggableJsValue(err);
+                        "caught an error when attempting to notify the epoch observer of an epoch change"
+                    );
+                }
+            }
+            // if the channel ever closes or produces an error, this task will complete
+        });
+        self.inner
+            .register_epoch_observer(shim)
+            .await
+            .map_err(InternalError::generic())
+            .map_err(Into::into)
+    }
+}
+
+struct LoggableJsValue(JsValue);
+
+impl kv::ToValue for LoggableJsValue {
+    fn to_value(&self) -> kv::Value<'_> {
+        // can't get a borrowed str from `JsValue`, so can't directly
+        // convert into a string; oh well; fallback should catch it
+        if let Some(f) = self.0.as_f64() {
+            return f.into();
+        }
+        if let Some(b) = self.0.as_bool() {
+            return b.into();
+        }
+        if self.0.is_null() || self.0.is_undefined() {
+            return kv::Value::null();
+        }
+        kv::Value::from_debug(&self.0)
+    }
+}

--- a/crypto-ffi/src/wasm/mod.rs
+++ b/crypto-ffi/src/wasm/mod.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 #![allow(unused_variables)]
 pub mod context;
+mod epoch_observer;
 mod utils;
 
 use std::{
@@ -790,6 +791,7 @@ impl TryFrom<MlsConversationDecryptMessage> for DecryptedMessage {
             .transpose()
             .map_err(InternalError::generic())?;
 
+        #[expect(deprecated)]
         Ok(Self {
             message: from.app_msg,
             proposals,
@@ -899,6 +901,7 @@ impl TryFrom<MlsBufferedConversationDecryptMessage> for BufferedDecryptedMessage
             .transpose()
             .map_err(InternalError::generic())?;
 
+        #[expect(deprecated)]
         Ok(Self {
             message: from.app_msg,
             proposals,
@@ -1464,6 +1467,7 @@ impl CoreCrypto {
         entropy_seed: Option<Box<[u8]>>,
         nb_key_package: Option<u32>,
     ) -> WasmCryptoResult<CoreCrypto> {
+        console_error_panic_hook::set_once();
         let ciphersuites = lower_ciphersuites(&ciphersuites)?;
         let entropy_seed = entropy_seed.map(|s| s.to_vec());
         let nb_key_package = nb_key_package

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -97,6 +97,7 @@ pub mod prelude {
             credential::{typ::MlsCredentialType, x509::CertificateBundle},
             proposal::{MlsProposal, MlsProposalRef},
         },
+        obfuscate::Obfuscated,
     };
 }
 

--- a/crypto/src/mls/client/epoch_observer.rs
+++ b/crypto/src/mls/client/epoch_observer.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::prelude::ConversationId;
+
+use super::{Client, Error, Result};
+
+/// An `EpochObserver` is notified whenever a conversation's epoch changes.
+#[async_trait]
+pub trait EpochObserver: std::fmt::Debug + Send + Sync {
+    /// This function will be called every time a conversation's epoch changes.
+    ///
+    /// The `epoch` parameter is the new epoch.
+    ///
+    /// <div class="warning">
+    /// This function must not block! Foreign implementors of this inteface can
+    /// spawn a task indirecting the notification, or (unblocking) send the notification
+    /// on some kind of channel, or anything else, as long as the operation completes
+    /// quickly.
+    /// </div>
+    async fn epoch_changed(&self, conversation_id: ConversationId, epoch: u64);
+}
+
+impl Client {
+    /// Add an epoch observer to this client.
+    ///
+    /// This function should be called 0 or 1 times in a client's lifetime. If called
+    /// when an epoch observer already exists, this will return an error.
+    pub async fn register_epoch_observer(&self, epoch_observer: Arc<dyn EpochObserver>) -> Result<()> {
+        let mut guard = self.state.write().await;
+        let inner = guard.as_mut().ok_or(Error::MlsNotInitialized)?;
+        if inner.epoch_observer.is_some() {
+            return Err(Error::EpochObserverAlreadyExists);
+        }
+        inner.epoch_observer = Some(epoch_observer);
+        Ok(())
+    }
+
+    /// Notify the observer that the epoch has changed, if one is present.
+    pub(crate) async fn notify_epoch_changed(&self, conversation_id: ConversationId, epoch: u64) {
+        let guard = self.state.read().await;
+        if let Some(inner) = guard.as_ref() {
+            if let Some(observer) = inner.epoch_observer.as_ref() {
+                observer.epoch_changed(conversation_id, epoch).await;
+            }
+        }
+    }
+}

--- a/crypto/src/mls/client/epoch_observer.rs
+++ b/crypto/src/mls/client/epoch_observer.rs
@@ -8,7 +8,7 @@ use super::{Client, Error, Result};
 
 /// An `EpochObserver` is notified whenever a conversation's epoch changes.
 #[async_trait]
-pub trait EpochObserver: std::fmt::Debug + Send + Sync {
+pub trait EpochObserver: Send + Sync {
     /// This function will be called every time a conversation's epoch changes.
     ///
     /// The `epoch` parameter is the new epoch.

--- a/crypto/src/mls/client/error.rs
+++ b/crypto/src/mls/client/error.rs
@@ -47,6 +47,8 @@ pub enum Error {
     TooManyIdentitiesPresent,
     #[error("The supplied credential does not match the id or signature schemes provided")]
     WrongCredential,
+    #[error("An EpochObserver has already been registered; reregistration is not possible")]
+    EpochObserverAlreadyExists,
     #[error("Serializing {item} for TLS")]
     TlsSerialize {
         item: &'static str,

--- a/crypto/src/mls/client/mod.rs
+++ b/crypto/src/mls/client/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+mod epoch_observer;
 mod error;
 pub(crate) mod id;
 pub(crate) mod identifier;
@@ -29,6 +30,7 @@ use crate::{
         key_package::KEYPACKAGE_DEFAULT_LIFETIME,
     },
 };
+pub use epoch_observer::EpochObserver;
 pub(crate) use error::{Error, Result};
 
 use async_lock::RwLock;
@@ -63,6 +65,7 @@ struct ClientInner {
     id: ClientId,
     pub(crate) identities: ClientIdentities,
     keypackage_lifetime: std::time::Duration,
+    epoch_observer: Option<Arc<dyn EpochObserver>>,
 }
 
 impl Client {
@@ -241,6 +244,7 @@ impl Client {
             id: client_id.clone(),
             identities: ClientIdentities::new(stored_skp.len()),
             keypackage_lifetime: KEYPACKAGE_DEFAULT_LIFETIME,
+            epoch_observer: None,
         })
         .await;
 
@@ -301,6 +305,7 @@ impl Client {
             id: id.into_owned(),
             identities: ClientIdentities::new(signature_schemes.len()),
             keypackage_lifetime: KEYPACKAGE_DEFAULT_LIFETIME,
+            epoch_observer: None,
         })
         .await;
 
@@ -406,6 +411,7 @@ impl Client {
             id: id.clone(),
             identities,
             keypackage_lifetime: KEYPACKAGE_DEFAULT_LIFETIME,
+            epoch_observer: None,
         })
         .await;
         Ok(())

--- a/crypto/src/mls/client/mod.rs
+++ b/crypto/src/mls/client/mod.rs
@@ -39,9 +39,9 @@ use log::debug;
 use openmls::prelude::{Credential, CredentialType};
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::{OpenMlsCryptoProvider, crypto::OpenMlsCrypto, types::SignatureScheme};
-use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
+use std::{collections::HashSet, fmt};
 use tls_codec::{Deserialize, Serialize};
 
 use core_crypto_keystore::entities::{EntityFindParams, MlsCredential, MlsSignatureKeyPair};
@@ -60,12 +60,28 @@ pub struct Client {
     state: Arc<RwLock<Option<ClientInner>>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct ClientInner {
     id: ClientId,
     pub(crate) identities: ClientIdentities,
     keypackage_lifetime: std::time::Duration,
     epoch_observer: Option<Arc<dyn EpochObserver>>,
+}
+
+impl fmt::Debug for ClientInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let observer_debug = if self.epoch_observer.is_some() {
+            "Some(Arc<dyn EpochObserver>)"
+        } else {
+            "None"
+        };
+        f.debug_struct("ClientInner")
+            .field("id", &self.id)
+            .field("identities", &self.identities)
+            .field("keypackage_lifetime", &self.keypackage_lifetime)
+            .field("epoch_observer", &observer_debug)
+            .finish()
+    }
 }
 
 impl Client {

--- a/crypto/src/mls/conversation/conversation_guard/commit.rs
+++ b/crypto/src/mls/conversation/conversation_guard/commit.rs
@@ -29,9 +29,10 @@ impl ConversationGuard {
         match self.send_commit(commit).await {
             Ok(TransportedCommitPolicy::None) => Ok(()),
             Ok(TransportedCommitPolicy::Merge) => {
+                let client = self.mls_client().await?;
                 let backend = self.mls_provider().await?;
                 let mut conversation = self.inner.write().await;
-                conversation.commit_accepted(&backend).await
+                conversation.commit_accepted(&client, &backend).await
             }
             Err(e @ Error::MessageRejected { .. }) => {
                 self.clear_pending_commit().await?;

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -1073,14 +1073,6 @@ mod tests {
                             .unwrap();
                         alice_central.invite_all(&case, &id, [&bob_central]).await.unwrap();
 
-                        let bob_observer = TestEpochObserver::new();
-                        bob_central
-                            .client()
-                            .await
-                            .register_epoch_observer(bob_observer.clone())
-                            .await
-                            .unwrap();
-
                         let charlie_kp = charlie_central.get_one_key_package(&case).await;
                         let proposal = alice_central
                             .context
@@ -1109,7 +1101,6 @@ mod tests {
                             .await
                             .unwrap();
                         assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
-                        assert!(!bob_observer.has_changed().await);
 
                         alice_central.verify_sender_identity(&case, &decrypted).await;
                     })

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -86,7 +86,7 @@ impl MlsConversation {
         client: &Client,
         backend: &MlsCryptoProvider,
     ) -> Result<MlsConversationDecryptMessage> {
-        self.commit_accepted(backend).await?;
+        self.commit_accepted(client, backend).await?;
 
         let own_leaf = self
             .group
@@ -109,10 +109,6 @@ impl MlsConversation {
         )
         .await
         .map_err(RecursiveError::mls_credential("getting new crl distribution points"))?;
-
-        client
-            .notify_epoch_changed(self.id.clone(), self.group.epoch().as_u64())
-            .await;
 
         // we still support the `has_epoch_changed` field, though we'll remove it later
         #[expect(deprecated)]

--- a/crypto/src/mls/conversation/pending_conversation.rs
+++ b/crypto/src/mls/conversation/pending_conversation.rs
@@ -190,6 +190,12 @@ impl PendingConversation {
         .await
         .map_err(RecursiveError::mls_credential("getting new crl distribution points"))?;
 
+        // Note that though we return `has_epoch_changed: true` here, we don't notify the observer.
+        // This function can only be reached via a code path going through `MlsConversation::decrypt_message`
+        // which already notifies the observer; it would be redundant to notify here also.
+
+        // we still support the `has_epoch_changed` field, though we'll remove it later
+        #[expect(deprecated)]
         Ok(MlsConversationDecryptMessage {
             app_msg: None,
             proposals: vec![],

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod external_commit;
 pub(crate) mod external_proposal;
 pub(crate) mod proposal;
 
+pub use client::EpochObserver;
 pub use error::{Error, Result};
 
 // Prevents direct instantiation of [MlsCentralConfiguration]

--- a/crypto/src/obfuscate.rs
+++ b/crypto/src/obfuscate.rs
@@ -56,8 +56,14 @@ impl Obfuscate for &Sender {
     }
 }
 
+/// We often want logging for some values that we shouldn't know the real value of, for privacy reasons.
+///
+/// `ConversationId` is a canonical example of such an item.
+///
+/// This wrapper lets us log a partial hash of the sensitive item, so we have deterministic loggable non-sensitive
+/// aliases for all our sensitive values.
 #[derive(From, Constructor)]
-pub(crate) struct Obfuscated<T>(T);
+pub struct Obfuscated<T>(T);
 
 impl<T> Debug for Obfuscated<T>
 where

--- a/crypto/src/test_utils/epoch_observer.rs
+++ b/crypto/src/test_utils/epoch_observer.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use async_lock::Mutex;
+use async_trait::async_trait;
+
+use crate::prelude::{ConversationId, EpochObserver};
+
+pub(crate) struct TestEpochObserver(Mutex<EpochObserverInner>);
+
+#[derive(Default)]
+struct EpochObserverInner {
+    observed_epochs: Vec<(ConversationId, u64)>,
+}
+
+impl TestEpochObserver {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self(Default::default()))
+    }
+
+    pub(crate) async fn reset(&self) {
+        let mut guard = self.0.lock().await;
+        guard.observed_epochs.clear();
+    }
+
+    pub(crate) async fn has_changed(&self) -> bool {
+        let guard = self.0.lock().await;
+        !guard.observed_epochs.is_empty()
+    }
+
+    pub(crate) async fn observed_epochs(&self) -> Vec<(ConversationId, u64)> {
+        self.0.lock().await.observed_epochs.clone()
+    }
+}
+
+#[async_trait]
+impl EpochObserver for TestEpochObserver {
+    async fn epoch_changed(&self, conversation_id: ConversationId, epoch: u64) {
+        let mut guard = self.0.lock().await;
+        guard.observed_epochs.push((conversation_id, epoch));
+    }
+}

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -33,11 +33,12 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 pub mod context;
+mod epoch_observer;
+mod error;
 pub mod fixtures;
 pub mod message;
 pub mod x509;
 // Cannot name it `proteus` because then it conflicts with proteus the crate :(
-mod error;
 #[cfg(feature = "proteus")]
 pub mod proteus_utils;
 
@@ -45,6 +46,7 @@ use crate::context::CentralContext;
 use crate::e2e_identity::id::{QualifiedE2eiClientId, WireQualifiedClientId};
 use crate::prelude::{Client, MlsCommitBundle, MlsGroupInfoBundle};
 pub use crate::prelude::{ClientIdentifier, INITIAL_KEYING_MATERIAL_COUNT, MlsCredentialType};
+pub(crate) use epoch_observer::TestEpochObserver;
 pub use error::Error as TestError;
 use error::Result;
 pub use fixtures::{TestCase, *};


### PR DESCRIPTION
# What's new in this PR

- Add an `EpochObserver` API for notifications when the epoch changes
- Deprecate the old `has_epoch_changed` member of the struct returned when decrypting a message

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
