### PR TITLE
test(js): re-add database tests which were accidentally omitted

### DIFF
--- a/crypto-ffi/bindings/js/test/wdio/database.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/database.test.ts
@@ -1,0 +1,105 @@
+import { browser, expect } from "@wdio/globals";
+import { setup, teardown } from "./utils";
+import { afterEach, beforeEach, describe } from "mocha";
+
+beforeEach(async () => {
+    await setup();
+});
+
+afterEach(async () => {
+    await teardown();
+});
+
+describe("database key", () => {
+    it("must have correct length", async () => {
+        expect(() =>
+            browser.execute(async () => {
+                new window.ccModule.DatabaseKey(new Uint8Array(11));
+            })
+        ).rejects.toThrow();
+    });
+});
+
+describe("database migration", () => {
+    it("migrating key type to bytes works", async () => {
+        const stores = await import("./db-v10002003-dump.json");
+
+        // This fetch() and subsequent browser.executeScript() download and
+        // inject the idb module into the browser context. We cannot do the
+        // fetch from the browser context due to permissions so we first
+        // download the code and then tell the browser to execute it. This also
+        // means the TS compiler has no idea about it, which is why we use
+        // ts-expect-error further down.
+        const response = await fetch(
+            "https://cdn.jsdelivr.net/npm/idb@8/build/umd.js"
+        );
+        if (!response.ok)
+            throw new Error(`failed to fetch script: ${response.statusText}`);
+
+        await browser.executeScript(await response.text(), []);
+
+        const result = await browser.execute(async (stores_) => {
+            // First, we need to restore the IndexedDB database in the browser.
+            const stores: { string: [] } = JSON.parse(stores_);
+            const clientName = "alice";
+            const version = 10002003;
+            // @ts-expect-error TS2304: Cannot find name 'idb'
+            const db = await idb.openDB(clientName, version, {
+                // @ts-expect-error TS7006: Parameter 'db' implicitly has an 'any' type
+                async upgrade(db) {
+                    for (const name of Object.keys(stores)) {
+                        await db.createObjectStore(name);
+                    }
+                },
+            });
+
+            const chunks = (s: string) =>
+                Array.from({ length: s.length / 2 }, (_, i) =>
+                    s.substr(i * 2, 2)
+                );
+            const fromHex = (s: string) =>
+                Uint8Array.from(chunks(s), (byte) => parseInt(byte, 16));
+
+            for (const [name, value] of Object.entries(stores)) {
+                for (const [key, val] of Object.entries(value)) {
+                    await db.put(name, val, fromHex(key));
+                }
+            }
+
+            // It is important to close the database here since otherwise the migration process
+            // will be stuck because we'd be holding a connection to the same database open.
+            db.close();
+
+            // Migrate the whole database to use the new key type.
+            const old_key = clientName;
+            const new_key = new window.ccModule.DatabaseKey(new Uint8Array(32));
+            await window.ccModule.migrateDatabaseKeyTypeToBytes(
+                clientName,
+                old_key,
+                new_key
+            );
+
+            // Reconstruct the client based on the migrated database and fetch the epoch.
+            const cipherSuite = window.defaultCipherSuite;
+            const encoder = new TextEncoder();
+            const clientConfig = {
+                databaseName: clientName,
+                key: new_key,
+                wasmModule: undefined,
+                ciphersuites: [cipherSuite],
+                clientId: new window.ccModule.ClientId(
+                    encoder.encode(clientName)
+                ),
+            };
+            const instance =
+                await window.ccModule.CoreCrypto.init(clientConfig);
+            const epoch = await instance.conversationEpoch(
+                new window.ccModule.ConversationId(encoder.encode("convId"))
+            );
+            return epoch;
+        }, JSON.stringify(stores));
+
+        // If the migration succeeded, the epoch has to be 1.
+        expect(result).toEqual(1);
+    });
+});


### PR DESCRIPTION
a5e510c2829d6a9e460eb0eff5f213305c93fc51 broke a large test file into many smaller files, and these tests were accidentally omitted.

This re-adds them.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
