### PR TITLE
fix: proteus error type mapping

### DIFF
--- a/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/ProteusClientTest.kt
+++ b/crypto-ffi/bindings/jvm/src/test/kotlin/com/wire/crypto/ProteusClientTest.kt
@@ -115,4 +115,17 @@ internal class ProteusClientTest {
         bobClient.transaction { it.proteusCreateSession(aliceKey, ALICE_SESSION_ID) }
         assertNotNull(bobClient.transaction { it.proteusEncrypt("Hello World".encodeToByteArray(), ALICE_SESSION_ID) })
     }
+
+    @Test
+    fun givenNoSessionExists_whenGettingRemoteFingerprint_thenReturnSessionNotFound() = runTest {
+        val aliceClient = newProteusClient(alice)
+
+        assertFailsWith<CoreCryptoException.Proteus> {
+            aliceClient.transaction {
+                it.proteusGetRemoteFingerprint(
+                    ALICE_SESSION_ID
+                )
+            }
+        }.also { it.exception is ProteusException.SessionNotFound }
+    }
 }

--- a/crypto-ffi/src/error/proteus.rs
+++ b/crypto-ffi/src/error/proteus.rs
@@ -1,3 +1,5 @@
+use core_crypto::LeafError;
+
 #[derive(Debug, thiserror::Error)]
 #[cfg_attr(target_family = "wasm", derive(strum::AsRefStr))]
 #[cfg_attr(not(target_family = "wasm"), derive(uniffi::Error))]
@@ -51,6 +53,7 @@ impl From<&core_crypto::ProteusErrorKind> for ProteusError {
             core_crypto::ProteusErrorKind::ProteusSessionError(SessionError::InternalError(
                 proteus_wasm::internal::types::InternalError::NoSessionForTag,
             )) => Self::SessionNotFound,
+            core_crypto::ProteusErrorKind::Leaf(LeafError::ConversationNotFound(_)) => Self::SessionNotFound,
             core_crypto::ProteusErrorKind::ProteusSessionError(SessionError::DuplicateMessage) => {
                 Self::DuplicateMessage
             }

--- a/crypto/src/error/proteus.rs
+++ b/crypto/src/error/proteus.rs
@@ -35,6 +35,9 @@ impl ProteusErrorKind {
             ProteusErrorKind::ProteusEncodeError(encode_error) => Some(encode_error.code()),
             ProteusErrorKind::ProteusInternalError(proteus_error) => Some(proteus_error.code()),
             ProteusErrorKind::ProteusSessionError(session_error) => Some(session_error.code()),
+            ProteusErrorKind::Leaf(crate::LeafError::ConversationNotFound(_)) => {
+                Some(proteus_traits::ProteusErrorKind::SessionStateNotFoundForTag)
+            }
             ProteusErrorKind::Leaf(_) => None,
         };
         if out == Some(proteus_traits::ProteusErrorKind::None) {


### PR DESCRIPTION
# What's new in this PR
Until now, we incorrectly assumed, that we could determine whether a
recursive error is a proteus error by just looking at the innermost
type. However, this approach fails in the case of a
`ConversationNotFoundError`, wrapped in a `LeafError`, which is not
proteus-specific.

Therefore, we're now checking entire error stack for proteus error
kinds.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
