### PR TITLE
chore(test): rm comment asking for parallelization [WPB-9624]

### DIFF
--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -651,7 +651,6 @@ mod tests {
                 );
 
                 let mut bob_and_friends_groups = Vec::with_capacity(bob_and_friends.len());
-                // TODO: Do things in parallel, this is waaaaay too slow (takes around 5 minutes). Tracking issue: WPB-9624
                 for c in bob_and_friends {
                     c.transaction
                         .process_welcome_message(welcome.clone().into(), case.custom_cfg())


### PR DESCRIPTION
We had a comment in a test asking for parallelization due to a claimed 5m execution time. On investigation, two different team members couldn't get it to take more than 10s. So this just removes the comment.



----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
