### PR TITLE
fix: create an inteface for `ConversationConfiguration`

### DIFF
--- a/crypto-ffi/bindings/js/src/.gitignore
+++ b/crypto-ffi/bindings/js/src/.gitignore
@@ -1,0 +1,9 @@
+# the actual wasm files
+*.wasm
+*.wasm.d.ts
+# emitted low-level bindings to the wasm files
+*ffi.js
+*ffi.d.ts
+# compiled high-level bindings
+corecrypto.js
+corecrypto.d.ts

--- a/crypto-ffi/bindings/js/src/Ciphersuite.ts
+++ b/crypto-ffi/bindings/js/src/Ciphersuite.ts
@@ -1,0 +1,34 @@
+
+/**
+ * see [core_crypto::prelude::CiphersuiteName]
+ */
+export enum Ciphersuite {
+    /**
+     * DH KEM x25519 | AES-GCM 128 | SHA2-256 | Ed25519
+     */
+    MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 0x0001,
+    /**
+     * DH KEM P256 | AES-GCM 128 | SHA2-256 | EcDSA P256
+     */
+    MLS_128_DHKEMP256_AES128GCM_SHA256_P256 = 0x0002,
+    /**
+     * DH KEM x25519 | Chacha20Poly1305 | SHA2-256 | Ed25519
+     */
+    MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003,
+    /**
+     * DH KEM x448 | AES-GCM 256 | SHA2-512 | Ed448
+     */
+    MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448 = 0x0004,
+    /**
+     * DH KEM P521 | AES-GCM 256 | SHA2-512 | EcDSA P521
+     */
+    MLS_256_DHKEMP521_AES256GCM_SHA512_P521 = 0x0005,
+    /**
+     * DH KEM x448 | Chacha20Poly1305 | SHA2-512 | Ed448
+     */
+    MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006,
+    /**
+     * DH KEM P384 | AES-GCM 256 | SHA2-384 | EcDSA P384
+     */
+    MLS_256_DHKEMP384_AES256GCM_SHA384_P384 = 0x0007,
+}

--- a/crypto-ffi/bindings/js/src/Ciphersuite.ts
+++ b/crypto-ffi/bindings/js/src/Ciphersuite.ts
@@ -1,4 +1,3 @@
-
 /**
  * see [core_crypto::prelude::CiphersuiteName]
  */

--- a/crypto-ffi/bindings/js/src/ConversationConfiguration.ts
+++ b/crypto-ffi/bindings/js/src/ConversationConfiguration.ts
@@ -1,5 +1,9 @@
 import { Ciphersuite } from "./Ciphersuite.js";
-import { WirePolicy, ConversationConfiguration as ConversationConfigurationFfi, Ciphersuite as CiphersuiteFfi } from "./core-crypto-ffi.js";
+import {
+    Ciphersuite as CiphersuiteFfi,
+    ConversationConfiguration as ConversationConfigurationFfi,
+    WirePolicy,
+} from "./core-crypto-ffi.js";
 
 export interface ConversationConfiguration {
     /**
@@ -22,7 +26,16 @@ export interface ConversationConfiguration {
     wirePolicy?: WirePolicy;
 }
 
-export function conversationConfigurationToFfi(cc: ConversationConfiguration): ConversationConfigurationFfi {
-    const ciphersuite = cc.ciphersuite ? new CiphersuiteFfi(cc.ciphersuite) : null;
-    return new ConversationConfigurationFfi(ciphersuite, cc.externalSenders, cc.keyRotationSpan, cc.wirePolicy);
+export function conversationConfigurationToFfi(
+    cc: ConversationConfiguration
+): ConversationConfigurationFfi {
+    const ciphersuite = cc.ciphersuite
+        ? new CiphersuiteFfi(cc.ciphersuite)
+        : null;
+    return new ConversationConfigurationFfi(
+        ciphersuite,
+        cc.externalSenders,
+        cc.keyRotationSpan,
+        cc.wirePolicy
+    );
 }

--- a/crypto-ffi/bindings/js/src/ConversationConfiguration.ts
+++ b/crypto-ffi/bindings/js/src/ConversationConfiguration.ts
@@ -1,0 +1,28 @@
+import { Ciphersuite } from "./Ciphersuite.js";
+import { WirePolicy, ConversationConfiguration as ConversationConfigurationFfi, Ciphersuite as CiphersuiteFfi } from "./core-crypto-ffi.js";
+
+export interface ConversationConfiguration {
+    /**
+     * The ciphersuite which should be used to encrypt this conversation.
+     */
+    ciphersuite?: Ciphersuite;
+    /**
+     * List of client IDs that are allowed to be external senders
+     */
+    externalSenders?: Uint8Array[];
+    /**
+     *  Duration in seconds after which we will automatically force a self-update commit
+     *  Note: This isn't currently implemented
+     */
+    keyRotationSpan?: number;
+    /**
+     * Defines if handshake messages are encrypted or not
+     * Note: encrypted handshake messages are not supported by wire-server
+     */
+    wirePolicy?: WirePolicy;
+}
+
+export function conversationConfigurationToFfi(cc: ConversationConfiguration): ConversationConfigurationFfi {
+    const ciphersuite = cc.ciphersuite ? new CiphersuiteFfi(cc.ciphersuite) : null;
+    return new ConversationConfigurationFfi(ciphersuite, cc.externalSenders, cc.keyRotationSpan, cc.wirePolicy);
+}

--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+export { Ciphersuite } from "./Ciphersuite.js";
+export type { ConversationConfiguration } from "./ConversationConfiguration.js";
 export type { CoreCryptoRichError } from "./CoreCryptoError.js";
 export { CoreCryptoError } from "./CoreCryptoError.js";
 
@@ -38,7 +40,6 @@ export type {
 } from "./CoreCryptoInstance.js";
 
 export {
-    Ciphersuite,
     CredentialType,
     WirePolicy,
     GroupInfoEncryptionType,
@@ -71,7 +72,6 @@ export type { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 
 export {
     AcmeChallenge,
-    ConversationConfiguration,
     CustomConfiguration,
     DatabaseKey,
     E2eiDumpedPkiEnv,

--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -71,7 +71,6 @@ export type { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 
 export {
     AcmeChallenge,
-    Ciphersuite as CiphersuiteFfi,
     ConversationConfiguration,
     CustomConfiguration,
     DatabaseKey,

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -32,7 +32,10 @@ import {
 import { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 import { safeBigintToNumber } from "./Conversions.js";
 import { Ciphersuite } from "./Ciphersuite.js";
-import { ConversationConfiguration, conversationConfigurationToFfi } from "./ConversationConfiguration.js";
+import {
+    ConversationConfiguration,
+    conversationConfigurationToFfi,
+} from "./ConversationConfiguration.js";
 
 export class CoreCryptoContext {
     /** @hidden */

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -3,7 +3,6 @@ import {
     Ciphersuite as CiphersuiteFfi,
     Ciphersuites as CiphersuitesFfi,
     ClientId as ClientIdFfi,
-    ConversationConfiguration,
     CoreCryptoContext as CoreCryptoContextFfi,
     CustomConfiguration,
     E2eiDumpedPkiEnv,
@@ -13,7 +12,6 @@ import * as CoreCryptoFfiTypes from "./core-crypto-ffi.d.js";
 
 import { CoreCryptoError } from "./CoreCryptoError.js";
 import {
-    Ciphersuite,
     ClientId,
     ConversationId,
     CredentialType,
@@ -33,6 +31,8 @@ import {
 
 import { ProteusAutoPrekeyBundle } from "./CoreCryptoProteus.js";
 import { safeBigintToNumber } from "./Conversions.js";
+import { Ciphersuite } from "./Ciphersuite.js";
+import { ConversationConfiguration, conversationConfigurationToFfi } from "./ConversationConfiguration.js";
 
 export class CoreCryptoContext {
     /** @hidden */
@@ -227,15 +227,9 @@ export class CoreCryptoContext {
     async createConversation(
         conversationId: ConversationId,
         creatorCredentialType: CredentialType,
-        configuration: Partial<ConversationConfiguration> = {}
+        configuration: ConversationConfiguration = {}
     ) {
-        const { ciphersuite, externalSenders, custom } = configuration;
-        const config = new ConversationConfiguration(
-            ciphersuite,
-            externalSenders,
-            custom?.keyRotationSpan,
-            custom?.wirePolicy
-        );
+        const config = conversationConfigurationToFfi(configuration);
         return await CoreCryptoError.asyncMapErr(
             this.#ctx.create_conversation(
                 conversationId,

--- a/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoInstance.ts
@@ -37,7 +37,6 @@ import {
 
 import { CoreCryptoError } from "./CoreCryptoError.js";
 import {
-    Ciphersuite,
     ClientId,
     ConversationId,
     CredentialType,
@@ -49,6 +48,7 @@ import { CoreCryptoContext } from "./CoreCryptoContext.js";
 
 import { E2eiConversationState, normalizeEnum } from "./CoreCryptoE2EI.js";
 import { safeBigintToNumber } from "./Conversions.js";
+import { Ciphersuite } from "./Ciphersuite.js";
 
 /**
  * Params for CoreCrypto deferred initialization

--- a/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
@@ -26,40 +26,6 @@ export {
 };
 
 /**
- * see [core_crypto::prelude::CiphersuiteName]
- */
-export enum Ciphersuite {
-    /**
-     * DH KEM x25519 | AES-GCM 128 | SHA2-256 | Ed25519
-     */
-    MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 0x0001,
-    /**
-     * DH KEM P256 | AES-GCM 128 | SHA2-256 | EcDSA P256
-     */
-    MLS_128_DHKEMP256_AES128GCM_SHA256_P256 = 0x0002,
-    /**
-     * DH KEM x25519 | Chacha20Poly1305 | SHA2-256 | Ed25519
-     */
-    MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003,
-    /**
-     * DH KEM x448 | AES-GCM 256 | SHA2-512 | Ed448
-     */
-    MLS_256_DHKEMX448_AES256GCM_SHA512_Ed448 = 0x0004,
-    /**
-     * DH KEM P521 | AES-GCM 256 | SHA2-512 | EcDSA P521
-     */
-    MLS_256_DHKEMP521_AES256GCM_SHA512_P521 = 0x0005,
-    /**
-     * DH KEM x448 | Chacha20Poly1305 | SHA2-512 | Ed448
-     */
-    MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006,
-    /**
-     * DH KEM P384 | AES-GCM 256 | SHA2-384 | EcDSA P384
-     */
-    MLS_256_DHKEMP384_AES256GCM_SHA384_P384 = 0x0007,
-}
-
-/**
  * Alias for conversation IDs.
  * This is a freeform, uninspected buffer.
  */
@@ -288,11 +254,11 @@ export type MlsTransportResponse =
     | "success"
     | "retry"
     | {
-          /**
-           * The message was rejected by the delivery service and there's no recovery.
-           */
-          abort: { reason: string };
-      };
+        /**
+         * The message was rejected by the delivery service and there's no recovery.
+         */
+        abort: { reason: string };
+    };
 
 function mapTransportResponseToFfi(
     response: MlsTransportResponse

--- a/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoMLS.ts
@@ -254,11 +254,11 @@ export type MlsTransportResponse =
     | "success"
     | "retry"
     | {
-        /**
-         * The message was rejected by the delivery service and there's no recovery.
-         */
-        abort: { reason: string };
-    };
+          /**
+           * The message was rejected by the delivery service and there's no recovery.
+           */
+          abort: { reason: string };
+      };
 
 function mapTransportResponseToFfi(
     response: MlsTransportResponse


### PR DESCRIPTION
# What's new in this PR

Previously clients needed to sometimes use a low-level
`ConversationConfiguration` instance, which required i.e. a `number`
for the ciphersuite instead of an enum variant, with obvious
usability problems resulting.

This creates a high-level `ConversationConfiguration` interface
that they can use instead.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
