### PR TITLE
Revert "build(deps): bump rstest from 0.24.0 to 0.25.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -3973,9 +3973,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if",
  "glob",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -94,7 +94,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = "0.3"
 js-sys = "0.3"
-rstest = "0.25"
+rstest = "0.24"
 rstest_reuse = "0.7"
 env_logger = "0.11"
 async-std = { workspace = true, features = ["attributes"] }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -102,7 +102,7 @@ rand = { workspace = true, features = ["getrandom"] }
 getrandom = { version = "0.2", features = ["js"] }
 openmls = { workspace = true, features = ["crypto-subtle"] }
 mls-crypto-provider.workspace = true
-rstest = "0.25"
+rstest = "0.24"
 rstest_reuse = "0.7"
 async-std = { workspace = true, features = ["attributes"] }
 futures-lite = "2.6"

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -56,7 +56,7 @@ features = ["x25519", "p256", "p384", "p521"]
 wasm-bindgen-test = "0.3"
 uuid = { workspace = true, features = ["v4", "js"] }
 openmls.workspace = true
-rstest = "0.25"
+rstest = "0.24"
 rstest_reuse = "0.7"
 async-std = { workspace = true, features = ["attributes"] }
 cfg-if.workspace = true


### PR DESCRIPTION
This reverts commit 7da2234db5144c0484000e9e0e7e009046a5e2b4.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
