### PR TITLE
fix: kotlin documentation links on the main page [WPB-16460]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,14 +5,14 @@
 https://github.com/wireapp/core-crypto/actions/workflows/docs.yml, click "run workflow" and provide the tag number as 
 input, and confirm by "run workflow" below the input. Note that deployment depends on successfully building all docs. -->
 
-|            | TypeScript                                                 | Kotlin                                                     | Swift                                              | Rust                                             |
-|------------|------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------------|--------------------------------------------------|
-| **main**   | [TypeScript](./core_crypto_ffi/bindings/typescript/)       | [Kotlin](./core_crypto_ffi/bindings/kotlin/)               | [Swift](./core_crypto_ffi/bindings/swift/)         | [Rust](./core_crypto/)                           |
-| **v4.2.3** | [TypeScript](./v4.2.3/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.3/core_crypto_ffi/bindings/kotlin)         | [Swift](./v4.2.3/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.3/core_crypto)                     |
-| **v4.2.2** | [TypeScript](./v4.2.2/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.2/core_crypto_ffi/bindings/kotlin)         | [Swift](./v4.2.2/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.2/core_crypto)                     |
-| **v4.2.1** | [TypeScript](./v4.2.1/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.1/core_crypto_ffi/bindings/kotlin)         | [Swift](./v4.2.1/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.1/core_crypto)                     |
-| **v4.2.0** | [TypeScript](./v4.2.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.0/core_crypto_ffi/bindings/kotlin)         | [Swift](./v4.2.0/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.0/core_crypto)                     |
-| **v3.1.0** | [TypeScript](./v3.1.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v3.1.0/core_crypto_ffi/bindings/kotlin)         | [Swift](./v3.1.0/core_crypto_ffi/bindings/swift)   | [Rust](./v3.1.0/core_crypto)                     |
+|            | TypeScript                                                 | Kotlin                                                  | Swift                                              | Rust                                             |
+|------------|------------------------------------------------------------|---------------------------------------------------------|----------------------------------------------------|--------------------------------------------------|
+| **main**   | [TypeScript](./core_crypto_ffi/bindings/typescript/)       | [Kotlin](./core_crypto_ffi/bindings/kotlin/html)        | [Swift](./core_crypto_ffi/bindings/swift/)         | [Rust](./core_crypto/)                           |
+| **v4.2.3** | [TypeScript](./v4.2.3/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.3/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v4.2.3/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.3/core_crypto)                     |
+| **v4.2.2** | [TypeScript](./v4.2.2/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.2/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v4.2.2/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.2/core_crypto)                     |
+| **v4.2.1** | [TypeScript](./v4.2.1/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.1/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v4.2.1/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.1/core_crypto)                     |
+| **v4.2.0** | [TypeScript](./v4.2.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v4.2.0/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v4.2.0/core_crypto_ffi/bindings/swift)   | [Rust](./v4.2.0/core_crypto)                     |
+| **v3.1.0** | [TypeScript](./v3.1.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v3.1.0/core_crypto_ffi/bindings/kotlin)      | [Swift](./v3.1.0/core_crypto_ffi/bindings/swift)   | [Rust](./v3.1.0/core_crypto)                     |
 
-<!-- | **vx.x.x** | [TypeScript](./vx.x.x/core_crypto_ffi/bindings/typescript) | [Kotlin](./vx.x.x/core_crypto_ffi/bindings/kotlin) | [Swift](./vx.x.x/core_crypto_ffi/bindings/swift) | [Rust](./vx.x.x/core_crypto) | -->
+<!-- | **vx.x.x** | [TypeScript](./vx.x.x/core_crypto_ffi/bindings/typescript) | [Kotlin](./vx.x.x/core_crypto_ffi/bindings/kotlin/html) | [Swift](./vx.x.x/core_crypto_ffi/bindings/swift) | [Rust](./vx.x.x/core_crypto) | -->
 


### PR DESCRIPTION
# What's new in this PR

kotlin documentation links on the main page

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
