### PR TITLE
chore: fix release instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ The versioning scheme used is [SemVer AKA Semantic Versioning](https://semver.or
    - baz
    ```
 1. In [index.md](docs/index.md), copy the commented-out table row from  the bottom of the file to the appropriate place
+in the table, ordering by version number, descending. Search and replace the first 5 occurrences of `x.x.x` with `X.Y.Z`.
 1. Make sure the changes look reasonable and complete; you can use the previous release as a reference
 1. Push your `prepare-release/X.Y.Z` branch and create a PR for it
 1. Get it reviewed, then merge it into `main` and remove the `prepare-release/X.Y.Z` branch from the remote
@@ -306,7 +307,6 @@ The versioning scheme used is [SemVer AKA Semantic Versioning](https://semver.or
 1. Create the release tag: `git tag -s vX.Y.Z`
 1. Push the new tag: `git push origin tag vX.Y.Z`
 1. Create a new release on github, copying the relevant section from `CHANGELOG.md`
-in the table, ordering by version number, descending. Search and replace the first 5 occurrences of `x.x.x` with `X.Y.Z`.
 1. Voilà!
 
 


### PR DESCRIPTION
There were two lines in the updated instruction, I only shifted the first one of them. This fixes it.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
