### PR TITLE
ci: add cache key prefixes

### DIFF
--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -35,4 +35,4 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ inputs.target }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
This solves the problem that builds were cached for only one target on the same runner operating system.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
