### PR TITLE
chore: interop: be more thorough when cleaning up simulator devices

### DIFF
--- a/interop/src/clients/InteropClient/delete_simulator.sh
+++ b/interop/src/clients/InteropClient/delete_simulator.sh
@@ -4,3 +4,6 @@ DEVICE=$1
 
 xcrun simctl shutdown $DEVICE
 xcrun simctl delete $DEVICE
+
+rm -rf ~/Library/Logs/CoreSimulator/$DEVICE
+rm -rf ~/Library/Developer/CoreSimulator/Devices/$DEVICE


### PR DESCRIPTION
It turns out that simctl may not completely remove devices every time, which causes our runner to waste multiple GBs of disk space.
