### PR TITLE
chore: mls-crypto-provider: remove features that nobody uses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,7 +2677,6 @@ dependencies = [
  "hkdf 0.12.4",
  "hmac",
  "hpke",
- "mls-crypto-provider",
  "openmls",
  "openmls_traits",
  "p256",

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -14,10 +14,6 @@ crate-type = ["lib", "cdylib"]
 [lints]
 workspace = true
 
-[features]
-default = []
-raw-rand-access = [] # TESTING ONLY
-
 [dependencies]
 openmls_traits.workspace = true
 async-trait.workspace = true
@@ -61,4 +57,3 @@ rstest_reuse = "0.7"
 async-std = { workspace = true, features = ["attributes"] }
 cfg-if.workspace = true
 hex-literal = "1.0"
-mls-crypto-provider = { workspace = true, features = ["raw-rand-access"] }


### PR DESCRIPTION
And that don't actually do anything.
