### PR TITLE
refactor: rename `TestCase` to `TestContext` [WPB-15769]

### DIFF
--- a/crypto/src/e2e_identity/enrollment/test_utils.rs
+++ b/crypto/src/e2e_identity/enrollment/test_utils.rs
@@ -4,7 +4,7 @@ use crate::{
     KeystoreError, RecursiveError,
     e2e_identity::{E2eiEnrollment, Error, Result, id::QualifiedE2eiClientId},
     prelude::{CertificateBundle, MlsCredentialType},
-    test_utils::{SessionContext, TestCase, context::TEAM, x509::X509TestChain},
+    test_utils::{SessionContext, TestContext, context::TEAM, x509::X509TestChain},
     transaction_context::TransactionContext,
 };
 use itertools::Itertools as _;
@@ -133,12 +133,12 @@ pub(crate) type InitFnReturn<'a> = std::pin::Pin<Box<dyn std::future::Future<Out
 /// Helps the compiler with its lifetime inference rules while passing async closures
 pub(crate) struct E2eiInitWrapper<'a> {
     pub(crate) context: &'a TransactionContext,
-    pub(crate) case: &'a TestCase,
+    pub(crate) case: &'a TestContext,
 }
 
 pub(crate) async fn e2ei_enrollment<'a>(
     ctx: &'a mut SessionContext,
-    case: &TestCase,
+    case: &TestContext,
     x509_test_chain: &X509TestChain,
     client_id: Option<&str>,
     #[cfg(not(target_family = "wasm"))] is_renewal: bool,

--- a/crypto/src/mls/conversation/commit.rs
+++ b/crypto/src/mls/conversation/commit.rs
@@ -132,7 +132,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn retry_should_work(case: TestCase) {
+        async fn retry_should_work(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -242,7 +242,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_add_members_to_conversation(case: TestCase) {
+        async fn can_add_members_to_conversation(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -316,7 +316,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_welcome(case: TestCase) {
+        async fn should_return_valid_welcome(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -356,7 +356,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_group_info(case: TestCase) {
+        async fn should_return_valid_group_info(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "guest"],
@@ -399,7 +399,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn alice_can_remove_bob_from_conversation(case: TestCase) {
+        async fn alice_can_remove_bob_from_conversation(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -448,7 +448,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_welcome(case: TestCase) {
+        async fn should_return_valid_welcome(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "guest"],
@@ -504,7 +504,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_group_info(case: TestCase) {
+        async fn should_return_valid_group_info(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "guest"],
@@ -552,7 +552,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_succeed(case: TestCase) {
+        async fn should_succeed(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -640,7 +640,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_create_welcome_for_pending_add_proposals(case: TestCase) {
+        async fn should_create_welcome_for_pending_add_proposals(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -764,7 +764,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_welcome(case: TestCase) {
+        async fn should_return_valid_welcome(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "guest"],
@@ -832,7 +832,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_group_info(case: TestCase) {
+        async fn should_return_valid_group_info(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "guest"],
@@ -875,7 +875,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_create_a_commit_out_of_self_pending_proposals(case: TestCase) {
+        async fn should_create_a_commit_out_of_self_pending_proposals(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob"],
@@ -919,7 +919,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_create_a_commit_out_of_pending_proposals_by_ref(case: TestCase) {
+        async fn should_create_a_commit_out_of_pending_proposals_by_ref(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -977,7 +977,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_welcome(case: TestCase) {
+        async fn should_return_valid_welcome(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1015,7 +1015,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_return_valid_group_info(case: TestCase) {
+        async fn should_return_valid_group_info(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "guest"],
@@ -1061,7 +1061,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_prevent_out_of_order_commits(case: TestCase) {
+        async fn should_prevent_out_of_order_commits(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1130,7 +1130,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_prevent_replayed_encrypted_handshake_messages(case: TestCase) {
+        async fn should_prevent_replayed_encrypted_handshake_messages(case: TestContext) {
             if !case.is_pure_ciphertext() {
                 return;
             }

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -165,7 +165,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn calculate_delay_creator_removed(case: TestCase) {
+    async fn calculate_delay_creator_removed(case: TestContext) {
         run_test_with_client_ids(
             case.clone(),
             ["alice", "bob", "charlie"],

--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -204,7 +204,7 @@ mod tests {
     #[cfg_attr(not(target_family = "wasm"), async_std::test)]
     #[wasm_bindgen_test]
     pub async fn group_should_have_required_capabilities() {
-        let case = TestCase::default();
+        let case = TestContext::default();
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -231,7 +231,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn creator_leaf_node_should_have_default_capabilities(case: TestCase) {
+    pub async fn creator_leaf_node_should_have_default_capabilities(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -276,7 +276,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_support_raw_external_sender(case: TestCase) {
+    pub async fn should_support_raw_external_sender(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let (_sk, pk) = cc
@@ -301,7 +301,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_support_jwk_external_sender(case: TestCase) {
+    pub async fn should_support_jwk_external_sender(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let sc = case.signature_scheme();

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/buffer_messages.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/buffer_messages.rs
@@ -145,7 +145,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_buffer_and_reapply_messages_after_commit_merged_for_sender(case: TestCase) {
+    async fn should_buffer_and_reapply_messages_after_commit_merged_for_sender(case: TestContext) {
         if case.is_pure_ciphertext() {
             // The use case tested here requires inspecting your own commit.
             // Openmls does not support this currently when protocol messages are encrypted.
@@ -307,7 +307,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_buffer_and_reapply_messages_after_commit_merged_for_receivers(case: TestCase) {
+    async fn should_buffer_and_reapply_messages_after_commit_merged_for_receivers(case: TestContext) {
         if case.is_pure_ciphertext() {
             // The use case tested here requires inspecting your own commit.
             // Openmls does not support this currently when protocol messages are encrypted.
@@ -474,7 +474,7 @@ mod tests {
     ///
     /// [WPB-15810]: https://wearezeta.atlassian.net/browse/WPB-15810
     #[apply(all_cred_cipher)]
-    async fn wpb_15810(case: TestCase) {
+    async fn wpb_15810(case: TestContext) {
         use openmls::{
             group::GroupId,
             prelude::{ExternalProposal, SenderExtensionIndex},

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -559,7 +559,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn decrypting_a_regular_commit_should_leave_conversation_active(case: TestCase) {
+        pub async fn decrypting_a_regular_commit_should_leave_conversation_active(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -595,7 +595,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_removing_self_should_set_conversation_inactive(case: TestCase) {
+        pub async fn decrypting_a_commit_removing_self_should_set_conversation_inactive(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -635,7 +635,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_should_succeed(case: TestCase) {
+        pub async fn decrypting_a_commit_should_succeed(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -688,7 +688,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_should_not_renew_proposals_in_valid_commit(case: TestCase) {
+        pub async fn decrypting_a_commit_should_not_renew_proposals_in_valid_commit(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -758,7 +758,7 @@ mod tests {
         // orphan proposal = not backed by the pending commit
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_should_renew_orphan_pending_proposals(case: TestCase) {
+        pub async fn decrypting_a_commit_should_renew_orphan_pending_proposals(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -885,7 +885,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn decrypting_a_commit_should_discard_pending_external_proposals(case: TestCase) {
+        pub async fn decrypting_a_commit_should_discard_pending_external_proposals(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -952,7 +952,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_not_return_sender_client_id(case: TestCase) {
+        async fn should_not_return_sender_client_id(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -994,7 +994,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_decrypt_external_proposal(case: TestCase) {
+        async fn can_decrypt_external_proposal(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "alice2"],
@@ -1058,7 +1058,7 @@ mod tests {
         // Ensures decrypting an proposal is durable
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_decrypt_proposal(case: TestCase) {
+        async fn can_decrypt_proposal(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -1110,7 +1110,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_not_return_sender_client_id(case: TestCase) {
+        async fn should_not_return_sender_client_id(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1144,7 +1144,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_decrypt_app_message(case: TestCase) {
+        async fn can_decrypt_app_message(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1222,7 +1222,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn cannot_decrypt_app_message_after_rejoining(case: TestCase) {
+        async fn cannot_decrypt_app_message_after_rejoining(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1269,7 +1269,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn cannot_decrypt_app_message_from_future_epoch(case: TestCase) {
+        async fn cannot_decrypt_app_message_from_future_epoch(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1330,7 +1330,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_decrypt_app_message_in_any_order(mut case: TestCase) {
+        async fn can_decrypt_app_message_in_any_order(mut case: TestContext) {
             // otherwise the test would fail because we decrypt messages in reverse order which is
             // kinda dropping them
             case.cfg.custom.maximum_forward_distance = 0;
@@ -1386,7 +1386,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn returns_sender_client_id(case: TestCase) {
+        async fn returns_sender_client_id(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1430,7 +1430,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_throw_specialized_error_when_epoch_too_old(mut case: TestCase) {
+        async fn should_throw_specialized_error_when_epoch_too_old(mut case: TestContext) {
             case.cfg.custom.out_of_order_tolerance = 0;
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
@@ -1525,7 +1525,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_throw_specialized_error_when_epoch_desynchronized(mut case: TestCase) {
+        async fn should_throw_specialized_error_when_epoch_desynchronized(mut case: TestContext) {
             case.cfg.custom.out_of_order_tolerance = 0;
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {

--- a/crypto/src/mls/conversation/conversation_guard/encrypt.rs
+++ b/crypto/src/mls/conversation/conversation_guard/encrypt.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_encrypt_app_message(case: TestCase) {
+    async fn can_encrypt_app_message(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -91,7 +91,7 @@ mod tests {
     // Ensures encrypting an application message is durable
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_encrypt_consecutive_messages(case: TestCase) {
+    async fn can_encrypt_consecutive_messages(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();

--- a/crypto/src/mls/conversation/conversation_guard/merge.rs
+++ b/crypto/src/mls/conversation/conversation_guard/merge.rs
@@ -92,7 +92,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_remove_proposal(case: TestCase) {
+        pub async fn should_remove_proposal(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -188,7 +188,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_fail_when_proposal_ref_not_found(case: TestCase) {
+        pub async fn should_fail_when_proposal_ref_not_found(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -216,7 +216,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_clean_associated_key_material(case: TestCase) {
+        pub async fn should_clean_associated_key_material(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut cc]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -256,7 +256,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_remove_commit(case: TestCase) {
+        pub async fn should_remove_commit(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -285,7 +285,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_fail_when_pending_commit_absent(case: TestCase) {
+        pub async fn should_fail_when_pending_commit_absent(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -310,7 +310,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_clean_associated_key_material(case: TestCase) {
+        pub async fn should_clean_associated_key_material(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
                 Box::pin(async move {
                     let id = conversation_id();

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -54,7 +54,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn decrypting_duplicate_member_commit_should_fail(case: TestCase) {
+    async fn decrypting_duplicate_member_commit_should_fail(case: TestContext) {
         // cannot work in pure ciphertext since we'd have to decrypt the message first
         if !case.is_pure_ciphertext() {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
@@ -125,7 +125,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn decrypting_duplicate_external_commit_should_fail(case: TestCase) {
+    async fn decrypting_duplicate_external_commit_should_fail(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -187,7 +187,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn decrypting_duplicate_proposal_should_fail(case: TestCase) {
+    async fn decrypting_duplicate_proposal_should_fail(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -246,7 +246,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn decrypting_duplicate_external_proposal_should_fail(case: TestCase) {
+    async fn decrypting_duplicate_external_proposal_should_fail(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -311,7 +311,7 @@ mod tests {
     // Ensures decrypting an application message is durable (we increment the messages generation & persist the group)
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn decrypting_duplicate_application_message_should_fail(case: TestCase) {
+    async fn decrypting_duplicate_application_message_should_fail(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();

--- a/crypto/src/mls/conversation/leaf_node_validation.rs
+++ b/crypto/src/mls/conversation/leaf_node_validation.rs
@@ -19,7 +19,7 @@ mod tests {
         /// When a LeafNode is downloaded in a KeyPackage, before it is used to add the client to the group
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_validate_leaf_node_when_adding(case: TestCase) {
+        async fn should_validate_leaf_node_when_adding(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob"],
@@ -98,7 +98,7 @@ mod tests {
         /// When a LeafNode is received by a group member in an Add, Update, or Commit message
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_validate_leaf_node_when_receiving_expired_add_proposal(case: TestCase) {
+        async fn should_validate_leaf_node_when_receiving_expired_add_proposal(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -157,7 +157,7 @@ mod tests {
         /// When a LeafNode is received by a group member in an Add, Update, or Commit message
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_validate_leaf_node_when_receiving_add_commit(case: TestCase) {
+        async fn should_validate_leaf_node_when_receiving_add_commit(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -223,7 +223,7 @@ mod tests {
         /// When a client validates a ratchet tree, e.g., when joining a group or after processing a Commit
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_validate_leaf_node_when_receiving_welcome(case: TestCase) {
+        async fn should_validate_leaf_node_when_receiving_welcome(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let expiration_time = 14;

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -60,7 +60,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_apply_pending_commit(case: TestCase) {
+        async fn should_apply_pending_commit(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -87,7 +87,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_clear_pending_commit_and_proposals(case: TestCase) {
+        async fn should_clear_pending_commit_and_proposals(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -118,7 +118,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_clean_associated_key_material(case: TestCase) {
+        async fn should_clean_associated_key_material(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -510,7 +510,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn create_self_conversation_should_succeed(case: TestCase) {
+    pub async fn create_self_conversation_should_succeed(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -545,7 +545,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn create_1_1_conversation_should_succeed(case: TestCase) {
+    pub async fn create_1_1_conversation_should_succeed(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -597,7 +597,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn create_many_people_conversation(case: TestCase) {
+    pub async fn create_many_people_conversation(case: TestContext) {
         use crate::e2e_identity::enrollment::test_utils::failsafe_ctx;
 
         run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
@@ -803,7 +803,7 @@ mod tests {
         #[async_std::test]
         #[wasm_bindgen_test]
         async fn should_read_device_identities() {
-            let case = TestCase::default_x509();
+            let case = TestContext::default_x509();
             run_test_with_client_ids(
                 case.clone(),
                 ["alice_android", "alice_ios"],
@@ -893,7 +893,7 @@ mod tests {
         #[async_std::test]
         #[wasm_bindgen_test]
         async fn should_read_revoked_device_cross_signed() {
-            let case = TestCase::default_x509();
+            let case = TestContext::default_x509();
             run_test_with_client_ids_and_revocation(
                 case.clone(),
                 ["alice", "bob", "rupert"],
@@ -945,7 +945,7 @@ mod tests {
         #[async_std::test]
         #[wasm_bindgen_test]
         async fn should_read_revoked_device() {
-            let case = TestCase::default_x509();
+            let case = TestContext::default_x509();
             run_test_with_client_ids_and_revocation(
                 case.clone(),
                 ["alice", "bob", "rupert"],
@@ -989,7 +989,7 @@ mod tests {
         #[async_std::test]
         #[wasm_bindgen_test]
         async fn should_not_fail_when_basic() {
-            let case = TestCase::default();
+            let case = TestContext::default();
             run_test_with_client_ids(
                 case.clone(),
                 ["alice_android", "alice_ios"],
@@ -1052,7 +1052,7 @@ mod tests {
         #[async_std::test]
         #[wasm_bindgen_test]
         async fn should_read_users_cross_signed() {
-            let case = TestCase::default_x509();
+            let case = TestContext::default_x509();
 
             let (alice_android, alice_ios) = (
                 "satICT30SbiIpjj1n-XQtA:7684f3f95a5e6848@world.com",
@@ -1164,7 +1164,7 @@ mod tests {
         #[async_std::test]
         #[wasm_bindgen_test]
         async fn should_read_users() {
-            let case = TestCase::default_x509();
+            let case = TestContext::default_x509();
 
             let (alice_android, alice_ios) = (
                 "satICT30SbiIpjj1n-XQtA:7684f3f95a5e6848@world.com",
@@ -1262,7 +1262,7 @@ mod tests {
             let bob_android = "I_7X5oRAToKy9z_kvhDKKQ:8b1fd601510d102a@wire.com";
             let bobt_android = "HSLU78bpQCOYwh4FWCac5g:68db8bac6a65d@zeta.com";
 
-            let case = TestCase::default_x509();
+            let case = TestContext::default_x509();
 
             run_cross_signed_tests_with_client_ids(
                 case.clone(),
@@ -1347,7 +1347,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn can_export_secret_key(case: TestCase) {
+        pub async fn can_export_secret_key(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1374,7 +1374,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn cannot_export_secret_key_invalid_length(case: TestCase) {
+        pub async fn cannot_export_secret_key_invalid_length(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1407,7 +1407,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn can_get_client_ids(case: TestCase) {
+        pub async fn can_get_client_ids(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -1452,7 +1452,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_fetch_ext_sender(case: TestCase) {
+        pub async fn should_fetch_ext_sender(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();

--- a/crypto/src/mls/conversation/orphan_welcome.rs
+++ b/crypto/src/mls/conversation/orphan_welcome.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn orphan_welcome_should_generate_external_commit(case: TestCase) {
+    pub async fn orphan_welcome_should_generate_external_commit(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -141,7 +141,7 @@ mod tests {
     // If there’s a pending commit & it matches the incoming commit: mark pending commit as accepted
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_succeed_when_incoming_commit_same_as_pending(case: TestCase) {
+    pub async fn should_succeed_when_incoming_commit_same_as_pending(case: TestContext) {
         if !case.is_pure_ciphertext() && case.is_x509() {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
@@ -214,7 +214,7 @@ mod tests {
     // If there’s a pending commit & it does not match the self incoming commit: fail with dedicated error
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_succeed_when_incoming_commit_mismatches_pending_commit(case: TestCase) {
+    pub async fn should_succeed_when_incoming_commit_mismatches_pending_commit(case: TestContext) {
         if !case.is_pure_ciphertext() {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
@@ -261,7 +261,7 @@ mod tests {
     // if there’s no pending commit & and the incoming commit originates from self: succeed by ignoring the incoming commit
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_ignore_self_incoming_commit_when_no_pending_commit(case: TestCase) {
+    pub async fn should_ignore_self_incoming_commit_when_no_pending_commit(case: TestContext) {
         if !case.is_pure_ciphertext() {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
@@ -306,7 +306,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn should_fail_when_tampering_with_incoming_own_commit_same_as_pending(case: TestCase) {
+    pub async fn should_fail_when_tampering_with_incoming_own_commit_same_as_pending(case: TestContext) {
         use crate::MlsErrorKind;
 
         if case.is_pure_ciphertext() {

--- a/crypto/src/mls/conversation/pending_conversation.rs
+++ b/crypto/src/mls/conversation/pending_conversation.rs
@@ -321,7 +321,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_buffer_and_reapply_messages_after_external_commit_merged(case: TestCase) {
+    async fn should_buffer_and_reapply_messages_after_external_commit_merged(case: TestContext) {
         run_test_with_client_ids(
             case.clone(),
             ["alice", "bob", "charlie", "debbie"],
@@ -471,7 +471,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_not_reapply_buffered_messages_when_external_commit_contains_remove(case: TestCase) {
+    async fn should_not_reapply_buffered_messages_when_external_commit_contains_remove(case: TestContext) {
         use crate::mls;
 
         run_test_with_client_ids(

--- a/crypto/src/mls/conversation/proposal.rs
+++ b/crypto/src/mls/conversation/proposal.rs
@@ -173,7 +173,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_propose_adding_members_to_conversation(case: TestCase) {
+        async fn can_propose_adding_members_to_conversation(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -250,7 +250,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_propose_removing_members_from_conversation(case: TestCase) {
+        async fn can_propose_removing_members_from_conversation(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -317,7 +317,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_propose_updating(case: TestCase) {
+        async fn can_propose_updating(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -408,7 +408,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_prevent_out_of_order_proposals(case: TestCase) {
+        async fn should_prevent_out_of_order_proposals(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -176,7 +176,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn renewable_when_created_by_self(case: TestCase) {
+        pub async fn renewable_when_created_by_self(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob"],
@@ -249,7 +249,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_when_in_valid_commit(case: TestCase) {
+        pub async fn not_renewable_when_in_valid_commit(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob"],
@@ -339,7 +339,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_by_ref(case: TestCase) {
+        pub async fn not_renewable_by_ref(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -402,7 +402,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_when_valid_commit_adds_same(case: TestCase) {
+        pub async fn not_renewable_when_valid_commit_adds_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -451,7 +451,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_in_pending_commit_when_valid_commit_adds_same(case: TestCase) {
+        pub async fn not_renewable_in_pending_commit_when_valid_commit_adds_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -504,7 +504,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_by_ref(case: TestCase) {
+        pub async fn not_renewable_by_ref(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie", "debbie"],
@@ -569,7 +569,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn renewable_when_valid_commit_doesnt_adds_same(case: TestCase) {
+        pub async fn renewable_when_valid_commit_doesnt_adds_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -645,7 +645,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn renews_pending_commit_when_valid_commit_doesnt_add_same(case: TestCase) {
+        pub async fn renews_pending_commit_when_valid_commit_doesnt_add_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob"],
@@ -697,7 +697,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_when_valid_commit_removes_same(case: TestCase) {
+        pub async fn not_renewable_when_valid_commit_removes_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -751,7 +751,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn not_renewable_by_ref(case: TestCase) {
+        pub async fn not_renewable_by_ref(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -814,7 +814,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn renewable_when_valid_commit_doesnt_remove_same(case: TestCase) {
+        pub async fn renewable_when_valid_commit_doesnt_remove_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie", "debbie"],
@@ -870,7 +870,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn renews_pending_commit_when_commit_doesnt_remove_same(case: TestCase) {
+        pub async fn renews_pending_commit_when_commit_doesnt_remove_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie", "debbie"],
@@ -926,7 +926,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn renews_pending_commit_from_proposal_when_commit_doesnt_remove_same(case: TestCase) {
+        pub async fn renews_pending_commit_from_proposal_when_commit_doesnt_remove_same(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie", "debbie"],

--- a/crypto/src/mls/conversation/wipe.rs
+++ b/crypto/src/mls/conversation/wipe.rs
@@ -32,7 +32,7 @@ mod tests {
     // should delete anything related to this conversation
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_cascade_deletion(case: TestCase) {
+    async fn should_cascade_deletion(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let id = conversation_id();

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -129,7 +129,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn basic_clients_can_send_messages(case: TestCase) {
+    async fn basic_clients_can_send_messages(case: TestContext) {
         if case.is_basic() {
             let alice_identifier = ClientIdentifier::Basic("alice".into());
             let bob_identifier = ClientIdentifier::Basic("bob".into());
@@ -139,7 +139,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn certificate_clients_can_send_messages(case: TestCase) {
+    async fn certificate_clients_can_send_messages(case: TestContext) {
         if case.is_x509() {
             let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
 
@@ -155,7 +155,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn heterogeneous_clients_can_send_messages(case: TestCase) {
+    async fn heterogeneous_clients_can_send_messages(case: TestContext) {
         let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
 
         // check that both credentials can initiate/join a group
@@ -182,7 +182,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_certificate_chain_is_empty(case: TestCase) {
+    async fn should_fail_when_certificate_chain_is_empty(case: TestContext) {
         let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
 
         let x509_intermediate = x509_test_chain.find_local_intermediate_ca();
@@ -200,7 +200,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_certificate_chain_has_a_single_self_signed(case: TestCase) {
+    async fn should_fail_when_certificate_chain_has_a_single_self_signed(case: TestContext) {
         use crate::MlsErrorKind;
 
         if case.is_x509() {
@@ -227,7 +227,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_signature_key_doesnt_match_certificate_public_key(case: TestCase) {
+    async fn should_fail_when_signature_key_doesnt_match_certificate_public_key(case: TestContext) {
         if case.is_x509() {
             let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
             let x509_intermediate = x509_test_chain.find_local_intermediate_ca();
@@ -258,7 +258,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_not_fail_but_degrade_when_certificate_expired(case: TestCase) {
+    async fn should_not_fail_but_degrade_when_certificate_expired(case: TestContext) {
         if !case.is_x509() {
             return;
         }
@@ -313,7 +313,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_not_fail_but_degrade_when_basic_joins(case: TestCase) {
+    async fn should_not_fail_but_degrade_when_basic_joins(case: TestContext) {
         if !case.is_x509() {
             return;
         }
@@ -456,7 +456,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_certificate_not_valid_yet(case: TestCase) {
+    async fn should_fail_when_certificate_not_valid_yet(case: TestContext) {
         use crate::MlsErrorKind;
 
         if case.is_x509() {
@@ -507,7 +507,7 @@ mod tests {
     }
 
     async fn try_talk(
-        case: &TestCase,
+        case: &TestContext,
         x509_test_chain: Option<&X509TestChain>,
         creator_identifier: ClientIdentifier,
         guest_identifier: ClientIdentifier,

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -291,7 +291,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_get_newly_created_conversation_epoch(case: TestCase) {
+        async fn can_get_newly_created_conversation_epoch(case: TestContext) {
             run_test_with_central(case.clone(), move |[central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -309,7 +309,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_get_conversation_epoch(case: TestCase) {
+        async fn can_get_conversation_epoch(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -328,7 +328,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn conversation_not_found(case: TestCase) {
+        async fn conversation_not_found(case: TestContext) {
             use crate::LeafError;
 
             run_test_with_central(case.clone(), move |[central]| {
@@ -352,7 +352,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn can_create_from_valid_configuration(case: TestCase) {
+        async fn can_create_from_valid_configuration(case: TestContext) {
             run_tests(move |[tmp_dir_argument]| {
                 Box::pin(async move {
                     let configuration = MlsClientConfiguration::try_new(
@@ -416,7 +416,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn create_conversation_should_fail_when_already_exists(case: TestCase) {
+    async fn create_conversation_should_fail_when_already_exists(case: TestContext) {
         use crate::LeafError;
 
         run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
@@ -442,7 +442,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_fetch_client_public_key(case: TestCase) {
+    async fn can_fetch_client_public_key(case: TestContext) {
         run_tests(move |[tmp_dir_argument]| {
             Box::pin(async move {
                 let configuration = MlsClientConfiguration::try_new(
@@ -465,7 +465,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_2_phase_init_central(case: TestCase) {
+    async fn can_2_phase_init_central(case: TestContext) {
         run_tests(move |[tmp_dir_argument]| {
             Box::pin(async move {
                 let x509_test_chain = X509TestChain::init_empty(case.signature_scheme());

--- a/crypto/src/mls/session/epoch_observer.rs
+++ b/crypto/src/mls/session/epoch_observer.rs
@@ -69,11 +69,13 @@ mod tests {
     use rstest_reuse::apply;
     use wasm_bindgen_test::*;
 
-    use crate::test_utils::{TestCase, TestEpochObserver, all_cred_cipher, conversation_id, run_test_with_client_ids};
+    use crate::test_utils::{
+        TestContext, TestEpochObserver, all_cred_cipher, conversation_id, run_test_with_client_ids,
+    };
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn observe_local_epoch_change(case: TestCase) {
+    pub async fn observe_local_epoch_change(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[session_context]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -119,7 +121,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    pub async fn observe_remote_epoch_change(case: TestCase) {
+    pub async fn observe_remote_epoch_change(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice, bob]| {
             Box::pin(async move {
                 let id = conversation_id();

--- a/crypto/src/mls/session/identities.rs
+++ b/crypto/src/mls/session/identities.rs
@@ -139,7 +139,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_find_most_recent(case: TestCase) {
+        async fn should_find_most_recent(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut central]| {
                 Box::pin(async move {
                     let cert = central.get_intermediate_ca().cloned();
@@ -163,7 +163,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_find_by_public_key(case: TestCase) {
+        async fn should_find_by_public_key(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut central]| {
                 Box::pin(async move {
                     const N: usize = 50;
@@ -196,7 +196,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_add_credential(case: TestCase) {
+        async fn should_add_credential(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut central]| {
                 Box::pin(async move {
                     let client = central.session().await;
@@ -213,7 +213,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn pushing_duplicates_should_fail(case: TestCase) {
+        async fn pushing_duplicates_should_fail(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut central]| {
                 Box::pin(async move {
                     let cert = central.get_intermediate_ca().cloned();

--- a/crypto/src/mls/session/key_package.rs
+++ b/crypto/src/mls/session/key_package.rs
@@ -431,7 +431,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_assess_keypackage_expiration(case: TestCase) {
+    async fn can_assess_keypackage_expiration(case: TestContext) {
         run_test_with_central(case.clone(), move |[central]| {
             Box::pin(async move {
                 let (cs, ct) = (case.ciphersuite(), case.credential_type);
@@ -476,7 +476,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn requesting_x509_key_packages_after_basic(case: TestCase) {
+    async fn requesting_x509_key_packages_after_basic(case: TestContext) {
         // Basic test case
         if !case.is_basic() {
             return;
@@ -534,7 +534,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn generates_correct_number_of_kpbs(case: TestCase) {
+    async fn generates_correct_number_of_kpbs(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 const N: usize = 2;
@@ -616,7 +616,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn automatically_prunes_lifetime_expired_keypackages(case: TestCase) {
+    async fn automatically_prunes_lifetime_expired_keypackages(case: TestContext) {
         run_test_with_central(case.clone(), move |[central]| {
             Box::pin(async move {
                 const UNEXPIRED_COUNT: usize = 125;
@@ -706,7 +706,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn new_keypackage_has_correct_extensions(case: TestCase) {
+    async fn new_keypackage_has_correct_extensions(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let kps = cc

--- a/crypto/src/mls/session/mod.rs
+++ b/crypto/src/mls/session/mod.rs
@@ -820,7 +820,7 @@ mod tests {
 
         pub async fn random_generate(
             &self,
-            case: &crate::test_utils::TestCase,
+            case: &crate::test_utils::TestContext,
             signer: Option<&crate::test_utils::x509::X509Certificate>,
             provision: bool,
         ) -> Result<()> {
@@ -919,7 +919,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_generate_client(case: TestCase) {
+    async fn can_generate_client(case: TestContext) {
         run_test_with_central(case.clone(), move |[alice]| {
             Box::pin(async move {
                 let key = DatabaseKey::generate();
@@ -948,7 +948,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn can_externally_generate_client(case: TestCase) {
+    async fn can_externally_generate_client(case: TestContext) {
         run_test_with_central(case.clone(), move |[alice]| {
             Box::pin(async move {
                 if case.is_basic() {

--- a/crypto/src/proteus.rs
+++ b/crypto/src/proteus.rs
@@ -1339,7 +1339,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn cc_can_init(case: TestCase) {
+    async fn cc_can_init(case: TestContext) {
         #[cfg(not(target_family = "wasm"))]
         let (path, db_file) = tmp_db_file();
         #[cfg(target_family = "wasm")]
@@ -1365,7 +1365,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn cc_can_2_phase_init(case: TestCase) {
+    async fn cc_can_2_phase_init(case: TestContext) {
         #[cfg(not(target_family = "wasm"))]
         let (path, db_file) = tmp_db_file();
         #[cfg(target_family = "wasm")]

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 pub mod context;
 mod epoch_observer;
 mod error;
-pub mod fixtures;
 pub mod message;
+pub mod test_context;
 pub mod x509;
 // Cannot name it `proteus` because then it conflicts with proteus the crate :(
 #[cfg(feature = "proteus")]
@@ -35,8 +35,8 @@ use crate::transaction_context::TransactionContext;
 pub(crate) use epoch_observer::TestEpochObserver;
 pub use error::Error as TestError;
 use error::Result;
-pub use fixtures::{TestCase, *};
 pub use message::*;
+pub use test_context::{TestContext, *};
 
 pub const GROUP_SAMPLE_SIZE: usize = 9;
 
@@ -118,7 +118,7 @@ impl SessionContext {
 }
 
 fn init_x509_test_chain(
-    case: &TestCase,
+    case: &TestContext,
     client_ids: &[[&str; 3]],
     revoked_display_names: &[&str],
     cert_params: CertificateParams,
@@ -168,14 +168,14 @@ fn init_x509_test_chain(
 }
 
 pub async fn run_test_with_central(
-    case: TestCase,
+    case: TestContext,
     test: impl FnOnce([SessionContext; 1]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
 ) {
     run_test_with_client_ids(case.clone(), ["alice"], test).await
 }
 
 pub async fn run_test_with_client_ids<const N: usize>(
-    case: TestCase,
+    case: TestContext,
     client_ids: [&'static str; N],
     test: impl FnOnce([SessionContext; N]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
 ) {
@@ -183,7 +183,7 @@ pub async fn run_test_with_client_ids<const N: usize>(
 }
 
 pub async fn run_test_with_client_ids_and_revocation<const N: usize, const F: usize>(
-    case: TestCase,
+    case: TestContext,
     client_ids: [&'static str; N],
     other_client_ids: [&'static str; F],
     revoked_display_names: &'static [&'static str],
@@ -204,7 +204,7 @@ pub async fn run_test_with_client_ids_and_revocation<const N: usize, const F: us
 }
 
 pub async fn run_test_with_deterministic_client_ids<const N: usize>(
-    case: TestCase,
+    case: TestContext,
     client_ids: [[&'static str; 3]; N],
     test: impl FnOnce([SessionContext; N]) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
 ) {
@@ -216,7 +216,7 @@ pub async fn run_test_with_deterministic_client_ids<const N: usize>(
 
 /// Generates 2 x509 test chains, where the intermediate certificates are also cross-signed.
 pub fn init_cross_signed_x509_test_chains<const N: usize, const F: usize>(
-    case: &TestCase,
+    case: &TestContext,
     client_ids: [[&'static str; 3]; N],
     other_client_ids: [[&'static str; 3]; F],
     (params1, params2): (CertificateParams, CertificateParams),
@@ -229,7 +229,7 @@ pub fn init_cross_signed_x509_test_chains<const N: usize, const F: usize>(
 }
 
 pub async fn run_cross_signed_tests_with_client_ids<const N: usize, const F: usize>(
-    case: TestCase,
+    case: TestContext,
     client_ids: [[&'static str; 3]; N],
     other_client_ids: [[&'static str; 3]; F],
     (domain1, domain2): (&'static str, &'static str),
@@ -305,7 +305,7 @@ pub async fn run_cross_signed_tests_with_client_ids<const N: usize, const F: usi
 }
 
 async fn create_centrals<const N: usize>(
-    case: &TestCase,
+    case: &TestContext,
     paths: [String; N],
     chain: Option<&X509TestChain>,
     transport: Arc<dyn MlsTransport>,
@@ -371,7 +371,7 @@ async fn create_centrals<const N: usize>(
 }
 
 pub async fn run_test_with_deterministic_client_ids_and_revocation<const N: usize, const F: usize>(
-    case: TestCase,
+    case: TestContext,
     client_ids: [[&'static str; 3]; N],
     cross_signed_client_ids: [[&'static str; 3]; F],
     revoked_display_names: &'static [&'static str],
@@ -462,7 +462,7 @@ pub async fn run_test_with_deterministic_client_ids_and_revocation<const N: usiz
 }
 
 pub async fn run_test_wo_clients(
-    case: TestCase,
+    case: TestContext,
     test: impl FnOnce(SessionContext) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'static>> + 'static,
 ) {
     run_tests(move |paths: [String; 1]| {

--- a/crypto/src/test_utils/test_context.rs
+++ b/crypto/src/test_utils/test_context.rs
@@ -9,55 +9,55 @@ pub use rstest_reuse::{self, *};
 #[template]
 #[rstest(
     case,
-    case::basic_cs1(TestCase::new(
+    case::basic_cs1(TestContext::new(
         crate::prelude::MlsCredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
     )),
-    case::cert_cs1(TestCase::new(
+    case::cert_cs1(TestContext::new(
         crate::prelude::MlsCredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::basic_cs2(TestCase::new(
+    case::basic_cs2(TestContext::new(
         crate::prelude::MlsCredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::cert_cs2(TestCase::new(
+    case::cert_cs2(TestContext::new(
         crate::prelude::MlsCredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::basic_cs3(TestCase::new(
+    case::basic_cs3(TestContext::new(
         crate::prelude::MlsCredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::cert_cs3(TestCase::new(
+    case::cert_cs3(TestContext::new(
         crate::prelude::MlsCredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::basic_cs5(TestCase::new(
+    case::basic_cs5(TestContext::new(
         crate::prelude::MlsCredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::cert_cs5(TestCase::new(
+    case::cert_cs5(TestContext::new(
         crate::prelude::MlsCredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::basic_cs7(TestCase::new(
+    case::basic_cs7(TestContext::new(
         crate::prelude::MlsCredentialType::Basic,
         openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
     )),
     #[cfg(feature = "test-all-cipher")]
-    case::cert_cs7(TestCase::new(
+    case::cert_cs7(TestContext::new(
         crate::prelude::MlsCredentialType::X509,
         openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
     )),
-    case::pure_ciphertext(TestCase {
+    case::pure_ciphertext(TestContext {
         credential_type: crate::prelude::MlsCredentialType::Basic,
         cfg: $crate::prelude::MlsConversationConfiguration {
             custom: $crate::prelude::MlsCustomConfiguration {
@@ -70,16 +70,16 @@ pub use rstest_reuse::{self, *};
     }),
 )]
 #[allow(non_snake_case)]
-pub fn all_cred_cipher(case: TestCase) {}
+pub fn all_cred_cipher(case: TestContext) {}
 
 #[derive(Debug, Clone)]
-pub struct TestCase {
+pub struct TestContext {
     pub credential_type: MlsCredentialType,
     pub cfg: MlsConversationConfiguration,
     pub contexts: Vec<SessionContext>,
 }
 
-impl TestCase {
+impl TestContext {
     pub fn new(credential_type: MlsCredentialType, cs: openmls::prelude::Ciphersuite) -> Self {
         Self {
             credential_type,
@@ -124,7 +124,7 @@ impl TestCase {
     }
 }
 
-impl Default for TestCase {
+impl Default for TestContext {
     fn default() -> Self {
         Self {
             credential_type: MlsCredentialType::Basic,

--- a/crypto/src/transaction_context/conversation/external_commit.rs
+++ b/crypto/src/transaction_context/conversation/external_commit.rs
@@ -170,7 +170,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn join_by_external_commit_should_succeed(case: TestCase) {
+    async fn join_by_external_commit_should_succeed(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice, bob]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -228,7 +228,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn join_by_external_commit_should_be_retriable(case: TestCase) {
+    async fn join_by_external_commit_should_be_retriable(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -282,7 +282,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_bad_epoch(case: TestCase) {
+    async fn should_fail_when_bad_epoch(case: TestContext) {
         use crate::mls;
 
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
@@ -331,7 +331,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn existing_clients_can_join(case: TestCase) {
+    async fn existing_clients_can_join(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -355,7 +355,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_no_pending_external_commit(case: TestCase) {
+    async fn should_fail_when_no_pending_external_commit(case: TestContext) {
         run_test_with_central(case.clone(), move |[central]| {
             Box::pin(async move {
                 let non_existent_id = conversation_id();
@@ -376,7 +376,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_return_valid_group_info(case: TestCase) {
+    async fn should_return_valid_group_info(case: TestContext) {
         run_test_with_client_ids(
             case.clone(),
             ["alice", "bob", "charlie"],
@@ -459,7 +459,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn clear_pending_group_should_succeed(case: TestCase) {
+    async fn clear_pending_group_should_succeed(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -491,7 +491,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn new_with_inflight_join_should_fail_when_already_exists(case: TestCase) {
+    async fn new_with_inflight_join_should_fail_when_already_exists(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -527,7 +527,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn new_with_inflight_welcome_should_fail_when_already_exists(case: TestCase) {
+    async fn new_with_inflight_welcome_should_fail_when_already_exists(case: TestContext) {
         use crate::mls;
 
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
@@ -578,7 +578,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_invalid_group_info(case: TestCase) {
+    async fn should_fail_when_invalid_group_info(case: TestContext) {
         run_test_with_client_ids(
             case.clone(),
             ["alice", "bob", "guest"],
@@ -635,7 +635,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn group_should_have_right_config(case: TestCase) {
+    async fn group_should_have_right_config(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();

--- a/crypto/src/transaction_context/conversation/external_proposal.rs
+++ b/crypto/src/transaction_context/conversation/external_proposal.rs
@@ -95,7 +95,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn guest_should_externally_propose_adding_itself_to_owner_group(case: TestCase) {
+        async fn guest_should_externally_propose_adding_itself_to_owner_group(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["owner", "guest"],
@@ -168,7 +168,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn ds_should_remove_guest_from_conversation(case: TestCase) {
+        async fn ds_should_remove_guest_from_conversation(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["owner", "guest", "ds"], move |[owner, guest, ds]| {
                 Box::pin(async move {
                     let owner_central = &owner.context;
@@ -245,7 +245,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_fail_when_invalid_external_sender(case: TestCase) {
+        async fn should_fail_when_invalid_external_sender(case: TestContext) {
             use crate::mls;
 
             run_test_with_client_ids(
@@ -325,7 +325,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_fail_when_wrong_signature_key(case: TestCase) {
+        async fn should_fail_when_wrong_signature_key(case: TestContext) {
             use crate::mls;
 
             run_test_with_client_ids(case.clone(), ["owner", "guest", "ds"], move |[owner, guest, ds]| {
@@ -400,7 +400,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn joiners_from_welcome_can_accept_external_remove_proposals(case: TestCase) {
+        async fn joiners_from_welcome_can_accept_external_remove_proposals(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie", "ds"],
@@ -526,7 +526,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn joiners_from_external_commit_can_accept_external_remove_proposals(case: TestCase) {
+        async fn joiners_from_external_commit_can_accept_external_remove_proposals(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie", "ds"],

--- a/crypto/src/transaction_context/conversation/proposal.rs
+++ b/crypto/src/transaction_context/conversation/proposal.rs
@@ -83,7 +83,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_add_member(case: TestCase) {
+        pub async fn should_add_member(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -124,7 +124,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_update_hpke_key(case: TestCase) {
+        pub async fn should_update_hpke_key(case: TestContext) {
             run_test_with_central(case.clone(), move |[central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -166,7 +166,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_remove_member(case: TestCase) {
+        pub async fn should_remove_member(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice", "bob"], |[alice_central, bob_central]| {
                 Box::pin(async move {
                     let id = conversation_id();
@@ -222,7 +222,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_fail_when_unknown_client(case: TestCase) {
+        pub async fn should_fail_when_unknown_client(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {
                     let id = conversation_id();

--- a/crypto/src/transaction_context/conversation/welcome.rs
+++ b/crypto/src/transaction_context/conversation/welcome.rs
@@ -109,7 +109,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn joining_from_welcome_should_prune_local_key_material(case: TestCase) {
+    async fn joining_from_welcome_should_prune_local_key_material(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -154,7 +154,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn process_welcome_should_fail_when_already_exists(case: TestCase) {
+    async fn process_welcome_should_fail_when_already_exists(case: TestContext) {
         use crate::LeafError;
 
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {

--- a/crypto/src/transaction_context/e2e_identity/conversation_state.rs
+++ b/crypto/src/transaction_context/e2e_identity/conversation_state.rs
@@ -107,7 +107,7 @@ mod tests {
     // testing the case where both Bob & Alice have the same Credential type
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn uniform_conversation_should_be_not_verified_when_basic(case: TestCase) {
+    async fn uniform_conversation_should_be_not_verified_when_basic(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
             Box::pin(async move {
                 let id = conversation_id();
@@ -187,7 +187,7 @@ mod tests {
     // testing the case where Bob & Alice have different Credential type
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn heterogeneous_conversation_should_be_not_verified(case: TestCase) {
+    async fn heterogeneous_conversation_should_be_not_verified(case: TestContext) {
         use crate::e2e_identity::enrollment::test_utils::failsafe_ctx;
 
         run_test_with_client_ids(
@@ -270,7 +270,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_be_not_verified_when_one_expired(case: TestCase) {
+    async fn should_be_not_verified_when_one_expired(case: TestContext) {
         if !case.is_x509() {
             return;
         }
@@ -363,7 +363,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_be_not_verified_when_all_expired(case: TestCase) {
+    async fn should_be_not_verified_when_all_expired(case: TestContext) {
         if case.is_x509() {
             run_test_with_client_ids(case.clone(), ["alice"], move |[alice_central]| {
                 Box::pin(async move {

--- a/crypto/src/transaction_context/e2e_identity/enabled.rs
+++ b/crypto/src/transaction_context/e2e_identity/enabled.rs
@@ -30,7 +30,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_be_false_when_basic_and_true_when_x509(case: TestCase) {
+    async fn should_be_false_when_basic_and_true_when_x509(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 let e2ei_is_enabled = cc.context.e2ei_is_enabled(case.signature_scheme()).await.unwrap();
@@ -45,7 +45,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_no_client(case: TestCase) {
+    async fn should_fail_when_no_client(case: TestContext) {
         run_test_wo_clients(case.clone(), move |cc| {
             Box::pin(async move {
                 assert!(matches!(
@@ -60,7 +60,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_no_credential_for_given_signature_scheme(case: TestCase) {
+    async fn should_fail_when_no_credential_for_given_signature_scheme(case: TestContext) {
         run_test_with_client_ids(case.clone(), ["alice"], move |[cc]| {
             Box::pin(async move {
                 // just return something different from the signature scheme the MlsCentral was initialized with

--- a/crypto/src/transaction_context/e2e_identity/init_certificates.rs
+++ b/crypto/src/transaction_context/e2e_identity/init_certificates.rs
@@ -268,7 +268,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn register_acme_ca_should_fail_when_already_set(case: TestCase) {
+    async fn register_acme_ca_should_fail_when_already_set(case: TestContext) {
         use x509_cert::der::pem::LineEnding;
 
         if !case.is_x509() {
@@ -294,7 +294,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn x509_restore_should_not_happen_if_basic(case: TestCase) {
+    async fn x509_restore_should_not_happen_if_basic(case: TestContext) {
         if case.is_x509() {
             return;
         }

--- a/crypto/src/transaction_context/e2e_identity/mod.rs
+++ b/crypto/src/transaction_context/e2e_identity/mod.rs
@@ -120,7 +120,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn e2e_identity_should_work(case: TestCase) {
+    async fn e2e_identity_should_work(case: TestContext) {
         use e2ei_utils::E2EI_CLIENT_ID_URI;
 
         run_test_wo_clients(case.clone(), move |mut cc| {

--- a/crypto/src/transaction_context/e2e_identity/rotate.rs
+++ b/crypto/src/transaction_context/e2e_identity/rotate.rs
@@ -265,7 +265,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn enrollment_should_rotate_all(case: TestCase) {
+        async fn enrollment_should_rotate_all(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob", "charlie"],
@@ -485,7 +485,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn should_restore_credentials_in_order(case: TestCase) {
+        async fn should_restore_credentials_in_order(case: TestContext) {
             run_test_with_client_ids(case.clone(), ["alice"], move |[mut alice_central]| {
                 Box::pin(async move {
                     let x509_test_chain_arc =
@@ -617,7 +617,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        async fn rotate_should_roundtrip(case: TestCase) {
+        async fn rotate_should_roundtrip(case: TestContext) {
             run_test_with_client_ids(
                 case.clone(),
                 ["alice", "bob"],
@@ -809,7 +809,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn should_rotate_one_conversations_credential(case: TestCase) {
+        pub async fn should_rotate_one_conversations_credential(case: TestContext) {
             if case.is_x509() {
                 run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                     Box::pin(async move {
@@ -902,7 +902,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn rotate_should_be_renewable_when_commit_denied(case: TestCase) {
+        pub async fn rotate_should_be_renewable_when_commit_denied(case: TestContext) {
             if !case.is_x509() {
                 return;
             }
@@ -1015,7 +1015,7 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         #[wasm_bindgen_test]
-        pub async fn rotate_should_replace_existing_basic_credentials(case: TestCase) {
+        pub async fn rotate_should_replace_existing_basic_credentials(case: TestContext) {
             if case.is_x509() {
                 run_test_with_client_ids(case.clone(), ["alice", "bob"], move |[alice_central, bob_central]| {
                     Box::pin(async move {

--- a/crypto/src/transaction_context/e2e_identity/stash.rs
+++ b/crypto/src/transaction_context/e2e_identity/stash.rs
@@ -60,7 +60,7 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn stash_and_pop_should_not_abort_enrollment(case: TestCase) {
+    async fn stash_and_pop_should_not_abort_enrollment(case: TestContext) {
         run_test_wo_clients(case.clone(), move |mut cc| {
             Box::pin(async move {
                 let x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
@@ -97,7 +97,7 @@ mod tests {
     // this ensures the nominal test does its job
     #[apply(all_cred_cipher)]
     #[wasm_bindgen_test]
-    async fn should_fail_when_restoring_invalid(case: TestCase) {
+    async fn should_fail_when_restoring_invalid(case: TestContext) {
         run_test_wo_clients(case.clone(), move |mut cc| {
             Box::pin(async move {
                 let x509_test_chain = X509TestChain::init_empty(case.signature_scheme());


### PR DESCRIPTION
This name fits better, because this struct is going to do more than just describing a test case: at least, it's going to manage state, instantiate new test sessions and test conversations and be responsible for cleanup via its drop implementation.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
