### PR TITLE
build: add a reasonable set of commit types to legal ones

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+        args: [chore, build, refactor, fix, feat, test, ci, docs, wip, release] # git log  --oneline | cut -d' ' -f2- | rg '^[^:(!]+' -o | sort | uniq -c | sort -rn | rg -v '^\s*1 '
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:


### PR DESCRIPTION
Specifically, use the actual set of types which appear in this repo more than once. This is a somewhat broader set than the defaults.

As determined by 

```sh
git log  --oneline | cut -d' ' -f2- | rg '^[^:(!]+' -o | sort | uniq -c | sort -rn | rg -v '^\s*1 '
```
----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
