### PR TITLE
fix: building android bindings on a mac

### DIFF
--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -267,6 +267,8 @@ fn update_android_env
     platform = os_family
     if eq ${platform} "linux"
         platform_dir = set "linux-x86_64"
+     elseif eq ${platform} "mac"
+        platform_dir = set "darwin-x86_64"
     else
         trigger_error "Unsupported host platform"
     end


### PR DESCRIPTION
# What's new in this PR

The mac specific case was mistakenly removed in 4f4368f04894862f258a8a862240fb4c549b6b86

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
