### PR TITLE
chore: drop femme and reduce noise in CI interop test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,22 +1516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "femme"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc04871e5ae3aa2952d552dae6b291b3099723bf779a8054281c1366a54613ef"
-dependencies = [
- "cfg-if",
- "js-sys",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2289,6 @@ dependencies = [
  "dirs",
  "env_logger",
  "fantoccini",
- "femme",
  "hex",
  "log",
  "openmls",
@@ -4945,8 +4928,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,18 +676,18 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors 4.2.0",
+ "owo-colors",
  "tracing-error",
 ]
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
 dependencies = [
  "once_cell",
- "owo-colors 3.5.0",
+ "owo-colors",
  "tracing-core",
  "tracing-error",
 ]
@@ -2946,12 +2946,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "owo-colors"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,16 +667,16 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
 dependencies = [
  "backtrace",
  "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors",
+ "owo-colors 4.2.0",
  "tracing-error",
 ]
 
@@ -687,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
 dependencies = [
  "once_cell",
- "owo-colors",
+ "owo-colors 3.5.0",
  "tracing-core",
  "tracing-error",
 ]
@@ -2952,6 +2952,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "p256"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,6 +2303,7 @@ dependencies = [
  "core-crypto-ffi",
  "cryptobox",
  "dirs",
+ "env_logger",
  "fantoccini",
  "femme",
  "hex",

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 [dependencies]
 color-eyre = "0.6"
 log = "0.4"
-femme = "2.2"
 dirs = "6.0"
 env_logger = "0.11"
 core-crypto = { path = "../crypto" }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -22,6 +22,7 @@ color-eyre = "0.6"
 log = "0.4"
 femme = "2.2"
 dirs = "6.0"
+env_logger = "0.11"
 core-crypto = { path = "../crypto" }
 core-crypto-ffi = { path = "../crypto-ffi" }
 openmls.workspace = true

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -72,8 +72,7 @@ impl EmulatedClient for CoreCryptoFfiClient {
         EmulatedClientProtocol::MLS | EmulatedClientProtocol::PROTEUS
     }
 
-    async fn wipe(mut self) -> Result<()> {
-        drop(self.cc);
+    async fn wipe(&mut self) -> Result<()> {
         Ok(())
     }
 }

--- a/interop/src/clients/corecrypto/ios.rs
+++ b/interop/src/clients/corecrypto/ios.rs
@@ -199,7 +199,7 @@ impl EmulatedClient for CoreCryptoIosClient {
         EmulatedClientProtocol::MLS | EmulatedClientProtocol::PROTEUS
     }
 
-    async fn wipe(mut self) -> Result<()> {
+    async fn wipe(&mut self) -> Result<()> {
         Ok(())
     }
 }

--- a/interop/src/clients/corecrypto/mod.rs
+++ b/interop/src/clients/corecrypto/mod.rs
@@ -2,4 +2,5 @@ pub(crate) mod ffi;
 pub(crate) mod native;
 pub(crate) mod web;
 
+#[cfg(target_os = "ios")]
 pub(crate) mod ios;

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -70,8 +70,7 @@ impl EmulatedClient for CoreCryptoNativeClient {
         EmulatedClientProtocol::MLS | EmulatedClientProtocol::PROTEUS
     }
 
-    async fn wipe(mut self) -> Result<()> {
-        drop(self.cc);
+    async fn wipe(&mut self) -> Result<()> {
         Ok(())
     }
 }

--- a/interop/src/clients/corecrypto/web.rs
+++ b/interop/src/clients/corecrypto/web.rs
@@ -84,7 +84,7 @@ impl EmulatedClient for CoreCryptoWebClient {
         EmulatedClientProtocol::MLS | EmulatedClientProtocol::PROTEUS
     }
 
-    async fn wipe(mut self) -> Result<()> {
+    async fn wipe(&mut self) -> Result<()> {
         let client_id = uuid::Uuid::from_slice(self.client_id.as_slice())?;
         let client_id_str = client_id.as_hyphenated().to_string();
         let database_name = format!("db-{client_id_str}");

--- a/interop/src/clients/cryptobox/native.rs
+++ b/interop/src/clients/cryptobox/native.rs
@@ -39,7 +39,7 @@ impl EmulatedClient for CryptoboxNativeClient {
         EmulatedClientProtocol::PROTEUS
     }
 
-    async fn wipe(mut self) -> Result<()> {
+    async fn wipe(&mut self) -> Result<()> {
         let _ = self.cbox.take();
         if let Some(tempdir) = self.tempdir.take() {
             tempdir.close()?;

--- a/interop/src/clients/cryptobox/web.rs
+++ b/interop/src/clients/cryptobox/web.rs
@@ -42,7 +42,7 @@ impl EmulatedClient for CryptoboxWebClient {
         EmulatedClientProtocol::PROTEUS
     }
 
-    async fn wipe(mut self) -> Result<()> {
+    async fn wipe(&mut self) -> Result<()> {
         let _ = self
             .browser
             .execute_async(

--- a/interop/src/clients/mod.rs
+++ b/interop/src/clients/mod.rs
@@ -49,7 +49,7 @@ pub(crate) trait EmulatedClient {
     fn client_type(&self) -> EmulatedClientType;
     fn client_id(&self) -> &[u8];
     fn client_protocol(&self) -> EmulatedClientProtocol;
-    async fn wipe(mut self) -> Result<()>;
+    async fn wipe(&mut self) -> Result<()>;
 }
 
 #[async_trait::async_trait(?Send)]

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -85,9 +85,7 @@ fn run_test() -> Result<()> {
     use tokio::net::{TcpListener, TcpStream};
 
     color_eyre::install()?;
-    if std::env::var("RUST_LOG").is_ok() || std::env::var("CI").is_ok() {
-        femme::start();
-    }
+    env_logger::init();
 
     // Check if we have a correct pwd
     let current_dir = std::env::current_dir()?;

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -3,12 +3,9 @@
 use core_crypto::DatabaseKey;
 
 #[cfg(not(target_family = "wasm"))]
-use crate::clients::{EmulatedClient, EmulatedProteusClient};
-#[cfg(not(target_family = "wasm"))]
 use crate::util::{MlsTransportSuccessProvider, MlsTransportTestExt};
 use color_eyre::eyre::{Result, eyre};
 use core_crypto::prelude::CiphersuiteName;
-use std::rc::Rc;
 use std::sync::Arc;
 use tls_codec::Serialize;
 
@@ -29,6 +26,54 @@ const CIPHERSUITE_IN_USE: CiphersuiteName = CiphersuiteName::MLS_128_DHKEMX25519
 // TODO: Add support for iOS emulator when on macOS. Tracking issue: WPB-9646
 fn main() -> Result<()> {
     run_test()
+}
+
+async fn create_mls_clients<'a>(
+    chrome_driver_addr: &'a std::net::SocketAddr,
+    web_server: &'a std::net::SocketAddr,
+) -> Vec<Box<dyn clients::EmulatedMlsClient>> {
+    vec![
+        #[cfg(target_os = "ios")]
+        Box::new(clients::corecrypto::ios::CoreCryptoIosClient::new().await.unwrap()),
+        Box::new(
+            clients::corecrypto::native::CoreCryptoNativeClient::new()
+                .await
+                .unwrap(),
+        ),
+        Box::new(clients::corecrypto::ffi::CoreCryptoFfiClient::new().await.unwrap()),
+        Box::new(
+            clients::corecrypto::web::CoreCryptoWebClient::new(chrome_driver_addr, web_server)
+                .await
+                .unwrap(),
+        ),
+    ]
+}
+
+async fn create_proteus_clients<'a>(
+    chrome_driver_addr: &'a std::net::SocketAddr,
+    web_server: &'a std::net::SocketAddr,
+) -> Vec<Box<dyn clients::EmulatedProteusClient>> {
+    vec![
+        #[cfg(target_os = "ios")]
+        Box::new(clients::corecrypto::ios::CoreCryptoIosClient::new().await.unwrap()),
+        Box::new(
+            clients::corecrypto::native::CoreCryptoNativeClient::new()
+                .await
+                .unwrap(),
+        ),
+        Box::new(clients::corecrypto::ffi::CoreCryptoFfiClient::new().await.unwrap()),
+        Box::new(
+            clients::corecrypto::web::CoreCryptoWebClient::new(chrome_driver_addr, web_server)
+                .await
+                .unwrap(),
+        ),
+        Box::new(clients::cryptobox::native::CryptoboxNativeClient::new()),
+        Box::new(
+            clients::cryptobox::web::CryptoboxWebClient::new(chrome_driver_addr, web_server)
+                .await
+                .unwrap(),
+        ),
+    ]
 }
 
 // need to be handled like this because https://github.com/rust-lang/cargo/issues/5220, otherwise
@@ -107,18 +152,7 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr, web_server: &st
 
     let spinner = util::RunningProcess::new("[MLS] Step 0: Initializing clients & env...", true);
 
-    let ios_client = Rc::new(clients::corecrypto::ios::CoreCryptoIosClient::new().await?);
-    let native_client = Rc::new(clients::corecrypto::native::CoreCryptoNativeClient::new().await?);
-    let ffi_client = Rc::new(clients::corecrypto::ffi::CoreCryptoFfiClient::new().await?);
-    let web_client = Rc::new(clients::corecrypto::web::CoreCryptoWebClient::new(chrome_driver_addr, web_server).await?);
-
-    let mut clients: Vec<Rc<dyn clients::EmulatedMlsClient>> = vec![
-        native_client.clone(),
-        ffi_client.clone(),
-        web_client.clone(),
-        ios_client.clone(),
-    ];
-
+    let mut clients = create_mls_clients(chrome_driver_addr, web_server).await;
     let ciphersuites = vec![CIPHERSUITE_IN_USE.into()];
     let configuration = MlsClientConfiguration::try_new(
         "whatever".into(),
@@ -151,7 +185,7 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr, web_server: &st
 
     use tls_codec::Deserialize as _;
     let mut key_packages = vec![];
-    for c in clients.iter_mut() {
+    for c in clients.iter() {
         let kp = c.get_keypackage().await?;
         let kp = KeyPackageIn::tls_deserialize(&mut kp.as_slice())?;
         key_packages.push(kp);
@@ -249,31 +283,14 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr, web_server: &st
         ));
     }
 
-    clients.clear();
-
     spinner.success(format!(
         "[MLS] Step 3: Roundtripping {ROUNDTRIP_MSG_AMOUNT} messages... [OK]"
     ));
 
     let spinner = util::RunningProcess::new("[MLS] Step 4: Deleting clients...", true);
-
-    Rc::into_inner(ios_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(native_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(ffi_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(web_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-
+    for client in &mut clients {
+        client.wipe().await?;
+    }
     spinner.success("[MLS] Step 4: Deleting clients [OK]");
 
     Ok(())
@@ -285,36 +302,11 @@ async fn run_proteus_test(chrome_driver_addr: &std::net::SocketAddr, web_server:
 
     let spinner = util::RunningProcess::new("[Proteus] Step 0: Initializing clients & env...", true);
 
-    let mut ios_client = clients::corecrypto::ios::CoreCryptoIosClient::new().await?;
-    let mut native_client = clients::corecrypto::native::CoreCryptoNativeClient::new().await?;
-    let mut ffi_client = clients::corecrypto::ffi::CoreCryptoFfiClient::new().await?;
-    let mut web_client = clients::corecrypto::web::CoreCryptoWebClient::new(chrome_driver_addr, web_server).await?;
-    let mut cryptobox_native_client = clients::cryptobox::native::CryptoboxNativeClient::new();
-    let mut cryptobox_web_client =
-        clients::cryptobox::web::CryptoboxWebClient::new(chrome_driver_addr, web_server).await?;
+    let mut clients = create_proteus_clients(chrome_driver_addr, web_server).await;
 
-    ios_client.init().await?;
-    native_client.init().await?;
-    ffi_client.init().await?;
-    web_client.init().await?;
-    cryptobox_native_client.init().await?;
-    cryptobox_web_client.init().await?;
-
-    let ios_client = Rc::new(ios_client);
-    let native_client = Rc::new(native_client);
-    let ffi_client = Rc::new(ffi_client);
-    let web_client = Rc::new(web_client);
-    let cryptobox_native_client = Rc::new(cryptobox_native_client);
-    let cryptobox_web_client = Rc::new(cryptobox_web_client);
-
-    let mut clients: Vec<Rc<dyn clients::EmulatedProteusClient>> = vec![
-        ios_client.clone(),
-        native_client.clone(),
-        ffi_client.clone(),
-        web_client.clone(),
-        cryptobox_native_client.clone(),
-        cryptobox_web_client.clone(),
-    ];
+    for client in &mut clients {
+        client.init().await?;
+    }
 
     let configuration = MlsClientConfiguration::try_new(
         "whatever".into(),
@@ -433,32 +425,9 @@ async fn run_proteus_test(chrome_driver_addr: &std::net::SocketAddr, web_server:
     ));
 
     let spinner = util::RunningProcess::new("[Proteus] Step 4: Deleting clients...", true);
-
-    Rc::into_inner(ios_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(native_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(ffi_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(web_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(cryptobox_native_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-    Rc::into_inner(cryptobox_web_client)
-        .expect("Only one strong reference to the interop client")
-        .wipe()
-        .await?;
-
+    for client in &mut clients {
+        client.wipe().await?;
+    }
     spinner.success("[Proteus] Step 4: Deleting clients [OK]");
 
     Ok(())


### PR DESCRIPTION
This PR

- refactors the interop client setup a bit
- disables the iOS client on non-Mac platforms so we can run interop again on Windows and Linux
- drops femme in favor of env_logger

The last point also addresses the large output issue when running interop on CI. In that sense this PR obsoletes https://github.com/wireapp/core-crypto/pull/939.