### PR TITLE
chore: adjust log level of empty transaction log

### DIFF
--- a/keystore/src/transaction/mod.rs
+++ b/keystore/src/transaction/mod.rs
@@ -293,7 +293,7 @@ macro_rules! commit_transaction {
             }
 
             if tables.is_empty() {
-                log::warn!("Empty transaction was committed, this could be an indication of a programming error");
+                log::debug!("Empty transaction was committed.");
                 return Ok(());
             }
 


### PR DESCRIPTION
We realized that empty transactions are expected in regular scenarios, so this shouldn't be a warning.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
