### PR TITLE
docs: include hyperlink to commit in git cliff output

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -7,7 +7,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.breaking %}[**breaking**] {% endif %}\
          {{ commit.message }} \
-         ({{ commit.id | truncate(length=7, end="") }})\
+         ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/wireapp/core-crypto/commit/{{ commit.id }}))\
     {% endfor %}
 {% endfor %}\n\n
 """


### PR DESCRIPTION
This will make it easier for users to get to the referenced commit from both the changelog and the unreleased changes page.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
