### PR TITLE
refactor!: remove 2-phase MLS init

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -92,25 +92,6 @@ export class CoreCryptoContext {
     }
 
     /**
-     * Generates a MLS KeyPair/CredentialBundle with a temporary, random client ID.
-     * This method is designed to be used in conjunction with {@link CoreCryptoContext.mlsInitWithClientId} and represents the first step in this process
-     *
-     * @param ciphersuites - All the ciphersuites supported by this MLS client
-     * @returns This returns the TLS-serialized identity key (i.e. the signature keypair's public key)
-     */
-    async mlsGenerateKeypair(
-        ciphersuites: Ciphersuite[]
-    ): Promise<Uint8Array[]> {
-        const cs = new CiphersuitesFfi(
-            Uint16Array.from(ciphersuites.map((cs) => cs.valueOf()))
-        );
-        const kps = await CoreCryptoError.asyncMapErr(
-            this.#ctx.mls_generate_keypairs(cs)
-        );
-        return kps.map((kp) => kp.as_bytes());
-    }
-
-    /**
      * Checks if the Client is member of a given conversation and if the MLS Group is loaded up
      *
      * @returns Whether the given conversation ID exists

--- a/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoContext.ts
@@ -111,30 +111,6 @@ export class CoreCryptoContext {
     }
 
     /**
-     * Updates the current temporary Client ID with the newly provided one. This is the second step in the externally-generated clients process
-     *
-     * Important: This is designed to be called after {@link CoreCryptoContext.mlsGenerateKeypair}
-     *
-     * @param clientId - The newly-allocated client ID by the MLS Authentication Service
-     * @param signaturePublicKeys - The public key you were given at the first step; This is for authentication purposes
-     * @param ciphersuites - All the ciphersuites supported by this MLS client
-     */
-    async mlsInitWithClientId(
-        clientId: ClientId,
-        signaturePublicKeys: Uint8Array[],
-        ciphersuites: Ciphersuite[]
-    ): Promise<void> {
-        const id = new ClientIdFfi(clientId);
-        const pks = signaturePublicKeys.map((pk) => new ClientIdFfi(pk));
-        const cs = new CiphersuitesFfi(
-            Uint16Array.from(ciphersuites.map((cs) => cs.valueOf()))
-        );
-        return await CoreCryptoError.asyncMapErr(
-            this.#ctx.mls_init_with_client_id(id, pks, cs)
-        );
-    }
-
-    /**
      * Checks if the Client is member of a given conversation and if the MLS Group is loaded up
      *
      * @returns Whether the given conversation ID exists

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
@@ -60,25 +60,6 @@ class CoreCryptoContext(private val cc: com.wire.crypto.uniffi.CoreCryptoContext
     }
 
     /**
-     * Updates the current temporary Client ID with the newly provided one. This is the second step
-     * in the externally-generated clients process.
-     *
-     * **Important:** This is designed to be called after [mlsGenerateKeypairs]
-     *
-     * @param clientId - The newly allocated Client ID from the MLS Authentication Service
-     * @param tmpClientIds - The random clientId you obtained in [mlsGenerateKeypairs], for
-     *   authentication purposes
-     * @param ciphersuites - All the ciphersuites supported by this MLS client
-     */
-    suspend fun mlsInitWithClientId(
-        clientId: ClientId,
-        tmpClientIds: ExternallyGeneratedHandle,
-        ciphersuites: Ciphersuites = Ciphersuites.DEFAULT,
-    ) {
-        wrapException { cc.mlsInitWithClientId(clientId.lower(), tmpClientIds.lower(), ciphersuites.lower()) }
-    }
-
-    /**
      * Get the client's public signature key. To upload to the DS for further backend side
      * validation
      *

--- a/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
+++ b/crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/CoreCryptoContext.kt
@@ -46,20 +46,6 @@ class CoreCryptoContext(private val cc: com.wire.crypto.uniffi.CoreCryptoContext
     }
 
     /**
-     * Generates a MLS KeyPair/CredentialBundle with a temporary, random client ID. This method is
-     * designed to be used in conjunction with [mlsInitWithClientId] and represents the first step
-     * in this process
-     *
-     * @param ciphersuites - All the ciphersuites supported by this MLS client
-     * @return a list of random ClientId to use in [mlsInitWithClientId]
-     */
-    suspend fun mlsGenerateKeypairs(
-        ciphersuites: Ciphersuites = Ciphersuites.DEFAULT
-    ): ExternallyGeneratedHandle {
-        return wrapException { cc.mlsGenerateKeypairs(ciphersuites.lower()).toExternallyGeneratedHandle() }
-    }
-
-    /**
      * Get the client's public signature key. To upload to the DS for further backend side
      * validation
      *

--- a/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/MLSTest.kt
@@ -42,13 +42,6 @@ class MLSTest {
     }
 
     @Test
-    fun externally_generated_ClientId_should_init_the_MLS_client() = runTest {
-        val alice = initCc()
-        val handle = alice.transaction { it.mlsGenerateKeypairs() }
-        alice.transaction { it.mlsInitWithClientId(ALICE_ID.toClientId(), handle) }
-    }
-
-    @Test
     fun interaction_with_invalid_context_throws_error() = runTest {
         val cc = initCc()
         var context: CoreCryptoContext? = null

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -88,22 +88,6 @@ final class WireCoreCryptoTests: XCTestCase {
         try FileManager.default.removeItem(at: tmpdir)
     }
 
-    func testExternallyGeneratedClientIdShouldInitTheMLSClient() async throws {
-        let ciphersuite: Ciphersuite = 2
-        let alice = try await createCoreCrypto()
-        let aliceId = "alice1".data(using: .utf8)!
-        let handle = try await alice.transaction {
-            try await $0.mlsGenerateKeypairs(ciphersuites: [ciphersuite])
-        }
-        try await alice.transaction {
-            try await $0.mlsInitWithClientId(
-                clientId: aliceId,
-                tmpClientIds: handle,
-                ciphersuites: [ciphersuite]
-            )
-        }
-    }
-
     func testInteractionWithInvalidContextThrowsError() async throws {
         let ciphersuite: Ciphersuite = 2
         let aliceId = "alice1".data(using: .utf8)!

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -44,15 +44,6 @@ impl CoreCryptoContext {
         Ok(())
     }
 
-    /// See [core_crypto::transaction_context::TransactionContext::mls_generate_keypairs]
-    pub async fn mls_generate_keypairs(&self, ciphersuites: Ciphersuites) -> CoreCryptoResult<Vec<ClientId>> {
-        Ok(self
-            .inner
-            .mls_generate_keypairs((&ciphersuites).into())
-            .await
-            .map(|cids| cids.into_iter().map(ClientId).collect())?)
-    }
-
     /// See [core_crypto::transaction_context::TransactionContext::client_public_key]
     pub async fn client_public_key(
         &self,

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -53,23 +53,6 @@ impl CoreCryptoContext {
             .map(|cids| cids.into_iter().map(ClientId).collect())?)
     }
 
-    /// See [core_crypto::transaction_context::TransactionContext::mls_init_with_client_id]
-    pub async fn mls_init_with_client_id(
-        &self,
-        client_id: ClientId,
-        tmp_client_ids: Vec<ClientId>,
-        ciphersuites: Ciphersuites,
-    ) -> CoreCryptoResult<()> {
-        Ok(self
-            .inner
-            .mls_init_with_client_id(
-                client_id.0,
-                tmp_client_ids.into_iter().map(|cid| cid.0).collect(),
-                (&ciphersuites).into(),
-            )
-            .await?)
-    }
-
     /// See [core_crypto::transaction_context::TransactionContext::client_public_key]
     pub async fn client_public_key(
         &self,

--- a/crypto/src/mls/session/error.rs
+++ b/crypto/src/mls/session/error.rs
@@ -29,20 +29,6 @@ pub enum Error {
     UnexpectedlyReady,
     #[error("The keystore already contains a stored identity. Cannot create a new one!")]
     IdentityAlreadyPresent,
-    #[error(
-        r#"The externally-generated client ID initialization cannot continue - there's no provisional keypair in-store!
-
-        Have you called `CoreCrypto::generate_raw_keypair` ?"#
-    )]
-    NoProvisionalIdentityFound,
-    /// This error occurs when during the MLS external client generation, we end up with more than one client identity in store.
-    ///
-    /// This is usually not possible, unless there's some kind of concurrency issue
-    /// on the consumer (creating an ext-gen client AND a normal one at the same time for instance)
-    #[error(
-        "Somehow CoreCrypto holds more than one MLS identity. Something might've gone very wrong with this client!"
-    )]
-    TooManyIdentitiesPresent,
     #[error("The supplied credential does not match the id or signature schemes provided")]
     WrongCredential,
     #[error("An EpochObserver has already been registered; reregistration is not possible")]

--- a/crypto/src/transaction_context/mod.rs
+++ b/crypto/src/transaction_context/mod.rs
@@ -257,26 +257,6 @@ impl TransactionContext {
             .map_err(Into::into)
     }
 
-    /// Updates the current temporary Client ID with the newly provided one. This is the second step in the externally-generated clients process
-    ///
-    /// Important: This is designed to be called after [TransactionContext::mls_generate_keypairs]
-    #[cfg_attr(test, crate::dispotent)]
-    pub async fn mls_init_with_client_id(
-        &self,
-        client_id: ClientId,
-        tmp_client_ids: Vec<ClientId>,
-        ciphersuites: Vec<MlsCiphersuite>,
-    ) -> Result<()> {
-        self.session()
-            .await?
-            .init_with_external_client_id(client_id, tmp_client_ids, &ciphersuites, &self.mls_provider().await?)
-            .await
-            .map_err(RecursiveError::mls_client(
-                "initializing mls client with external client id",
-            ))
-            .map_err(Into::into)
-    }
-
     /// Returns the client's public key.
     pub async fn client_public_key(
         &self,

--- a/crypto/src/transaction_context/mod.rs
+++ b/crypto/src/transaction_context/mod.rs
@@ -243,20 +243,6 @@ impl TransactionContext {
         Ok(())
     }
 
-    /// Generates MLS KeyPairs/CredentialBundle with a temporary, random client ID.
-    /// This method is designed to be used in conjunction with [TransactionContext::mls_init_with_client_id] and represents the first step in this process.
-    ///
-    /// This returns the TLS-serialized identity keys (i.e. the signature keypair's public key)
-    #[cfg_attr(test, crate::dispotent)]
-    pub async fn mls_generate_keypairs(&self, ciphersuites: Vec<MlsCiphersuite>) -> Result<Vec<ClientId>> {
-        self.session()
-            .await?
-            .generate_raw_keypairs(&ciphersuites, &self.mls_provider().await?)
-            .await
-            .map_err(RecursiveError::mls_client("generating raw keypairs"))
-            .map_err(Into::into)
-    }
-
     /// Returns the client's public key.
     pub async fn client_public_key(
         &self,


### PR DESCRIPTION
It turns out clients don't actually use this API. And also there is no reason they should use it, since the backend doesn't require presence of a signature key before issuing a client ID.