### PR TITLE
ci: fix cache key prefixes for interop test

### DIFF
--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Additional components to install that don't come with the toolchain by default.
     required: false
     default: ''
+  cache-key-prefix:
+    description: A custom cache key prefix to be used instead of the rust target. Must be used if there are
+      multiple rust targets because keys cannot contain commas.
+    required: false
 runs:
   using: composite
   steps:
@@ -35,4 +39,4 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ inputs.target }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ inputs.cache-key-prefix || format('{0}', inputs.target) }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           target: "wasm32-unknown-unknown,aarch64-apple-ios,aarch64-apple-ios-sim"
           rustflags: ''
+          cache-key-prefix: e2e-interop-test 
       - uses: davidB/rust-cargo-make@v1
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
The rust target based cache keys don't work in cases where we have multiple targets because cache keys can't contain commas. This adds a custom cache key parameter to our action for the only such case we currently have.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
