### PR TITLE
refactor(test): use test conversation (1/2) [WPB-15788]

### DIFF
--- a/crypto/src/mls/conversation/commit.rs
+++ b/crypto/src/mls/conversation/commit.rs
@@ -298,7 +298,8 @@ mod tests {
                     .unwrap();
 
                 let welcome = alice_central
-                    .mls_transport
+                    .mls_transport()
+                    .await
                     .latest_commit_bundle()
                     .await
                     .welcome
@@ -335,7 +336,7 @@ mod tests {
                     .add_members(vec![bob])
                     .await
                     .unwrap();
-                let commit_bundle = alice_central.mls_transport.latest_commit_bundle().await;
+                let commit_bundle = alice_central.mls_transport().await.latest_commit_bundle().await;
                 let group_info = commit_bundle.group_info.get_group_info();
 
                 assert!(
@@ -374,7 +375,8 @@ mod tests {
                     .remove_members(&[bob_central.get_client_id().await])
                     .await
                     .unwrap();
-                let MlsCommitBundle { commit, welcome, .. } = alice_central.mls_transport.latest_commit_bundle().await;
+                let MlsCommitBundle { commit, welcome, .. } =
+                    alice_central.mls_transport().await.latest_commit_bundle().await;
                 assert!(welcome.is_none());
 
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
@@ -436,7 +438,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let welcome = alice_central.mls_transport.latest_welcome_message().await;
+                let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
 
                 assert!(
                     guest_central
@@ -473,7 +475,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let commit_bundle = alice_central.mls_transport.latest_commit_bundle().await;
+                let commit_bundle = alice_central.mls_transport().await.latest_commit_bundle().await;
 
                 let group_info = commit_bundle.group_info.get_group_info();
 
@@ -533,7 +535,8 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let MlsCommitBundle { commit, welcome, .. } = alice_central.mls_transport.latest_commit_bundle().await;
+                let MlsCommitBundle { commit, welcome, .. } =
+                    alice_central.mls_transport().await.latest_commit_bundle().await;
                 assert!(welcome.is_none());
 
                 assert!(
@@ -645,7 +648,8 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let MlsCommitBundle { commit, welcome, .. } = alice_central.mls_transport.latest_commit_bundle().await;
+                let MlsCommitBundle { commit, welcome, .. } =
+                    alice_central.mls_transport().await.latest_commit_bundle().await;
                 assert!(welcome.is_some());
                 assert!(
                     !alice_central
@@ -736,7 +740,8 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let MlsCommitBundle { commit, welcome, .. } = alice_central.mls_transport.latest_commit_bundle().await;
+                let MlsCommitBundle { commit, welcome, .. } =
+                    alice_central.mls_transport().await.latest_commit_bundle().await;
 
                 bob_central
                     .transaction
@@ -783,7 +788,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let group_info = alice_central.mls_transport.latest_group_info().await;
+                let group_info = alice_central.mls_transport().await.latest_group_info().await;
                 let group_info = group_info.get_group_info();
 
                 assert!(
@@ -828,7 +833,7 @@ mod tests {
                     .unwrap();
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
-                let welcome = alice_central.mls_transport.latest_commit_bundle().await.welcome;
+                let welcome = alice_central.mls_transport().await.latest_commit_bundle().await.welcome;
                 bob_central
                     .transaction
                     .process_welcome_message(welcome.unwrap().into(), case.custom_cfg())
@@ -875,7 +880,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit_bundle().await.commit;
+                let commit = alice_central.mls_transport().await.latest_commit_bundle().await.commit;
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
                 bob_central
@@ -917,7 +922,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let welcome = alice_central.mls_transport.latest_commit_bundle().await.welcome;
+                let welcome = alice_central.mls_transport().await.latest_commit_bundle().await.welcome;
 
                 bob_central
                     .transaction
@@ -953,7 +958,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit_bundle = alice_central.mls_transport.latest_commit_bundle().await;
+                let commit_bundle = alice_central.mls_transport().await.latest_commit_bundle().await;
                 let group_info = commit_bundle.group_info.get_group_info();
 
                 assert!(
@@ -991,7 +996,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit1 = alice_central.mls_transport.latest_commit().await;
+                let commit1 = alice_central.mls_transport().await.latest_commit().await;
                 let commit1 = commit1.to_bytes().unwrap();
                 alice_central
                     .transaction
@@ -1001,7 +1006,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit2 = alice_central.mls_transport.latest_commit().await;
+                let commit2 = alice_central.mls_transport().await.latest_commit().await;
                 let commit2 = commit2.to_bytes().unwrap();
 
                 // fails when a commit is skipped
@@ -1076,7 +1081,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit1 = alice_central.mls_transport.latest_commit().await;
+                let commit1 = alice_central.mls_transport().await.latest_commit().await;
                 let commit2 = commit1.clone();
 
                 // replayed encrypted proposal should fail

--- a/crypto/src/mls/conversation/commit_delay.rs
+++ b/crypto/src/mls/conversation/commit_delay.rs
@@ -185,7 +185,7 @@ mod tests {
                 .add_members(vec![bob])
                 .await
                 .unwrap();
-            let bob_welcome = alice_central.mls_transport.latest_welcome_message().await;
+            let bob_welcome = alice_central.mls_transport().await.latest_welcome_message().await;
             assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
             bob_central
@@ -203,7 +203,7 @@ mod tests {
                 .add_members(vec![charlie])
                 .await
                 .unwrap();
-            let charlie_welcome_bundle = alice_central.mls_transport.latest_commit_bundle().await;
+            let charlie_welcome_bundle = alice_central.mls_transport().await.latest_commit_bundle().await;
             assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
             let _ = bob_central

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/buffer_messages.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/buffer_messages.rs
@@ -234,7 +234,7 @@ mod tests {
                 .add_members(vec![charlie])
                 .await
                 .unwrap();
-            let commit = alice_central.mls_transport.latest_commit_bundle().await;
+            let commit = alice_central.mls_transport().await.latest_commit_bundle().await;
             charlie_central
                 .transaction
                 .process_welcome_message(commit.welcome.clone().unwrap().into(), case.custom_cfg())
@@ -351,7 +351,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let ext_commit = bob_central.mls_transport.latest_commit_bundle().await;
+            let ext_commit = bob_central.mls_transport().await.latest_commit_bundle().await;
 
             // And before others had the chance to get the commit, Bob will create & send messages in the next epoch
             // which Alice will have to buffer until she receives the commit.
@@ -388,7 +388,7 @@ mod tests {
                 .add_members(vec![debbie])
                 .await
                 .unwrap();
-            let commit = bob_central.mls_transport.latest_commit_bundle().await;
+            let commit = bob_central.mls_transport().await.latest_commit_bundle().await;
             charlie_central
                 .transaction
                 .process_welcome_message(commit.welcome.clone().unwrap().into(), case.custom_cfg())
@@ -680,7 +680,7 @@ mod tests {
                 .commit_pending_proposals()
                 .await
                 .unwrap();
-            let remove_two_members_commit = member_27.mls_transport.latest_commit().await;
+            let remove_two_members_commit = member_27.mls_transport().await.latest_commit().await;
 
             // In this case, note that observer receives the proposal before the commit.
             // This is the straightforward ordering and easy to deal with.

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -578,7 +578,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let MlsConversationDecryptMessage { is_active, .. } = alice_central
                     .transaction
                     .conversation(&id)
@@ -613,7 +613,7 @@ mod tests {
                     .remove_members(&[alice_central.get_client_id().await])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let MlsConversationDecryptMessage { is_active, .. } = alice_central
                     .transaction
                     .conversation(&id)
@@ -662,7 +662,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
 
                 let decrypted = bob_central
                     .transaction
@@ -730,7 +730,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let MlsConversationDecryptMessage { proposals, delay, .. } = alice_central
                     .transaction
                     .conversation(&id)
@@ -780,7 +780,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let bob_commit = bob_central.mls_transport.latest_commit().await;
+                let bob_commit = bob_central.mls_transport().await.latest_commit().await;
                 let commit_epoch = bob_commit.epoch().unwrap();
 
                 // Alice propose to add Charlie
@@ -843,7 +843,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let _decrypted = alice_central
                     .transaction
                     .conversation(&id)
@@ -920,7 +920,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let alice_renewed_proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -957,7 +957,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
 
                 let sender_client_id = bob_central
                     .transaction
@@ -1266,7 +1266,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
 
                 // Now in epoch 2 Alice will encrypt a message
                 let msg = b"Hello bob";
@@ -1446,7 +1446,7 @@ mod tests {
                         .update_key_material()
                         .await
                         .unwrap();
-                    let commit = alice_central.mls_transport.latest_commit().await;
+                    let commit = alice_central.mls_transport().await.latest_commit().await;
                     bob_central
                         .transaction
                         .conversation(&id)
@@ -1476,7 +1476,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
                 bob_central
                     .transaction
                     .conversation(&id)
@@ -1551,7 +1551,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
                 bob_central
                     .transaction
                     .conversation(&id)

--- a/crypto/src/mls/conversation/duplicate.rs
+++ b/crypto/src/mls/conversation/duplicate.rs
@@ -86,7 +86,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
 
                 // decrypt once ... ok
                 bob_central
@@ -148,7 +148,7 @@ mod tests {
                 .join_by_external_commit(gi, case.custom_cfg(), case.credential_type)
                 .await
                 .unwrap();
-            let ext_commit = bob_central.mls_transport.latest_commit().await;
+            let ext_commit = bob_central.mls_transport().await.latest_commit().await;
 
             // decrypt once ... ok
             alice_central

--- a/crypto/src/mls/conversation/leaf_node_validation.rs
+++ b/crypto/src/mls/conversation/leaf_node_validation.rs
@@ -174,7 +174,7 @@ mod tests {
                     .add_members(vec![invalid_kp.into()])
                     .await
                     .unwrap();
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
                 let commit = commit.to_bytes().unwrap();
 
                 let elapsed = start.elapsed();
@@ -240,7 +240,12 @@ mod tests {
                 let process_welcome = bob_central
                     .transaction
                     .process_welcome_message(
-                        alice_central.mls_transport.latest_welcome_message().await.into(),
+                        alice_central
+                            .mls_transport()
+                            .await
+                            .latest_welcome_message()
+                            .await
+                            .into(),
                         case.custom_cfg(),
                     )
                     .await;

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -584,7 +584,7 @@ mod tests {
             );
             assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
-            let welcome = alice_central.mls_transport.latest_welcome_message().await;
+            let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
             bob_central
                 .transaction
                 .process_welcome_message(welcome.into(), case.custom_cfg())
@@ -628,7 +628,7 @@ mod tests {
                 .add_members(bob_and_friends_kps)
                 .await
                 .unwrap();
-            let welcome = alice_central.mls_transport.latest_welcome_message().await;
+            let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
 
             assert_eq!(alice_central.get_conversation_unchecked(&id).await.id, id);
             assert_eq!(

--- a/crypto/src/mls/conversation/orphan_welcome.rs
+++ b/crypto/src/mls/conversation/orphan_welcome.rs
@@ -45,7 +45,7 @@ mod tests {
                 // ...Bob deletes locally (with the associated private key) before processing the Welcome
                 bob_central.transaction.delete_keypackages(&[bob_kp_ref]).await.unwrap();
 
-                let welcome = alice_central.mls_transport.latest_welcome_message().await;
+                let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
 
                 // in that case a dedicated error is thrown for clients to identify this case
                 // and rejoin with an external commit

--- a/crypto/src/mls/conversation/pending_conversation.rs
+++ b/crypto/src/mls/conversation/pending_conversation.rs
@@ -386,7 +386,7 @@ mod tests {
                 .add_members(vec![charlie])
                 .await
                 .unwrap();
-            let commit = alice_central.mls_transport.latest_commit_bundle().await;
+            let commit = alice_central.mls_transport().await.latest_commit_bundle().await;
             charlie_central
                 .transaction
                 .process_welcome_message(commit.welcome.clone().unwrap().into(), case.custom_cfg())
@@ -543,7 +543,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let ext_commit = alice_central.mls_transport.latest_commit_bundle().await;
+            let ext_commit = alice_central.mls_transport().await.latest_commit_bundle().await;
 
             bob_central
                 .transaction

--- a/crypto/src/mls/conversation/proposal.rs
+++ b/crypto/src/mls/conversation/proposal.rs
@@ -209,8 +209,8 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
-                let welcome = bob_central.mls_transport.latest_welcome_message().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
+                let welcome = bob_central.mls_transport().await.latest_welcome_message().await;
                 assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 3);
 
                 // if 'new_proposal' wasn't durable this would fail because proposal would
@@ -283,7 +283,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
                 // if 'new_proposal' wasn't durable this would fail because proposal would
@@ -355,7 +355,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
 
                 assert!(
                     !bob_central

--- a/crypto/src/mls/conversation/renew.rs
+++ b/crypto/src/mls/conversation/renew.rs
@@ -200,7 +200,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
 
                 let proposals = alice_central
                     .transaction
@@ -224,7 +224,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -282,7 +282,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
 
                 // Bob's commit has Alice's proposal
                 let proposals = alice_central
@@ -320,7 +320,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -374,7 +374,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = charlie_central.mls_transport.latest_commit().await;
+                let commit = charlie_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -426,7 +426,7 @@ mod tests {
                     .add_members(vec![charlie])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -478,7 +478,7 @@ mod tests {
                     .add_members(vec![charlie])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -538,7 +538,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = charlie_central.mls_transport.latest_commit().await;
+                let commit = charlie_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -587,7 +587,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -612,7 +612,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -656,7 +656,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -709,7 +709,7 @@ mod tests {
                     .remove_members(&[charlie_central.get_client_id().await])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -767,7 +767,7 @@ mod tests {
                     .update_key_material()
                     .await
                     .unwrap();
-                let commit = charlie_central.mls_transport.latest_commit().await;
+                let commit = charlie_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -818,7 +818,7 @@ mod tests {
                     .remove_members(&[debbie_central.get_client_id().await])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -869,7 +869,7 @@ mod tests {
                     .remove_members(&[debbie_central.get_client_id().await])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)
@@ -919,7 +919,7 @@ mod tests {
                     .remove_members(&[debbie_central.get_client_id().await])
                     .await
                     .unwrap();
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
                 let proposals = alice_central
                     .transaction
                     .conversation(&id)

--- a/crypto/src/test_utils/context.rs
+++ b/crypto/src/test_utils/context.rs
@@ -206,7 +206,7 @@ impl SessionContext {
             .add_members(key_packages)
             .await
             .map_err(RecursiveError::mls_conversation("adding members"))?;
-        let welcome = self.mls_transport.latest_commit_bundle().await.welcome.unwrap();
+        let welcome = self.mls_transport().await.latest_commit_bundle().await.welcome.unwrap();
 
         for other in &others {
             other
@@ -249,7 +249,7 @@ impl SessionContext {
             .await
             .map_err(RecursiveError::transaction("joining by external commit"))?;
 
-        let commit = self.mls_transport.latest_commit().await;
+        let commit = self.mls_transport().await.latest_commit().await;
 
         assert_eq!(conversation_id.as_slice(), id.as_slice());
         for other in others {
@@ -558,7 +558,7 @@ impl SessionContext {
                 .e2ei_rotate(None)
                 .await
                 .map_err(RecursiveError::mls_conversation("e2ei rotating"))?;
-            let commit = self.mls_transport.latest_commit_bundle().await;
+            let commit = self.mls_transport().await.latest_commit_bundle().await;
             conversation_ids_and_commits.push((id, commit));
         }
         let new_key_packages = self

--- a/crypto/src/test_utils/test_context.rs
+++ b/crypto/src/test_utils/test_context.rs
@@ -327,11 +327,15 @@ impl TestContext {
             .next()
             .expect("each conversation needs at least 1 member, the creator");
 
-        let mut conversation = TestConversation::new(self, creator).await;
+        let conversation = TestConversation::new(self, creator).await;
 
-        conversation.invite(members).await;
+        // if members are empty, return early here
+        let mut members = members.peekable();
+        if members.peek().is_none() {
+            return conversation;
+        }
 
-        conversation
+        conversation.invite(members).await
     }
 }
 

--- a/crypto/src/test_utils/test_conversation.rs
+++ b/crypto/src/test_utils/test_conversation.rs
@@ -14,8 +14,7 @@ pub struct TestConversation<'a> {
     pub(crate) case: &'a TestContext,
     #[as_ref]
     pub(crate) id: ConversationId,
-    pub(crate) creator: &'a SessionContext,
-    pub(crate) joiners: Vec<&'a SessionContext>,
+    pub(crate) members: Vec<&'a SessionContext>,
 }
 
 impl<'a> TestConversation<'a> {
@@ -30,8 +29,7 @@ impl<'a> TestConversation<'a> {
         Self {
             case,
             id,
-            creator,
-            joiners: Vec::new(),
+            members: vec![creator],
         }
     }
 
@@ -46,50 +44,45 @@ impl<'a> TestConversation<'a> {
     }
 
     pub async fn invite(&'a mut self, sessions: impl IntoIterator<Item = &'a SessionContext>) -> CommitGuard<'a> {
-        let idx_of_first_new_member = self.joiners.len();
-        let sessions = sessions.into_iter();
-        let (lower_bound, _) = sessions.size_hint();
-        self.joiners.reserve(lower_bound);
-        self.joiners.extend(sessions);
-        let new_members = &self.joiners[idx_of_first_new_member..];
-        let new_members_iter = new_members.iter();
-        let (lower_bound, _) = new_members_iter.size_hint();
+        let new_members = sessions.into_iter().collect::<Vec<_>>();
 
-        let mut key_packages = Vec::with_capacity(lower_bound);
-        for cc in new_members_iter {
-            let kp = cc.rand_key_package(self.case).await;
-            key_packages.push(kp);
-        }
+        let key_packages =
+            futures_util::future::join_all(new_members.iter().map(|cc| cc.rand_key_package(self.case))).await;
         self.guard().await.add_members(key_packages).await.unwrap();
         let welcome = self.transport().latest_commit_bundle().await.welcome.unwrap();
         let commit = self.transport().latest_commit_bundle().await.commit;
-        let existing_members = self.joiners[..idx_of_first_new_member].to_vec();
         CommitGuard {
             conversation: self,
-            members_to_notify: existing_members,
-            committer: self.creator,
+            committed_operation: CommittedOperation::Add(AddGuard {
+                committer_index: 0,
+                new_members,
+                welcome_message: welcome,
+            }),
             commit,
-            invited_members: Some((new_members.to_vec(), welcome)),
         }
+    }
+
+    pub fn creator(&self) -> &SessionContext {
+        self.members[0]
     }
 
     /// All members of this conversation.
     ///
-    /// The creator is always the first member returned.
+    /// The creator is always the first member returned (if they're still a member).
     pub fn members(&self) -> impl Iterator<Item = &SessionContext> {
-        std::iter::once(self.creator).chain(self.joiners.iter().copied())
+        self.members.iter().copied()
     }
 
     /// Convenience function to get the mls transport of the creator.
     pub fn transport(&self) -> Arc<dyn MlsTransportTestExt> {
-        self.creator.mls_transport.clone()
+        self.creator().mls_transport.clone()
     }
 
     /// Convenience function to get the conversation guard of this conversation.
     ///
     /// The guard belongs to the creator of the conversation.
     pub async fn guard(&self) -> ConversationGuard {
-        self.creator.transaction.conversation(&self.id).await.unwrap()
+        self.creator().transaction.conversation(&self.id).await.unwrap()
     }
 
     /// Remove this member from this conversation.
@@ -99,9 +92,14 @@ impl<'a> TestConversation<'a> {
     /// Panics if you try to remove the conversation creator; use a different abstraction if you are testing that case.
     /// Panics if you try to remove someone who is not a current member.
     pub async fn remove(&mut self, member_id: &ClientId) -> &'a SessionContext {
+        assert_ne!(
+            &self.creator().session.id().await.unwrap(),
+            member_id,
+            "cannot remove the creator via this API because we're acting on the creators behalf."
+        );
         // can't use `Iterator::position` because getting the id is async
         let mut joiner_idx = None;
-        for (idx, joiner) in self.joiners.iter().enumerate() {
+        for (idx, joiner) in self.members.iter().enumerate() {
             let joiner_id = joiner.session.id().await.unwrap();
             if joiner_id == *member_id {
                 joiner_idx = Some(idx);
@@ -111,7 +109,7 @@ impl<'a> TestConversation<'a> {
 
         // if we didn't find it, return early instead of trying to apply that removal to the conversation
         let removed = joiner_idx
-            .map(|idx| self.joiners.swap_remove(idx))
+            .map(|idx| self.members.swap_remove(idx))
             .expect("could find the member to remove among the joiners of this conversation");
 
         // removing the member here removes it from the creator and also produces a commit
@@ -123,7 +121,7 @@ impl<'a> TestConversation<'a> {
         let commit = self.transport().latest_commit().await.to_bytes().unwrap();
 
         // we already removed the member from the joined members of our conversation, so chain it in
-        for joiner in std::iter::once(removed).chain(self.joiners.iter().copied()) {
+        for joiner in std::iter::once(removed).chain(self.members.iter().copied()) {
             joiner
                 .transaction
                 .conversation(&self.id)
@@ -144,21 +142,52 @@ impl<'a> TestConversation<'a> {
 /// To notify all existing members of the conversation, call [`Self::notify_existing_members`].
 /// Otherwise, use the struct members to do things manually.
 pub struct CommitGuard<'a> {
-    conversation: &'a TestConversation<'a>,
-    pub(crate) members_to_notify: Vec<&'a SessionContext>,
-    // this is dead code for now, but we expect to use it in the relatively near future
-    // once we start using this in tests. At that point, remove the annotation.
-    #[expect(dead_code)]
-    pub(crate) committer: &'a SessionContext,
+    conversation: &'a mut TestConversation<'a>,
+    /// The member at this index won't be included in the list of [Self::members_to_notify]
+    committed_operation: CommittedOperation<'a>,
     pub(crate) commit: MlsMessageOut,
-    /// In case someone was invited to this group, there will be a welcome message.
-    pub(crate) invited_members: Option<(Vec<&'a SessionContext>, MlsMessageOut)>,
 }
 
-impl CommitGuard<'_> {
+struct AddGuard<'a> {
+    committer_index: usize,
+    new_members: Vec<&'a SessionContext>,
+    welcome_message: MlsMessageOut,
+}
+
+/// Keeps state about the comitted operation that will be used when the
+/// corresponding [CommitGuard] is used to (notify members)[CommitGuard::notify_members].
+#[expect(clippy::large_enum_variant)]
+enum CommittedOperation<'a> {
+    /// The member with the provided index won't be notified, new members will be
+    /// added to the member list of the test conversation
+    Add(AddGuard<'a>),
+    /// All existing members will be notified, the new joiner will be added to the
+    /// member list of the conversation.
+    ExternalJoin(&'a SessionContext),
+}
+
+impl<'a> CommitGuard<'a> {
+    fn members_to_notify(&self) -> Box<dyn Iterator<Item = &'a SessionContext> + '_> {
+        if let CommittedOperation::Add(AddGuard {
+            committer_index: skipped_index,
+            ..
+        }) = self.committed_operation
+        {
+            Box::new(
+                self.conversation
+                    .members
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(idx, member)| (idx != skipped_index).then_some(*member)),
+            )
+        } else {
+            Box::new(self.conversation.members.iter().copied())
+        }
+    }
+
     pub async fn notify_members(self) {
         let message_bytes = self.commit.to_bytes().unwrap();
-        for member in self.members_to_notify {
+        for member in self.members_to_notify() {
             member
                 .transaction
                 .conversation(&self.conversation.id)
@@ -169,12 +198,28 @@ impl CommitGuard<'_> {
                 .unwrap();
         }
 
-        if let Some((invited_members, welcome_message)) = self.invited_members {
-            for new_member in invited_members {
-                new_member
-                    .transaction
-                    .process_welcome_message(welcome_message.clone().into(), self.conversation.case.custom_cfg())
-                    .await;
+        // In case of an external join or an add operation, update the member list
+        // of the test conversation.
+        match self.committed_operation {
+            CommittedOperation::ExternalJoin(joiner) => {
+                self.conversation.members.push(joiner);
+            }
+            CommittedOperation::Add(AddGuard {
+                new_members: invited_members,
+                welcome_message,
+                ..
+            }) => {
+                // Process welcome message on receiver side
+                for new_member in invited_members.iter() {
+                    new_member
+                        .transaction
+                        .process_welcome_message(welcome_message.clone().into(), self.conversation.case.custom_cfg())
+                        .await
+                        .unwrap();
+                }
+                // Then update the member list
+                self.conversation.members.reserve(invited_members.len());
+                self.conversation.members.extend(invited_members);
             }
         }
     }
@@ -184,10 +229,10 @@ impl<'a> TestConversation<'a> {
     /// The supplied session joins this conversation by external commit.
     ///
     /// This does _not_ distribute the external commit to the existing members. To do that,
-    /// use the [`notify_existing_members` method][ExternalJoinGuard::notify_existing_members] of
+    /// use the [`notify_existing_members` method][CommitGuard::notify_members] of
     /// the returned item.
     pub async fn external_join(&'a mut self, joiner: &'a SessionContext) -> CommitGuard<'a> {
-        let group_info = self.creator.get_group_info(&self.id).await;
+        let group_info = self.creator().get_group_info(&self.id).await;
         joiner
             .transaction
             .join_by_external_commit(group_info, self.case.custom_cfg(), self.case.credential_type)
@@ -195,18 +240,10 @@ impl<'a> TestConversation<'a> {
             .unwrap();
         let join_commit = joiner.mls_transport.latest_commit().await;
 
-        let mut previous_conversation_members = Vec::with_capacity(self.joiners.len() + 1);
-        previous_conversation_members.push(self.creator);
-        previous_conversation_members.extend(self.joiners.iter().copied());
-
-        self.joiners.push(joiner);
-
         CommitGuard {
             conversation: self,
-            members_to_notify: previous_conversation_members,
-            committer: joiner,
+            committed_operation: CommittedOperation::ExternalJoin(joiner),
             commit: join_commit,
-            invited_members: None,
         }
     }
 }

--- a/crypto/src/transaction_context/conversation/external_commit.rs
+++ b/crypto/src/transaction_context/conversation/external_commit.rs
@@ -267,7 +267,7 @@ mod tests {
             assert!(bob_central.transaction.conversation(&id).await.is_ok());
             assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
-            let external_commit = bob_central.mls_transport.latest_commit().await;
+            let external_commit = bob_central.mls_transport().await.latest_commit().await;
             // Alice decrypts the external commit and adds Bob
             assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
             alice_central
@@ -307,7 +307,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let external_commit = bob_central.mls_transport.latest_commit().await;
+            let external_commit = bob_central.mls_transport().await.latest_commit().await;
 
             // Alice creates a new commit before receiving the external join
             alice_central
@@ -395,7 +395,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let bob_external_commit = bob_central.mls_transport.latest_commit().await;
+            let bob_external_commit = bob_central.mls_transport().await.latest_commit().await;
             assert!(bob_central.transaction.conversation(&id).await.is_ok());
             assert_eq!(bob_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
@@ -412,7 +412,7 @@ mod tests {
             assert!(alice_central.try_talk_to(&id, &bob_central).await.is_ok());
 
             // Now charlie wants to join with the [GroupInfo] from Bob's external commit
-            let group_info = bob_central.mls_transport.latest_group_info().await;
+            let group_info = bob_central.mls_transport().await.latest_group_info().await;
             let bob_gi = group_info.get_group_info();
             charlie_central
                 .transaction
@@ -420,7 +420,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let charlie_external_commit = charlie_central.mls_transport.latest_commit().await;
+            let charlie_external_commit = charlie_central.mls_transport().await.latest_commit().await;
 
             // Both Alice & Bob decrypt the commit
             alice_central
@@ -550,7 +550,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let welcome = alice_central.mls_transport.latest_welcome_message().await;
+                let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
                 // erroneous call
                 let conflict_welcome = bob_central
                     .transaction

--- a/crypto/src/transaction_context/conversation/external_proposal.rs
+++ b/crypto/src/transaction_context/conversation/external_proposal.rs
@@ -140,7 +140,7 @@ mod tests {
                 // guest joined the group
                 assert_eq!(owner_central.get_conversation_unchecked(&id).await.members().len(), 2);
 
-                let welcome = guest_central.mls_transport.latest_welcome_message().await;
+                let welcome = guest_central.mls_transport().await.latest_welcome_message().await;
                 guest_central
                     .transaction
                     .process_welcome_message(welcome.into(), case.custom_cfg())
@@ -218,7 +218,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = owner.mls_transport.latest_commit().await;
+                let commit = owner.mls_transport().await.latest_commit().await;
 
                 assert_eq!(owner.get_conversation_unchecked(&id).await.members().len(), 1);
 
@@ -418,8 +418,8 @@ mod tests {
                     .add_members(vec![charlie_kp])
                     .await
                     .unwrap();
-                let welcome = alice.mls_transport.latest_welcome_message().await;
-                let commit = alice.mls_transport.latest_commit().await;
+                let welcome = alice.mls_transport().await.latest_welcome_message().await;
+                let commit = alice.mls_transport().await.latest_commit().await;
                 bob_central
                     .conversation(&id)
                     .await
@@ -479,7 +479,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let commit = charlie.mls_transport.latest_commit().await;
+                let commit = charlie.mls_transport().await.latest_commit().await;
                 assert_eq!(charlie.get_conversation_unchecked(&id).await.members().len(), 2);
 
                 alice_central
@@ -535,7 +535,7 @@ mod tests {
                     .join_by_external_commit(public_group_state, case.custom_cfg(), case.credential_type)
                     .await
                     .unwrap();
-                let commit = charlie.mls_transport.latest_commit().await;
+                let commit = charlie.mls_transport().await.latest_commit().await;
 
                 // Purposely have a configuration without `external_senders`
                 alice_central
@@ -602,7 +602,7 @@ mod tests {
                     .unwrap();
                 assert_eq!(charlie.get_conversation_unchecked(&id).await.members().len(), 2);
 
-                let commit = charlie.mls_transport.latest_commit().await;
+                let commit = charlie.mls_transport().await.latest_commit().await;
                 alice_central
                     .conversation(&id)
                     .await

--- a/crypto/src/transaction_context/conversation/proposal.rs
+++ b/crypto/src/transaction_context/conversation/proposal.rs
@@ -102,7 +102,7 @@ mod tests {
                     .commit_pending_proposals()
                     .await
                     .unwrap();
-                let welcome = alice_central.mls_transport.latest_welcome_message().await;
+                let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 2);
                 let new_id = bob_central
                     .transaction
@@ -197,7 +197,7 @@ mod tests {
                     .unwrap();
                 assert_eq!(alice_central.get_conversation_unchecked(&id).await.members().len(), 1);
 
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
                 bob_central
                     .transaction
                     .conversation(&id)

--- a/crypto/src/transaction_context/conversation/welcome.rs
+++ b/crypto/src/transaction_context/conversation/welcome.rs
@@ -134,7 +134,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let welcome = alice_central.mls_transport.latest_welcome_message().await;
+            let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
             // Bob accepts the welcome message, and as such, it should prune the used keypackage from the store
             bob_central
                 .transaction
@@ -174,7 +174,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let welcome = alice_central.mls_transport.latest_welcome_message().await;
+                let welcome = alice_central.mls_transport().await.latest_welcome_message().await;
                 // Meanwhile Bob creates a conversation with the exact same id as the one he's trying to join
                 bob_central
                     .transaction

--- a/crypto/src/transaction_context/e2e_identity/conversation_state.rs
+++ b/crypto/src/transaction_context/e2e_identity/conversation_state.rs
@@ -294,7 +294,7 @@ mod tests {
                 .e2ei_rotate(Some(&cb))
                 .await
                 .unwrap();
-            let commit = alice_central.mls_transport.latest_commit().await;
+            let commit = alice_central.mls_transport().await.latest_commit().await;
             bob_central
                 .transaction
                 .conversation(&id)

--- a/crypto/src/transaction_context/e2e_identity/rotate.rs
+++ b/crypto/src/transaction_context/e2e_identity/rotate.rs
@@ -683,7 +683,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let commit = alice_central.mls_transport.latest_commit().await;
+                let commit = alice_central.mls_transport().await.latest_commit().await;
 
                 let decrypted = bob_central
                     .transaction
@@ -762,7 +762,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                let commit = bob_central.mls_transport.latest_commit().await;
+                let commit = bob_central.mls_transport().await.latest_commit().await;
 
                 let decrypted = alice_central
                     .transaction
@@ -841,7 +841,7 @@ mod tests {
                         .e2ei_rotate(Some(&cb))
                         .await
                         .unwrap();
-                    let commit = alice_central.mls_transport.latest_commit().await;
+                    let commit = alice_central.mls_transport().await.latest_commit().await;
 
                     // Bob decrypts the commit...
                     let decrypted = bob_central
@@ -918,7 +918,7 @@ mod tests {
                     .await
                     .unwrap();
                 // accepted by the backend
-                let bob_commit = bob_central.mls_transport.latest_commit().await;
+                let bob_commit = bob_central.mls_transport().await.latest_commit().await;
 
                 // Alice decrypts the commit...
                 let decrypted = alice_central
@@ -956,7 +956,7 @@ mod tests {
                     .verify_local_credential_rotated(&id, new_handle, new_display_name)
                     .await;
 
-                let rotate_commit = alice_central.mls_transport.latest_commit().await;
+                let rotate_commit = alice_central.mls_transport().await.latest_commit().await;
                 // Bob verifies that now Alice is represented with her new identity
                 let decrypted = bob_central
                     .transaction
@@ -1026,7 +1026,7 @@ mod tests {
                         .e2ei_rotate(None)
                         .await
                         .unwrap();
-                    let commit = alice_central.mls_transport.latest_commit().await;
+                    let commit = alice_central.mls_transport().await.latest_commit().await;
 
                     // Bob decrypts the commit...
                     let decrypted = bob_central


### PR DESCRIPTION
# What's new in this PR
This PR First, adds necessary features to the test conversaiton before starting to introduce test conversation usage into tests. 
This is the first of two PRs, to avoid piling up too many changes in a single PR.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
