### PR TITLE
chore: update to latest state wire/stable of our fork of OpenMLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,7 +3154,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "1.0.0"
-source = "git+https://github.com/wireapp/openmls?rev=54ee2f6a8a149a2a864a57fa83a616c03263ca61#54ee2f6a8a149a2a864a57fa83a616c03263ca61"
+source = "git+https://github.com/wireapp/openmls?rev=fd243f4467d5be9bcd2434a3188134645ae3a642#fd243f4467d5be9bcd2434a3188134645ae3a642"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -3176,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.2.0"
-source = "git+https://github.com/wireapp/openmls?rev=54ee2f6a8a149a2a864a57fa83a616c03263ca61#54ee2f6a8a149a2a864a57fa83a616c03263ca61"
+source = "git+https://github.com/wireapp/openmls?rev=fd243f4467d5be9bcd2434a3188134645ae3a642#fd243f4467d5be9bcd2434a3188134645ae3a642"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -3194,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.2.0"
-source = "git+https://github.com/wireapp/openmls?rev=54ee2f6a8a149a2a864a57fa83a616c03263ca61#54ee2f6a8a149a2a864a57fa83a616c03263ca61"
+source = "git+https://github.com/wireapp/openmls?rev=fd243f4467d5be9bcd2434a3188134645ae3a642#fd243f4467d5be9bcd2434a3188134645ae3a642"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -3211,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "openmls_x509_credential"
 version = "0.2.0"
-source = "git+https://github.com/wireapp/openmls?rev=54ee2f6a8a149a2a864a57fa83a616c03263ca61#54ee2f6a8a149a2a864a57fa83a616c03263ca61"
+source = "git+https://github.com/wireapp/openmls?rev=fd243f4467d5be9bcd2434a3188134645ae3a642#fd243f4467d5be9bcd2434a3188134645ae3a642"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,10 @@ x509-cert = "0.2"
 zeroize = "1.8"
 
 # our OpenMLS fork
-openmls = { git = "https://github.com/wireapp/openmls", rev = "54ee2f6a8a149a2a864a57fa83a616c03263ca61", version = "1" }
-openmls_traits = { git = "https://github.com/wireapp/openmls", rev = "54ee2f6a8a149a2a864a57fa83a616c03263ca61", version = "0.2" }
-openmls_basic_credential = { git = "https://github.com/wireapp/openmls", rev = "54ee2f6a8a149a2a864a57fa83a616c03263ca61", version = "0.2" }
-openmls_x509_credential = { git = "https://github.com/wireapp/openmls", rev = "54ee2f6a8a149a2a864a57fa83a616c03263ca61", version = "0.2" }
+openmls = { git = "https://github.com/wireapp/openmls", rev = "fd243f4467d5be9bcd2434a3188134645ae3a642", version = "1" }
+openmls_traits = { git = "https://github.com/wireapp/openmls", rev = "fd243f4467d5be9bcd2434a3188134645ae3a642", version = "0.2" }
+openmls_basic_credential = { git = "https://github.com/wireapp/openmls", rev = "fd243f4467d5be9bcd2434a3188134645ae3a642", version = "0.2" }
+openmls_x509_credential = { git = "https://github.com/wireapp/openmls", rev = "fd243f4467d5be9bcd2434a3188134645ae3a642", version = "0.2" }
 
 # proteus
 proteus-traits = { git = "https://github.com/wireapp/proteus", tag = "v2.1.1" }


### PR DESCRIPTION
This version includes fixes for tests that were failing due to futures being too big to fit on stack.