### PR TITLE
build!: drop support for darwin x86_64 targets

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Setup rust macOS
         uses: ./.github/actions/setup-and-cache-rust
         with:
-          target: "wasm32-unknown-unknown,aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim"
+          target: "wasm32-unknown-unknown,aarch64-apple-ios,aarch64-apple-ios-sim"
           rustflags: ''
       - uses: davidB/rust-cargo-make@v1
       - name: setup Xcode

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -19,8 +19,6 @@ jobs:
         include:
           - task: ios-device
             target: aarch64-apple-ios
-          - task: ios-simulator-x86
-            target: x86_64-apple-ios
           - task: ios-simulator-arm
             target: aarch64-apple-ios-sim
     steps:

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -34,18 +34,13 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-          target: "x86_64-apple-darwin,aarch64-apple-darwin"
+          target: "aarch64-apple-darwin"
       - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - name: build artifacts
         run: |
           cd crypto-ffi
           cargo make jvm-darwin
-      - name: upload x86_64-apple-darwin artifacts
-        uses: actions/upload-artifact@v4
-        with:
-            name: x86_64-apple-darwin
-            path: target/x86_64-apple-darwin/release/*.dylib
       - name: upload aarch64-apple-darwin artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -82,11 +77,6 @@ jobs:
         with:
           name: jvm-linux-so-file-${{ github.run_id }}
           path: target/x86_64-unknown-linux-gnu/release
-      - name: download x86_64 apple darwin artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: x86_64-apple-darwin
-          path: target/x86_64-apple-darwin/release
       - name: download aarch64 apple darwin artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
         with:
           rustflags: ''
-          target: "aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim"
+          target: "aarch64-apple-ios,aarch64-apple-ios-sim"
       - name: setup cargo-make
         uses: davidB/rust-cargo-make@v1
       - name: build xcframework

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install Xcode & its command-line tools: [https://developer.apple.com/xcode/](htt
 
 Install iOS rust targets:
 ```ignore
-rustup target add aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim
 ```
 
 Build:
@@ -86,7 +86,7 @@ cargo make ios-create-xcframework
 
 Install macOS rust targets:
 ```ignore
-rustup target add x86_64-apple-darwin aarch64-apple-darwin
+rustup target add aarch64-apple-darwin
 ```
 
 ### Linux

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -129,21 +129,6 @@ args = [
     "-C", "strip=symbols"
 ]
 
-[tasks.ios-simulator-x86]
-dependencies = ["bindings-swift"]
-condition = { platforms = ["mac"] }
-command = "cargo"
-args = [
-    "rustc",
-    "--locked",
-    "--target", "x86_64-apple-ios",
-    "--crate-type=cdylib",
-    "--crate-type=staticlib",
-    "--release",
-    "--",
-    "-C", "strip=symbols"
-]
-
 [tasks.ios-simulator-arm]
 dependencies = ["bindings-swift"]
 # override CFLAGS to fix ring compilation
@@ -163,7 +148,7 @@ args = [
 
 [tasks.ios]
 condition = { platforms = ["mac"] }
-dependencies = ["ios-device", "ios-simulator-x86", "ios-simulator-arm"]
+dependencies = ["ios-device", "ios-simulator-arm"]
 
 [tasks.ios-create-xcframework]
 condition = { platforms = ["mac"] }
@@ -228,22 +213,7 @@ dependencies = ["android-armv7", "android-armv8", "android-x86"]
 
 ####################################  JVM  ####################################
 
-[tasks.jvm-x86-darwin]
-command = "cargo"
-args = [
-    "rustc",
-    "--locked",
-    "--target", "x86_64-apple-darwin",
-    "--crate-type=cdylib",
-    "--crate-type=staticlib",
-    "--release",
-    "--",
-    "-C", "strip=symbols"
-]
-dependencies = ["bindings-kotlin-jvm"]
-condition = { platforms = ["mac"] }
-
-[tasks.jvm-aarch64-darwin]
+[tasks.jvm-darwin]
 command = "cargo"
 args = [
     "rustc",
@@ -273,9 +243,6 @@ args = [
 dependencies = ["bindings-kotlin-jvm"]
 condition = { platforms = ["linux"] }
 
-[tasks.jvm-darwin]
-dependencies = ["jvm-aarch64-darwin", "jvm-x86-darwin"]
-
 [tasks.jvm]
 dependencies = ["jvm-darwin", "jvm-linux"]
 
@@ -296,8 +263,6 @@ fn update_android_env
     platform = os_family
     if eq ${platform} "linux"
         platform_dir = set "linux-x86_64"
-    elseif eq ${platform} "mac"
-        platform_dir = set "darwin-x86_64"
     else
         trigger_error "Unsupported host platform"
     end

--- a/crypto-ffi/bindings/swift/BuildSettings.xcconfig
+++ b/crypto-ffi/bindings/swift/BuildSettings.xcconfig
@@ -7,5 +7,4 @@ DYLIB_CURRENT_VERSION=$(CURRENT_PROJECT_VERSION)
 DYLIB_COMPATIBILITY_VERSION=$(CURRENT_PROJECT_VERSION)
 BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 OTHER_LDFLAGS[sdk=iphoneos*][arch=arm64] = ../../../../target/aarch64-apple-ios/release/libcore_crypto_ffi.a
-OTHER_LDFLAGS[sdk=iphonesimulator*][arch=x86_64] = ../../../../target/x86_64-apple-ios/release/libcore_crypto_ffi.a
 OTHER_LDFLAGS[sdk=iphonesimulator*][arch=arm64] = ../../../../target/aarch64-apple-ios-sim/release/libcore_crypto_ffi.a

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto.xcodeproj/project.pbxproj
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 				DEVELOPMENT_TEAM = "";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				"EXCLUDED_ARCHS[sdk=*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -398,6 +399,7 @@
 				DEVELOPMENT_TEAM = "";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				"EXCLUDED_ARCHS[sdk=*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -408,6 +410,7 @@
 				);
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireCoreCrypto;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto.xcodeproj/xcshareddata/xcschemes/WireCoreCrypto.xcscheme
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto.xcodeproj/xcshareddata/xcschemes/WireCoreCrypto.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "167AA1ED2D76FF330075DF93"
+               BuildableName = "WireCoreCrypto.framework"
+               BlueprintName = "WireCoreCrypto"
+               ReferencedContainer = "container:WireCoreCrypto.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "167AA1ED2D76FF330075DF93"
+            BuildableName = "WireCoreCrypto.framework"
+            BlueprintName = "WireCoreCrypto"
+            ReferencedContainer = "container:WireCoreCrypto.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/crypto-ffi/bindings/uniffi-jvm/build.gradle.kts
+++ b/crypto-ffi/bindings/uniffi-jvm/build.gradle.kts
@@ -27,7 +27,6 @@ fun registerCopyJvmBinaryTask(target: String, jniTarget: String, include: String
 val copyBinariesTasks = listOf(
     registerCopyJvmBinaryTask("x86_64-unknown-linux-gnu", "linux-x86-64"),
     registerCopyJvmBinaryTask("aarch64-apple-darwin", "darwin-aarch64", "*.dylib"),
-    registerCopyJvmBinaryTask("x86_64-apple-darwin", "darwin-x86-64", "*.dylib"),
 )
 
 tasks.withType<ProcessResources> { dependsOn(copyBinariesTasks) }

--- a/deny.toml
+++ b/deny.toml
@@ -5,13 +5,11 @@ targets = [
     { triple = "aarch64-unknown-linux-gnu" },
     { triple = "x86_64-unknown-linux-musl" },
     { triple = "aarch64-apple-darwin" },
-    { triple = "x86_64-apple-darwin" },
     { triple = "x86_64-pc-windows-msvc" },
     # WASM
     { triple = "wasm32-unknown-unknown" },
     # iOS
     { triple = "aarch64-apple-ios-sim" },
-    { triple = "x86_64-apple-ios" },
     { triple = "aarch64-apple-ios" },
     # Android
     { triple = "aarch64-linux-android" },


### PR DESCRIPTION
# What's new in this PR
drop support for darwin x86 targets

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
