### PR TITLE
chore: ci: run `cargo check` and clippy for all targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,26 +24,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool:
-          - name: fmt
-            trailer: --all -- --check
-          - name: clippy --locked
-          - name: clippy --locked
-            trailer: --tests
-          - name: check --locked
-            trailer: --tests
-        target: ["", "--target wasm32-unknown-unknown"]
-        exclude:
-          - {tool: {name: fmt},
-             target: "--target wasm32-unknown-unknown"}
-
+        command:
+          - cargo fmt --all -- --check
+          - cargo check --locked --all-targets
+          - cargo check --locked --target wasm32-unknown-unknown
+          - cargo clippy --locked --all-targets
+          - cargo clippy --locked --target wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-and-cache-rust
         with:
           components: rustfmt, clippy
           target: wasm32-unknown-unknown
-      - run: cargo ${{ matrix.tool.name }} ${{ matrix.target }} ${{ matrix.tool.trailer }}
+      - run: ${{ matrix.command }}
 
   test:
     runs-on: ubuntu-latest

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -30,7 +30,6 @@ fn commit_add_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         black_box(context.conversation(&id).await.unwrap().add_members(kps).await.unwrap());
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::LargeInput,
                 )
@@ -62,7 +61,6 @@ fn commit_add_n_clients_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         black_box(context.conversation(&id).await.unwrap().add_members(kps).await.unwrap());
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -89,6 +87,7 @@ fn commit_remove_bench(c: &mut Criterion) {
                     },
                     |(central, id, client_ids)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -99,7 +98,6 @@ fn commit_remove_bench(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -127,6 +125,7 @@ fn commit_remove_n_clients_bench(c: &mut Criterion) {
                     },
                     |(central, id, client_ids)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -137,7 +136,6 @@ fn commit_remove_n_clients_bench(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -163,6 +161,7 @@ fn commit_update_bench(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -173,7 +172,6 @@ fn commit_update_bench(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -208,6 +206,7 @@ fn commit_pending_proposals_bench_var_n_proposals(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -218,7 +217,6 @@ fn commit_pending_proposals_bench_var_n_proposals(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -251,6 +249,7 @@ fn commit_pending_proposals_bench_var_group_size(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -261,7 +260,6 @@ fn commit_pending_proposals_bench_var_group_size(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )

--- a/crypto/benches/mls_proteus.rs
+++ b/crypto/benches/mls_proteus.rs
@@ -126,7 +126,6 @@ fn add_client_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         black_box(context.conversation(&id).await.unwrap().add_members(kps).await.unwrap());
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -181,6 +180,7 @@ fn remove_client_bench(c: &mut Criterion) {
                     },
                     |(central, id, client_ids)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -191,7 +191,6 @@ fn remove_client_bench(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -221,7 +220,6 @@ fn remove_client_bench(c: &mut Criterion) {
                         let context = central.new_transaction().await.unwrap();
                         for (session_id, _) in session_material {
                             context.proteus_session_delete(&session_id).await.unwrap();
-                            black_box(());
                         }
                         context.finish().await.unwrap();
                     },
@@ -250,6 +248,7 @@ fn update_client_bench(c: &mut Criterion) {
                     },
                     |(central, id)| async move {
                         let context = central.new_transaction().await.unwrap();
+                        #[allow(clippy::unit_arg)]
                         black_box(
                             context
                                 .conversation(&id)
@@ -260,7 +259,6 @@ fn update_client_bench(c: &mut Criterion) {
                                 .unwrap(),
                         );
                         context.finish().await.unwrap();
-                        black_box(());
                     },
                     BatchSize::SmallInput,
                 )
@@ -297,7 +295,6 @@ fn update_client_bench(c: &mut Criterion) {
                         for (session_id, _) in session_material {
                             // replace existing session
                             context.proteus_session_delete(&session_id).await.unwrap();
-                            black_box(());
                             black_box(
                                 context
                                     .proteus_session_from_prekey(&session_id, &new_pkb)


### PR DESCRIPTION
Here targets refer to cargo targets: binaries, tests, benches etc.