### PR TITLE
docs: publish unreleased changes to github pages

### DIFF
--- a/.github/workflows/unreleased-changes.yml
+++ b/.github/workflows/unreleased-changes.yml
@@ -1,0 +1,46 @@
+name: document unreleased changes
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: document unreleased changes
+    runs-on: ubuntu-latest
+    if: github.repository == 'wireapp/core-crypto'
+    env:
+      CHANGELOG: docs/UNRELEASED_CHANGES.md
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # we want the entire history, so git-cliff can generate reasonable changesets
+
+    - name: generate unreleased changelog
+      uses: orhun/git-cliff-action@v4
+      with:
+        config: cliff.toml
+        args: -vv --unreleased
+      env:
+        OUTPUT: ${{ env.CHANGELOG }}
+
+    - name: fixup unreleased changelog
+      run: |
+        mkdir -p target/doc
+        sed -e 's/##  - 1970-01-01/## Unreleased/g' docs/ "$CHANGELOG" > target/doc/UNRELEASED_CHANGES.md
+
+    - name: deploy
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: target/doc
+        keep_files: true
+        force_orphan: false
+        enable_jekyll: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 # Core-Crypto Documentation
 
+- [Unreleased Changes](./UNRELEASED_CHANGES.md)
 - [Architecture](./ARCHITECTURE.md)
 - [Keystore Implementation](./KEYSTORE_IMPLEMENTATION.md)
 - [FFI](./FFI.md)


### PR DESCRIPTION
This updates every time we push to `main`, and updates the relevant `UNRELEASED_CHANGES.md` file.

Note that we do _not_ create a stub file in `docs/` because that introduces the risk of accidentally publishing the stub.



----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
