### PR TITLE
chore: drop sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "strum",
- "sysinfo",
  "tempfile",
  "thiserror 2.0.12",
  "time",
@@ -2353,7 +2352,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3077,15 +3076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,15 +3122,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
-dependencies = [
- "bitflags 2.9.0",
-]
 
 [[package]]
 name = "object"
@@ -4759,19 +4740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.34.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "windows",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5931,22 +5899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5956,69 +5908,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -72,10 +72,6 @@ sha2 = "0.10.8"
 core-crypto-keystore.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-sysinfo = { version = "0.34", default-features = false, features = [
-    "apple-app-store",
-    "system",
-] }
 async-fs = { version = "2.1", optional = true }
 futures-lite = { version = "2.6", optional = true }
 

--- a/crypto/src/group_store.rs
+++ b/crypto/src/group_store.rs
@@ -226,24 +226,8 @@ pub(crate) const MEMORY_LIMIT: usize = 100_000_000;
 pub(crate) const ITEM_LIMIT: u32 = 100;
 
 impl HybridMemoryLimiter {
-    // in the wasm case, we ignore the suggested memory limit
-    #[cfg_attr(target_family = "wasm", expect(unused_variables))]
     pub(crate) fn new(count: Option<u32>, memory: Option<usize>) -> Self {
-        #[cfg(target_family = "wasm")]
-        let memory_limit = MEMORY_LIMIT;
-
-        #[cfg(not(target_family = "wasm"))]
-        let memory_limit = memory
-            .or_else(|| {
-                let system = sysinfo::System::new_with_specifics(
-                    sysinfo::RefreshKind::nothing().with_memory(sysinfo::MemoryRefreshKind::nothing().with_ram()),
-                );
-
-                let available_sys_memory = system.available_memory();
-                (available_sys_memory > 0).then_some(available_sys_memory as usize)
-            })
-            .unwrap_or(MEMORY_LIMIT);
-
+        let memory_limit = memory.unwrap_or(MEMORY_LIMIT);
         let mem = schnellru::ByMemoryUsage::new(memory_limit);
         let len = schnellru::ByLength::new(count.unwrap_or(ITEM_LIMIT));
 

--- a/crypto/src/group_store.rs
+++ b/crypto/src/group_store.rs
@@ -124,22 +124,21 @@ impl<V: GroupStoreEntity> std::ops::DerefMut for GroupStore<V> {
 }
 
 impl<V: GroupStoreEntity> GroupStore<V> {
-    #[allow(dead_code)]
     pub(crate) fn new_with_limit(len: u32) -> Self {
         let limiter = HybridMemoryLimiter::new(Some(len), None);
         let store = schnellru::LruMap::new(limiter);
         Self(store)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn new(count: Option<u32>, memory: Option<usize>) -> Self {
+    #[cfg(test)]
+    fn new(count: Option<u32>, memory: Option<usize>) -> Self {
         let limiter = HybridMemoryLimiter::new(count, memory);
         let store = schnellru::LruMap::new(limiter);
         Self(store)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn contains_key(&self, k: &[u8]) -> bool {
+    #[cfg(test)]
+    fn contains_key(&self, k: &[u8]) -> bool {
         self.0.peek(k).is_some()
     }
 


### PR DESCRIPTION
sysinfo is currently only used to get available RAM on non-wasm platforms, but we really don't need that, and the information is not so useful anyway. On the other hand, sysinfo is another dependency that brings with it a few windows dependencies, which we don't really have a need for.