### PR TITLE
fix: android-uniffi library namespace was conflicting the main android library [WPB-16470]

### DIFF
--- a/crypto-ffi/bindings/uniffi-android/build.gradle.kts
+++ b/crypto-ffi/bindings/uniffi-android/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 }
 
 android {
-    namespace = "com.wire.crypto"
+    namespace = "com.wire.crypto.uniffi"
     compileSdk = libs.versions.sdk.compile.get().toInt()
     defaultConfig {
         minSdk = libs.versions.sdk.min.get().toInt()


### PR DESCRIPTION
# What's new in this PR

`android-uniffi` library namespace was conflicting the main `android` library

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
