### PR TITLE
fix: don't refer to the internal uniffi EpochObserver type in the public API [WPB-16684]

### DIFF
--- a/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/MLSTest.kt
@@ -312,7 +312,7 @@ class MLSTest {
         return scope.runTest {
             // set up the observer. this just keeps a list of all observations.
             data class EpochChanged(val conversationId: kotlin.ByteArray, val epoch: kotlin.ULong)
-            class Observer: com.wire.crypto.uniffi.EpochObserver {
+            class Observer: EpochObserver {
                 val observed_events = emptyList<EpochChanged>().toMutableList();
                 override suspend fun epochChanged(conversationId: kotlin.ByteArray, epoch: kotlin.ULong) {
                     observed_events.add(EpochChanged(conversationId, epoch))


### PR DESCRIPTION
# What's new in this PR

Don't refer to the internal uniffi EpochObserver type in the public API

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
