### PR TITLE
docs: add docs landing page [WPB-11382]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,6 +129,10 @@ jobs:
         path: target/doc
         merge-multiple: true
 
+    - name: Copy index.md
+      run: |
+        cp docs/index.md target/doc/index.md
+
     - name: deploy docs
       uses: peaceiris/actions-gh-pages@v4
       with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Core-Crypto Documentation
+
+## API Documentation
+
+|          | TypeScript                                           | Kotlin                                       | Swift                                      | Rust                   |
+|----------|------------------------------------------------------|----------------------------------------------|--------------------------------------------|------------------------|
+| **main** | [TypeScript](./core_crypto_ffi/bindings/typescript/) | [Kotlin](./core_crypto_ffi/bindings/kotlin/) | [Swift](./core_crypto_ffi/bindings/swift/) | [Rust](./core_crypto/) | 


### PR DESCRIPTION
Add a landing page that links rust and bindings api documentations. Currently only for main, next, version-specific links are going to be added.

# What's new in this PR
Docs landing page

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
