### PR TITLE
fix: swift publishing failing due to not running on latest macos runner

### DIFF
--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   publish-swift:
     if: github.repository == 'wireapp/core-crypto'
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
