### PR TITLE
ci: run cleanup script in macos jobs

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -29,6 +29,11 @@ jobs:
     needs: build-ios
     runs-on: macos-latest
     steps:
+      - name: Cleanup on post
+        uses: gacts/run-and-post-run@v1
+        with:
+            post: |
+              sh ./scripts/clean.sh
       - uses: actions/checkout@v4
       - name: download artifacts for ios
         uses: actions/download-artifact@v4
@@ -123,6 +128,11 @@ jobs:
     needs: build-ios
     runs-on: self-hosted
     steps:
+      - name: Cleanup on post
+        uses: gacts/run-and-post-run@v1
+        with:
+            post: |
+              sh ./scripts/clean.sh
       - uses: actions/checkout@v4
       - name: download artifacts for ios
         uses: actions/download-artifact@v4
@@ -148,6 +158,11 @@ jobs:
     runs-on: self-hosted
     needs: build-ios
     steps:
+      - name: Cleanup on post
+        uses: gacts/run-and-post-run@v1
+        with:
+            post: |
+              sh ./scripts/clean.sh
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -24,6 +24,11 @@ jobs:
           - task: ios-simulator-arm
             target: aarch64-apple-ios-sim
     steps:
+      - name: Cleanup on post
+        uses: gacts/run-and-post-run@v1
+        with:
+            post: |
+              sh ./scripts/clean.sh
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,9 @@
+set -e
+
+echo "Running cargo clean..."
+cargo clean
+
+echo "Deleting all node_modules directories..."
+find . -type d -name "node_modules" -exec rm -rf {} +
+
+echo "Done."


### PR DESCRIPTION
We are running low on disk space in our self-hosted runners, also, caches are downloaded as an artifact anyway, so there's no good reason in keeping them.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
