### PR TITLE
ci: stop running workflows for a second time on main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,8 +1,5 @@
 name: continuous benchmarks with bencher
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 env:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,8 +6,6 @@ concurrency:
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
We run the checks on the feature branch on the same state that gets merged to main. There is no point in running them a second time in the moment the PR gets merged (which triggers the GHA `push` event on `main`).

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
