### PR TITLE
fix: initWasm was being called with the wrong property field

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -87,11 +87,10 @@ import initWasm from "./core-crypto-ffi";
 export async function initWasmModule(location: string | undefined = undefined) {
     if (typeof window !== "undefined") {
         if (typeof location === "string") {
-            const path = new URL("core-crypto-ffi_bg.wasm", location);
-            await initWasm({ path });
+            const path = `${location}core-crypto-ffi_bg.wasm`;
+            await initWasm({ module_or_path: path });
         } else {
-            const path = new URL("core-crypto-ffi_bg.wasm", import.meta.url);
-            await initWasm({ path });
+            await initWasm({});
         }
     } else {
         // non-browser context, load WASM module from file


### PR DESCRIPTION
# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
