### PR TITLE
docs: fix comments in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 # Core-Crypto Documentation
 
 ## API Documentation
-[//]: # (If you want to try to deploy docs for an old tag, go to 
+<!-- If you want to try to deploy docs for an old tag, go to 
 https://github.com/wireapp/core-crypto/actions/workflows/docs.yml, click "run workflow" and provide the tag number as 
-input, and confirm by "run workflow" below the input. Note that deployment depends on successfully building all docs.)
+input, and confirm by "run workflow" below the input. Note that deployment depends on successfully building all docs. -->
 
 |            | TypeScript                                                 | Kotlin                                             | Swift                                            | Rust                         |
 |------------|------------------------------------------------------------|----------------------------------------------------|--------------------------------------------------|------------------------------|
@@ -11,5 +11,5 @@ input, and confirm by "run workflow" below the input. Note that deployment depen
 | **v4.2.0** | [TypeScript](./v4.2.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.0/core_crypto_ffi/bindings/kotlin) | [Swift](./v4.2.0/core_crypto_ffi/bindings/swift) | [Rust](./v4.2.0/core_crypto) |
 | **v3.1.0** | [TypeScript](./v3.1.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v3.1.0/core_crypto_ffi/bindings/kotlin) | [Swift](./v3.1.0/core_crypto_ffi/bindings/swift) | [Rust](./v3.1.0/core_crypto) |
 
-[//]: # (| **vx.x.x** | [TypeScript]&#40;./vx.x.x/core_crypto_ffi/bindings/typescript&#41; | [Kotlin]&#40;./vx.x.x/core_crypto_ffi/bindings/kotlin&#41; | [Swift]&#40;./vx.x.x/core_crypto_ffi/bindings/swift&#41; | [Rust]&#40;./vx.x.x/core_crypto&#41; |)
+<!-- | **vx.x.x** | [TypeScript](./vx.x.x/core_crypto_ffi/bindings/typescript) | [Kotlin](./vx.x.x/core_crypto_ffi/bindings/kotlin) | [Swift](./vx.x.x/core_crypto_ffi/bindings/swift) | [Rust](./vx.x.x/core_crypto) | -->
 


### PR DESCRIPTION
Jekyll doesn't interpret the markdown comments the way I expected, so it's better to just use HTML comments directly.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
