### PR TITLE
refactor: test: move API from `SessionContext` to `TestConversation` [WPB-18082]

### DIFF
--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -662,7 +662,7 @@ mod tests {
 
                 assert!(decrypted.proposals.is_empty());
                 assert!(decrypted.delay.is_none());
-                assert!(alice.pending_proposals(conversation.id()).await.is_empty());
+                assert!(!conversation.has_pending_proposals().await);
                 assert!(alice_observer.has_changed().await);
             })
             .await

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -176,8 +176,8 @@ mod tests {
             assert!(!conversation.has_pending_proposals().await);
 
             // verify that we return the new identity
-            alice
-                .verify_local_credential_rotated(conversation.id(), new_handle, new_display_name)
+            conversation
+                .verify_credential_handle_and_name(new_handle, new_display_name)
                 .await;
         })
         .await

--- a/crypto/src/test_utils/test_conversation/commit.rs
+++ b/crypto/src/test_utils/test_conversation/commit.rs
@@ -218,7 +218,7 @@ impl<'a> TestConversation<'a> {
     /// The supplied session joins this conversation by external commit.
     /// The group info needed for this is exported from the state of the actor.
     pub async fn external_join(self, joiner: &'a SessionContext) -> OperationGuard<'a, Commit> {
-        let group_info = self.actor().get_group_info(&self.id).await;
+        let group_info = self.export_group_info().await;
         self.external_join_via_group_info(joiner, group_info).await
     }
 
@@ -256,7 +256,7 @@ impl<'a> TestConversation<'a> {
         self,
         joiner: &'a SessionContext,
     ) -> (TestConversation<'a>, PendingConversation) {
-        let group_info = self.actor().get_group_info(self.id()).await;
+        let group_info = self.export_group_info().await;
         let (commit_guard, pending_conversation) = self.external_join_via_group_info_unmerged(joiner, group_info).await;
         (commit_guard.notify_members().await, pending_conversation)
     }
@@ -266,7 +266,7 @@ impl<'a> TestConversation<'a> {
         self,
         joiner: &'a SessionContext,
     ) -> (OperationGuard<'a, Commit>, PendingConversation) {
-        let group_info = self.actor().get_group_info(self.id()).await;
+        let group_info = self.export_group_info().await;
         self.external_join_via_group_info_unmerged(joiner, group_info).await
     }
 

--- a/crypto/src/transaction_context/conversation/external_commit.rs
+++ b/crypto/src/transaction_context/conversation/external_commit.rs
@@ -154,6 +154,7 @@ mod tests {
     use core_crypto_keystore::{CryptoKeystoreError, CryptoKeystoreMls, MissingKeyErrorKind};
 
     use super::Error;
+    use crate::mls::conversation::ConversationWithMls as _;
     use crate::{LeafError, prelude::MlsConversationConfiguration, test_utils::*, transaction_context};
 
     #[apply(all_cred_cipher)]
@@ -429,8 +430,6 @@ mod tests {
 
     #[apply(all_cred_cipher)]
     async fn group_should_have_right_config(case: TestContext) {
-        use crate::mls::conversation::ConversationWithMls as _;
-
         let [alice, bob] = case.sessions().await;
         Box::pin(async move {
             let conversation = case

--- a/crypto/src/transaction_context/conversation/proposal.rs
+++ b/crypto/src/transaction_context/conversation/proposal.rs
@@ -71,6 +71,7 @@ impl TransactionContext {
 
 #[cfg(test)]
 mod tests {
+    use crate::mls::conversation::ConversationWithMls as _;
     use crate::{prelude::*, test_utils::*};
 
     use super::Error;
@@ -102,8 +103,6 @@ mod tests {
 
         #[apply(all_cred_cipher)]
         pub async fn should_update_hpke_key(case: TestContext) {
-            use crate::mls::conversation::ConversationWithMls as _;
-
             let [session] = case.sessions().await;
             let conversation = case.create_conversation([&session]).await;
             let conversation_guard = conversation.guard().await;

--- a/crypto/src/transaction_context/e2e_identity/conversation_state.rs
+++ b/crypto/src/transaction_context/e2e_identity/conversation_state.rs
@@ -167,7 +167,6 @@ mod tests {
         let [alice, bob] = case.sessions().await;
         Box::pin(async move {
             let conversation = case.create_conversation([&alice, &bob]).await;
-            let id = conversation.id().clone();
 
             let expiration_time = core::time::Duration::from_secs(14);
             let start = web_time::Instant::now();
@@ -186,7 +185,7 @@ mod tests {
                 .unwrap();
 
             // Need to fetch it before it becomes invalid & expires
-            let gi = alice.get_group_info(&id).await;
+            let gi = conversation.export_group_info().await;
 
             let elapsed = start.elapsed();
             // Give time to the certificate to expire


### PR DESCRIPTION
# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
