### PR TITLE
ci: use chrome-headless-shell instead of chrome --headless [WPB-16565]

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -121,7 +121,7 @@ jobs:
 
   create-xcframework:
     needs: build-ios
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: download artifacts for ios
@@ -145,7 +145,7 @@ jobs:
           ./build-xcframework.sh
 
   e2e-interop-test:
-    runs-on: macos-latest
+    runs-on: self-hosted
     needs: build-ios
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -162,15 +162,13 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
-      - uses: wireapp/setup-chrome@master
-        id: setup-chrome
-        with:
-          chrome-version: latest
-      - run: |
-          echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      - name: Install chrome-headless-shell
+        run: |
+          bun x @puppeteer/browsers install chrome-headless-shell@latest --path $PWD
+          echo "CHROME_PATH=$(echo $PWD/chrome-headless-shell/*/*/chrome-headless-shell)" >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build-ios:
     if: github.repository == 'wireapp/core-crypto'
-    runs-on: macos-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         include:

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -31,8 +31,9 @@ args = ["install", "--cwd", "bindings/js"]
 
 [tasks.docs-ts]
 dependencies = ["wasm", "bun-deps"]
-command = "bunx"
+command = "bun"
 args = [
+    "x",
     "typedoc",
     "--basePath", "./bindings/js",
     "--entryPoints", "./bindings/js/src/CoreCrypto.ts",

--- a/crypto-ffi/bindings/js/package.json
+++ b/crypto-ffi/bindings/js/package.json
@@ -53,9 +53,9 @@
   "scripts": {
     "clean": "rm -f src/corecrypto.js src/corecrypto.d.ts",
     "build": "bun run clean && bun build --target browser --format esm --outfile src/corecrypto.js src/CoreCrypto.ts",
-    "postbuild": "bunx dts-bundle-generator --project tsconfig.json -o src/corecrypto.d.ts --no-check src/CoreCrypto.ts",
-    "test": "bunx wdio run wdio.conf.ts --spec test/**/*.test.ts",
-    "bench": "bunx wdio run wdio.conf.ts --spec benches/**/*.bench.ts --log-level warn"
+    "postbuild": "bun x dts-bundle-generator --project tsconfig.json -o src/corecrypto.d.ts --no-check src/CoreCrypto.ts",
+    "test": "bun x wdio run wdio.conf.ts --spec test/**/*.test.ts",
+    "bench": "bun x wdio run wdio.conf.ts --spec benches/**/*.bench.ts --log-level warn"
   },
   "type": "module",
   "types": "src/corecrypto.d.ts"

--- a/interop/src/build/web/webdriver.rs
+++ b/interop/src/build/web/webdriver.rs
@@ -56,7 +56,7 @@ pub(crate) async fn setup_browser(addr: &std::net::SocketAddr, folder: &str) -> 
     let mut caps_json = serde_json::json!({
         "goog:chromeOptions": {
             "args": [
-                "headless",
+                "headless=shell",
                 "disable-dev-shm-usage",
                 "no-sandbox"
             ]


### PR DESCRIPTION
# What's new in this PR
This PR reverts to using our self hosted runners and makes the necessary changes to our workflows to make them compatible.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
