### PR TITLE
ci(rust.yml): fail on warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,8 @@ jobs:
           - name: fmt
             trailer: --all -- --check
           - name: clippy --locked
+          - name: clippy --locked
+            trailer: --tests
           - name: check --locked
             trailer: --tests
         target: ["", "--target wasm32-unknown-unknown"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,6 @@ jobs:
           - name: fmt
             trailer: --all -- --check
           - name: clippy --locked
-            trailer: -- -D warnings
           - name: check --locked
             trailer: --tests
         target: ["", "--target wasm32-unknown-unknown"]
@@ -41,7 +40,6 @@ jobs:
       - uses: ./.github/actions/setup-and-cache-rust
         with:
           components: rustfmt, clippy
-          rustflags: ''
           target: wasm32-unknown-unknown
       - run: cargo ${{ matrix.tool.name }} ${{ matrix.target }} ${{ matrix.tool.trailer }}
 
@@ -50,8 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-and-cache-rust
-        with:
-          rustflags: ''
       - uses: taiki-e/install-action@nextest
       - name: "test corecrypto"
         run: cargo nextest run --verbose --locked
@@ -68,8 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-and-cache-rust
-        with:
-          rustflags: ''
       - uses: taiki-e/install-action@nextest
       - name: "test corecrypto's proteus implementation"
         run: cargo nextest run --locked --verbose --features proteus,cryptobox-migrate,proteus-keystore proteus
@@ -102,7 +96,6 @@ jobs:
       - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: wasm32-unknown-unknown
-          rustflags: ''
       - uses: wireapp/setup-chrome@master
         id: setup-chrome
         with:
@@ -119,6 +112,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-and-cache-rust
+        # Per default, we're using "-D warnings" for rustflags. However, it's a lot of (unnecessary) effort to fix all "unused import"
+        # issue for every possible feature set, that's why we don't want to fail on warnings here. For this, we're passing
+        # an empty set of rustflags.
         with:
           rustflags: ''
       - uses: taiki-e/install-action@cargo-hack

--- a/crypto/src/e2e_identity/enrollment/test_utils.rs
+++ b/crypto/src/e2e_identity/enrollment/test_utils.rs
@@ -1,8 +1,8 @@
 #[cfg(not(target_family = "wasm"))]
-use crate::e2e_identity::refresh_token::RefreshToken;
+use crate::{KeystoreError, e2e_identity::Error, e2e_identity::refresh_token::RefreshToken};
 use crate::{
-    KeystoreError, RecursiveError,
-    e2e_identity::{E2eiEnrollment, Error, Result, id::QualifiedE2eiClientId},
+    RecursiveError,
+    e2e_identity::{E2eiEnrollment, Result, id::QualifiedE2eiClientId},
     prelude::{CertificateBundle, MlsCredentialType},
     test_utils::{SessionContext, TestContext, context::TEAM, x509::X509TestChain},
     transaction_context::TransactionContext,
@@ -10,6 +10,7 @@ use crate::{
 use itertools::Itertools as _;
 use mls_crypto_provider::PkiKeypair;
 use openmls::prelude::SignatureScheme;
+#[cfg(not(target_family = "wasm"))]
 use openmls_traits::OpenMlsCryptoProvider as _;
 use serde_json::json;
 

--- a/crypto/src/ephemeral.rs
+++ b/crypto/src/ephemeral.rs
@@ -238,7 +238,7 @@ mod tests {
         // set up alice with x509
         let mut x509_test_chain = X509TestChain::init_empty(case.signature_scheme());
         let (alice_identifier, _) = x509_test_chain.issue_simple_certificate_bundle("alice", None);
-        let alice = SessionContext::new_with_identifier(&case, alice_identifier, Some((&x509_test_chain).into()))
+        let alice = SessionContext::new_with_identifier(&case, alice_identifier, Some(&x509_test_chain))
             .await
             .unwrap();
 

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -721,14 +721,14 @@ mod tests {
                 .await
                 .unwrap();
 
-            for j in 0..N {
+            for (user_name, status) in name_status.iter() {
                 let client_identity = identities.remove(
                     identities
                         .iter()
-                        .position(|i| i.x509_identity.as_ref().unwrap().display_name == name_status[j].0.to_string())
+                        .position(|i| i.x509_identity.as_ref().unwrap().display_name == user_name.to_string())
                         .unwrap(),
                 );
-                assert_eq!(client_identity.status, name_status[j].1);
+                assert_eq!(client_identity.status, *status);
             }
             assert!(identities.is_empty());
 

--- a/crypto/src/proteus.rs
+++ b/crypto/src/proteus.rs
@@ -1349,11 +1349,7 @@ mod tests {
         assert_eq!(proteus_central.fingerprint(), alice_fingerprint);
 
         // Session integrity check
-        let alice_new_session_lock = proteus_central
-            .session(&session_id, &mut keystore)
-            .await
-            .unwrap()
-            .unwrap();
+        let alice_new_session_lock = proteus_central.session(&session_id, &keystore).await.unwrap().unwrap();
         let alice_new_session = alice_new_session_lock.read().await;
         assert_eq!(
             alice_new_session.session.local_identity().fingerprint(),
@@ -1396,7 +1392,7 @@ mod tests {
             .unwrap();
         assert_eq!(&decrypted, &message[..]);
 
-        proteus_central.session_save(&mut keystore, &session_id).await.unwrap();
+        proteus_central.session_save(&keystore, &session_id).await.unwrap();
         keystore.commit_transaction().await.unwrap();
         keystore.wipe().await.unwrap();
     }
@@ -1533,7 +1529,7 @@ mod tests {
 
                 // Session integrity check
                 let alice_new_session_lock = proteus_central
-                    .session(&session_id, &mut keystore)
+                    .session(&session_id, &keystore)
                     .await
                     .unwrap()
                     .unwrap();

--- a/keystore/src/connection/platform/generic/mod.rs
+++ b/keystore/src/connection/platform/generic/mod.rs
@@ -106,9 +106,8 @@ impl SqlCipherConnection {
 
     #[cfg(feature = "log-queries")]
     fn log_query(event: TraceEvent) {
-        match event {
-            TraceEvent::Stmt(_, sql) => log::info!("{}", sql),
-            _ => {}
+        if let TraceEvent::Stmt(_, sql) = event {
+            log::info!("{}", sql)
         }
     }
 

--- a/keystore/tests/common.rs
+++ b/keystore/tests/common.rs
@@ -8,7 +8,7 @@ use core_crypto_keystore::connection::{DatabaseConnection, KeystoreDatabaseConne
 pub(crate) use rstest::*;
 pub(crate) use rstest_reuse::{self, *};
 
-pub(crate) static TEST_ENCRYPTION_KEY: LazyLock<DatabaseKey> = LazyLock::new(|| DatabaseKey::generate());
+pub(crate) static TEST_ENCRYPTION_KEY: LazyLock<DatabaseKey> = LazyLock::new(DatabaseKey::generate);
 
 #[fixture]
 pub fn store_name() -> String {


### PR DESCRIPTION
# What's new in this PR
The default behavior of our rust action is to fail on warnings.
There is no reason to override that default behavior.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
