### PR TITLE
ci: move to `actions/cache` from `swatinem/rust-cache`

### DIFF
--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -3,12 +3,15 @@ description: Sets up rust, and caches build artifacts. Runs scripts/clean.sh pos
 inputs:
   target:
     description: Rust target
-    required: true
-    default: $CARGO_BUILD_TARGET
+    required: false
   rustflags:
     description: Set the value of RUSTFLAGS (set to empty string to avoid overwriting existing flags)
     required: false
     default: -D warnings
+  components:
+    description: Additional components to install that don't come with the toolchain by default.
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -17,6 +20,7 @@ runs:
       with:
         target: ${{ inputs.target }}
         rustflags: ${{ inputs.rustflags }}
+        components: ${{ inputs.components }}
         cache: false
     - name: Cleanup on post
       uses: gacts/run-and-post-run@v1
@@ -24,7 +28,11 @@ runs:
           post: |
             sh ./scripts/clean.sh
     - name: Cache build artifacts
-      uses: Swatinem/rust-cache@v2
+      uses: actions/cache@v4
       with:
-        cache-on-failure: true
-        cache-bin: false
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
         rust_bench: [ "commit", "encryption", "key_package", "create_group", "mls_proteus", "transaction" ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
       - uses: actions/checkout@v4
       - name: run bencher cli
         uses: ./.github/actions/run-bencher
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -217,7 +217,7 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: stable
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: wasm32-unknown-unknown
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -25,7 +25,7 @@ jobs:
             target: x86_64-linux-android
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: ${{ matrix.target }}
       - name: setup cargo-make
@@ -52,7 +52,7 @@ jobs:
     needs: build-android
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
       - name: set up jdk 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build-jvm-linux.yml
+++ b/.github/workflows/build-jvm-linux.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: "x86_64-unknown-linux-gnu"
       - uses: davidB/rust-cargo-make@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+        uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
       - name: install cargo-llvm-cov

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
       - uses: taiki-e/install-action@cargo-deny

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ env.GIT_TAG || '' }}
-    - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+    - uses: ./.github/actions/setup-and-cache-rust
       with:
         rustflags: '-D warnings -W unreachable-pub'
     - run: cargo doc --all --no-deps
@@ -58,7 +58,7 @@ jobs:
       with:
         ref: ${{ env.GIT_TAG || '' }}
 
-    - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+    - uses: ./.github/actions/setup-and-cache-rust
       with:
         rustflags: ''
         target: |
@@ -102,7 +102,7 @@ jobs:
       with:
         ref: ${{ env.GIT_TAG || '' }}
 
-    - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+    - uses: ./.github/actions/setup-and-cache-rust
       with:
         rustflags: '' # note that this is _not_ the default
 

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -31,7 +31,7 @@ jobs:
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
       - name: setup rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+        uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
           target: "aarch64-apple-darwin"
@@ -59,7 +59,7 @@ jobs:
         with:
           java-version: "17"
           distribution: "adopt"
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
       - name: setup cargo-make

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -30,7 +30,7 @@ jobs:
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
       - name: "setup rust"
-        uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+        uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
           target: "aarch64-apple-ios,aarch64-apple-ios-sim"

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -26,7 +26,7 @@ jobs:
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
       - name: ensure the tag is signed
         run: git cat-file tag ${{ github.ref_name }} | grep -q -- '-----BEGIN PGP SIGNATURE-----'
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: wasm32-unknown-unknown
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           components: rustfmt, clippy
           rustflags: ''
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
       - uses: taiki-e/install-action@nextest
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
       - uses: taiki-e/install-action@nextest
@@ -99,7 +99,7 @@ jobs:
             module: -- proteus
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: wasm32-unknown-unknown
           rustflags: ''
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1  # this implicitly caches Rust tools and build artifacts
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
       - uses: taiki-e/install-action@cargo-hack


### PR DESCRIPTION
`swatinem/rust-cache` gave us trouble on our runner machine, so we want to use `actions/cache` instead, which is more widely used. To avoid copy and pasting the usage with parameters everywhere, we're it using our own composite action that sets up rust.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
