### PR TITLE
fix: re-expose proteus_reload_session which removed by mistake [WPB-16700]

### DIFF
--- a/crypto-ffi/src/generic/context/proteus.rs
+++ b/crypto-ffi/src/generic/context/proteus.rs
@@ -119,4 +119,9 @@ impl CoreCryptoContext {
     pub async fn proteus_cryptobox_migrate(&self, path: String) -> CoreCryptoResult<()> {
         proteus_impl!({ Ok(self.context.proteus_cryptobox_migrate(&path).await?) })
     }
+
+    /// See [core_crypto::context::CentralContext::proteus_reload_sessions]
+    pub async fn proteus_reload_sessions(&self) -> CoreCryptoResult<()> {
+        proteus_impl!({ Ok(self.context.proteus_reload_sessions().await?) })
+    }
 }


### PR DESCRIPTION
# What's new in this PR

Re-expose proteus_reload_session which removed by mistake

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
