### PR TITLE
docs: reorganize public docs tree [WPB-17912]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,7 +129,7 @@ jobs:
     - name: checkout repository
       uses: actions/checkout@v4
 
-    - name: download TypeScript and Kotlin docs
+    - name: download pre-rendered docs
       uses: actions/download-artifact@v4.1.8
       with:
         path: "./target/doc/${{ env.GIT_TAG }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4.5.0
       with:
-        name: rustdocs
+        name: rust
         path: target/doc
         retention-days: 1
         overwrite: true
@@ -78,8 +78,8 @@ jobs:
 
     - uses: actions/upload-artifact@v4.5.0
       with:
-        name: tsdoc
-        path: target/doc
+        name: typescript
+        path: target/typescript/doc
         retention-days: 1
         overwrite: true
         include-hidden-files: true
@@ -108,8 +108,8 @@ jobs:
 
     - uses: actions/upload-artifact@v4.5.0
       with:
-        name: ktdoc
-        path: target/doc
+        name: kotlin
+        path: target/kotlin/doc/html
         retention-days: 1
         overwrite: true
         include-hidden-files: true
@@ -123,32 +123,21 @@ jobs:
       - tsdoc
       - ktdoc
     env:
-      GIT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+      GIT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'main' }}
 
     steps:
     - name: checkout repository
       uses: actions/checkout@v4
 
-    # Note that we have to download Rust docs first so it can be overwritten by
-    # subsequent artifacts (in particular, Typescript). Once we isolate
-    # documentation for each language, we can download all doc artifacts at once.
-    - name: download Rust docs
-      uses: actions/download-artifact@v4.1.8
-      with:
-        pattern: "rustdocs"
-        path: "./target/doc/${{ env.GIT_TAG }}"
-        merge-multiple: true
-
     - name: download TypeScript and Kotlin docs
       uses: actions/download-artifact@v4.1.8
       with:
-        pattern: "*doc"
         path: "./target/doc/${{ env.GIT_TAG }}"
-        merge-multiple: true
+        merge-multiple: false
 
-    - name: copy index.md
+    - name: copy static files
       run: |
-        cp docs/index.md target/doc/index.md
+        cp docs/*.md target/doc/
 
     - name: deploy docs
       uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
       - main
     tags:
       - 'release/*'
+      - 'v*'
   pull_request:
 
 env:
@@ -117,7 +118,7 @@ jobs:
   deploy:
     name: deploy
     runs-on: ubuntu-latest
-    if: github.repository == 'wireapp/core-crypto' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release'))
+    if: github.repository == 'wireapp/core-crypto' && (github.ref == 'refs/heads/main' || (github.ref_type == 'tag' && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'v'))))
     needs:
       - rustdoc
       - tsdoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
     tags:
-      - 'release/*'
       - 'v*'
   pull_request:
 
@@ -118,7 +117,7 @@ jobs:
   deploy:
     name: deploy
     runs-on: ubuntu-latest
-    if: github.repository == 'wireapp/core-crypto' && (github.ref == 'refs/heads/main' || (github.ref_type == 'tag' && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'v'))))
+    if: github.repository == 'wireapp/core-crypto' && (github.ref == 'refs/heads/main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v')))
     needs:
       - rustdoc
       - tsdoc

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -17,8 +17,8 @@ script = '''
   cd bindings
   ./gradlew android:dokkaHtml
   cd -
-  mkdir -p ../target/doc/core_crypto_ffi/bindings/kotlin
-  cp -R bindings/android/build/dokka/html/ ../target/doc/core_crypto_ffi/bindings/kotlin
+  mkdir -p ../target/kotlin/doc
+  cp -R bindings/android/build/dokka/html/ ../target/kotlin/doc
 '''
 
 [tasks.docs-rust-wasm]
@@ -38,7 +38,7 @@ args = [
     "--basePath", "./bindings/js",
     "--entryPoints", "./bindings/js/src/CoreCrypto.ts",
     "--tsconfig", "./bindings/js/tsconfig.json",
-    "--out", "../target/doc/core_crypto_ffi/bindings/typescript",
+    "--out", "../target/typescript/doc",
     "--readme", "none",
     "--treatWarningsAsErrors",
 ]

--- a/crypto-ffi/src/bindings/mod.rs
+++ b/crypto-ffi/src/bindings/mod.rs
@@ -1,5 +1,0 @@
-#![doc = include_str!("../../../docs/FFI.md")]
-
-pub mod swift {}
-pub mod kotlin {}
-pub mod typescript {}

--- a/crypto-ffi/src/lib.rs
+++ b/crypto-ffi/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(doc)]
-pub mod bindings;
-
 #[cfg(not(target_family = "wasm"))]
 uniffi::setup_scaffolding!("core_crypto_ffi");
 

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -1,12 +1,16 @@
 # CoreCrypto FFI Details
 
-## Bindings
+## Rust Docs
 
-* WASM / TypeScript bindings are self-documented in [crypto-ffi/bindings/js/CoreCrypto.ts].
-    * Please refer to your IDE of choice's inlay hints or simply check out the `TypeDoc`-generated documentation on [typescript]
-    * Naming convention wise, `snake_case` gets translated to the TS idiomatic `camelCase` for methods and `PascalCase` for classes/interfaces
-* UniFFI-generated bindings (Swift, Kotlin) share the same characteristics in terms of naming convention translation.
-    * The general convention is that the idiomatic Rust `snake_case` gets translated to the language's idiomatic convention. Fortunately, for both Swift and Kotlin, the convention is `camelCase` for methods and `PascalCase` for classes/interfaces.
+- [Rust](/core-crypto/main/rust)
+
+These docs are most useful for Core-Crypto developers working internally, but may be useful for client developers looking for additional insights on implementation.
+
+## Bindings Docs
+
+- [Typescript](/core-crypto/main/typescript)
+- [Kotlin](/core-crypto/main/kotlin)
+- [Swift](/core-crypto/main/swift)
 
 ## Naming conventions table
 
@@ -40,17 +44,3 @@
 | `HashMap<String, T>`    | `Dictionary<String, T>`            | `Map<String, T>`           | `Record<string, T>`                      |
 | `()`                    | `nil`                              | `null`                     | `null`                                   |
 | `Result<T, E>`          | `func placeholder() throws E -> T` | `T placeholder() throws E` | `function placeholder(): T // @throws E` |
-
-## Adding new APIs
-
-1. Make your changes wherever applicable.
-1. Make sure your new API is available on `MlsCentral`, while respecting encapsulation
-    - For example, adding `MlsConversation::hello()` would mean exposing a new `MlsCentral::conversation_hello(conversation_id: ConversationId)`
-1. Expose your new API on both `crypto-ffi/src/[generic|wasm].rs`.
-1. Add the new APIs respecting the appropriate calling conventions defined above to
-    - Kotlin/Android: `crypto-ffi/bindings/jvm/src/main/kotlin/com/wire/crypto/client/[CoreCryptoCentral|E2eiClient|MLSClient].kt`
-    - TypeScript/Web: `crypto-ffi/bindings/js/CoreCrypto.ts`
-    (Swift/iOS are automatically generated)
-1. Add documentation for the new API in the bindings.
-1. Add a test for the bindings. This is easily done by extending the existing test suite in `crypto-ffi/bindings/js/test/CoreCrypto.test.ts`.
-   For example, see [this commit](https://github.com/wireapp/core-crypto/commit/5e9ecf7328b33730f31dfc25aeb168e090a7b1e5).

--- a/docs/FFI.md
+++ b/docs/FFI.md
@@ -2,7 +2,7 @@
 
 ## Rust Docs
 
-- [Rust](/core-crypto/main/rust)
+- [Rust](/core-crypto/main/rust/core_crypto/)
 
 These docs are most useful for Core-Crypto developers working internally, but may be useful for client developers looking for additional insights on implementation.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ input, and confirm by "run workflow" below the input. Note that deployment depen
 
 |            | TypeScript                                                 | Kotlin                                                  | Swift                                              | Rust                                             |
 |------------|------------------------------------------------------------|---------------------------------------------------------|----------------------------------------------------|--------------------------------------------------|
-| **main**   | [TypeScript](./main/typescript/)       | [Kotlin](./main/kotlin/)        | [Swift](./main/swift/)         | [Rust](./main/rust/core_crypto/)                           |
+| **main**   | [TypeScript](./main/typescript/)                           | [Kotlin](./main/kotlin/)                                | [Swift](./main/swift/)                             | [Rust](./main/rust/core_crypto/)                 |
 | **v7.0.1** | [TypeScript](./v7.0.1/core_crypto_ffi/bindings/typescript) | [Kotlin](./v7.0.1/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v7.0.1/core_crypto_ffi/bindings/swift)   | [Rust](./v7.0.1/core_crypto)                     |
 | **v7.0.0** | [TypeScript](./v7.0.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v7.0.0/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v7.0.0/core_crypto_ffi/bindings/swift)   | [Rust](./v7.0.0/core_crypto)                     |
 | **v6.0.1** | [TypeScript](./v6.0.1/core_crypto_ffi/bindings/typescript) | [Kotlin](./v6.0.1/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v6.0.1/core_crypto_ffi/bindings/swift)   | [Rust](./v6.0.1/core_crypto)                     |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 # Core-Crypto Documentation
 
+- [FFI](./FFI.md)
+
 ## API Documentation
 <!-- If you want to try to deploy docs for an old tag, go to
 https://github.com/wireapp/core-crypto/actions/workflows/docs.yml, click "run workflow" and provide the tag number as
@@ -7,7 +9,7 @@ input, and confirm by "run workflow" below the input. Note that deployment depen
 
 |            | TypeScript                                                 | Kotlin                                                  | Swift                                              | Rust                                             |
 |------------|------------------------------------------------------------|---------------------------------------------------------|----------------------------------------------------|--------------------------------------------------|
-| **main**   | [TypeScript](./core_crypto_ffi/bindings/typescript/)       | [Kotlin](./core_crypto_ffi/bindings/kotlin/html)        | [Swift](./core_crypto_ffi/bindings/swift/)         | [Rust](./core_crypto/)                           |
+| **main**   | [TypeScript](./main/typescript/)       | [Kotlin](./main/kotlin/)        | [Swift](./main/swift/)         | [Rust](./main/rust/core_crypto/)                           |
 | **v7.0.1** | [TypeScript](./v7.0.1/core_crypto_ffi/bindings/typescript) | [Kotlin](./v7.0.1/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v7.0.1/core_crypto_ffi/bindings/swift)   | [Rust](./v7.0.1/core_crypto)                     |
 | **v7.0.0** | [TypeScript](./v7.0.0/core_crypto_ffi/bindings/typescript) | [Kotlin](./v7.0.0/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v7.0.0/core_crypto_ffi/bindings/swift)   | [Rust](./v7.0.0/core_crypto)                     |
 | **v6.0.1** | [TypeScript](./v6.0.1/core_crypto_ffi/bindings/typescript) | [Kotlin](./v6.0.1/core_crypto_ffi/bindings/kotlin/html) | [Swift](./v6.0.1/core_crypto_ffi/bindings/swift)   | [Rust](./v6.0.1/core_crypto)                     |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 # Core-Crypto Documentation
 
+- [Architecture](./ARCHITECTURE.md)
+- [Keystore Implementation](./KEYSTORE_IMPLEMENTATION.md)
 - [FFI](./FFI.md)
+- [Crypto Dependencies](./CRYPTO_DEPENDENCIES.md)
 
 ## API Documentation
 <!-- If you want to try to deploy docs for an old tag, go to


### PR DESCRIPTION
# What's new in this PR

We're looking for an overall structure like `{tag}/{lang}` for the root of all documentation.

See also https://github.com/wireapp/core-crypto/commit/1dbf96a5379c9396d4724c15d2f125bcb811380e which cleans up the old/irrelevant files from the `gh-pages` branch.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
