### PR TITLE
test: fix constant interop http server test port

### DIFF
--- a/interop/src/build/web/webdriver.rs
+++ b/interop/src/build/web/webdriver.rs
@@ -1,4 +1,3 @@
-use crate::TEST_SERVER_URI;
 use crate::util::RunningProcess;
 use color_eyre::eyre::Result;
 
@@ -35,7 +34,11 @@ pub(crate) async fn start_webdriver_chrome(addr: &std::net::SocketAddr) -> Resul
         .spawn()?)
 }
 
-pub(crate) async fn setup_browser(addr: &std::net::SocketAddr, folder: &str) -> Result<fantoccini::Client> {
+pub(crate) async fn setup_browser(
+    client: &std::net::SocketAddr,
+    server: &std::net::SocketAddr,
+    folder: &str,
+) -> Result<fantoccini::Client> {
     let spinner = RunningProcess::new("Starting Fantoccini remote browser...", false);
     let mut caps_json = serde_json::json!({
         "goog:chromeOptions": {
@@ -57,9 +60,9 @@ pub(crate) async fn setup_browser(addr: &std::net::SocketAddr, folder: &str) -> 
 
     let browser = fantoccini::ClientBuilder::native()
         .capabilities(caps)
-        .connect(&format!("http://{addr}"))
+        .connect(&format!("http://{client}"))
         .await?;
-    browser.goto(&format!("{TEST_SERVER_URI}/{folder}/index.html")).await?;
+    browser.goto(&format!("http://{server}/{folder}/index.html")).await?;
 
     spinner.success("Browser [OK]");
     Ok(browser)

--- a/interop/src/clients/corecrypto/web.rs
+++ b/interop/src/clients/corecrypto/web.rs
@@ -17,7 +17,7 @@ pub(crate) struct CoreCryptoWebClient {
 }
 
 impl CoreCryptoWebClient {
-    pub(crate) async fn new(driver_addr: &SocketAddr) -> Result<Self> {
+    pub(crate) async fn new(driver_addr: &SocketAddr, server: &SocketAddr) -> Result<Self> {
         let client_id = uuid::Uuid::new_v4();
         let client_id_str = client_id.as_hyphenated().to_string();
         let ciphersuite = CIPHERSUITE_IN_USE as u16;
@@ -27,7 +27,7 @@ impl CoreCryptoWebClient {
             "ciphersuites": [ciphersuite],
             "clientId": client_id_str
         });
-        let browser = crate::build::web::webdriver::setup_browser(driver_addr, "core-crypto").await?;
+        let browser = crate::build::web::webdriver::setup_browser(driver_addr, server, "core-crypto").await?;
 
         let _ = browser
             .execute_async(

--- a/interop/src/clients/cryptobox/web.rs
+++ b/interop/src/clients/cryptobox/web.rs
@@ -11,9 +11,9 @@ pub(crate) struct CryptoboxWebClient {
 }
 
 impl CryptoboxWebClient {
-    pub(crate) async fn new(driver_addr: &SocketAddr) -> Result<Self> {
+    pub(crate) async fn new(driver_addr: &SocketAddr, server: &SocketAddr) -> Result<Self> {
         let client_id = uuid::Uuid::new_v4();
-        let browser = crate::build::web::webdriver::setup_browser(driver_addr, "cryptobox").await?;
+        let browser = crate::build::web::webdriver::setup_browser(driver_addr, server, "cryptobox").await?;
 
         Ok(Self {
             browser,


### PR DESCRIPTION
Right now, the interop http server port is always 8000. This means that only one server can run on a single machone. Our CI requires one per user. So we add the current user id to 8000 to avoid port collisions in cases where multiple users run the interop test in parallel.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
