### PR TITLE
chore: upgrade to use Dokka 2.0

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -160,7 +160,7 @@ jobs:
       - name: run dokka
         run: |
             cd crypto-ffi/bindings
-            ./gradlew android:dokkaHtml
+            ./gradlew android:dokkaGeneratePublicationHtml
             cd ..
             mkdir -p ../target/kotlin/doc
             cp -R bindings/android/build/dokka/html/ ../target/kotlin/doc

--- a/crypto-ffi/Makefile.toml
+++ b/crypto-ffi/Makefile.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 script = '''
   cd bindings
-  ./gradlew android:dokkaHtml
+  ./gradlew android:dokkaGeneratePublicationHtml
   cd -
   mkdir -p ../target/kotlin/doc
   cp -R bindings/android/build/dokka/html/ ../target/kotlin/doc

--- a/crypto-ffi/bindings/android/build.gradle.kts
+++ b/crypto-ffi/bindings/android/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 
 val kotlinSources = projectDir.resolve("../jvm/src")
 val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
-    dependsOn(tasks.dokkaHtml)
-    from(tasks.dokkaHtml)
+    dependsOn(tasks.dokkaGeneratePublicationHtml)
+    from(tasks.dokkaGeneratePublicationHtml.flatMap { it.outputDirectory })
     archiveClassifier.set("html-docs")
 }
 

--- a/crypto-ffi/bindings/build.gradle.kts
+++ b/crypto-ffi/bindings/build.gradle.kts
@@ -43,6 +43,18 @@ allprojects {
             showStackTraces = true
         }
     }
+
+    dokka {
+        moduleName.set("CoreCrypto")
+        pluginsConfiguration.html {
+            footerMessage.set("Copyright Wire GmbH")
+        }
+        dokkaSourceSets.configureEach {
+            sourceLink {
+                remoteUrl("https://github.com/wireapp/core-crypto/tree/main/crypto-ffi/bindings/jvm")
+            }
+        }
+    }
 }
 
 tasks.withType<Wrapper>().configureEach {

--- a/crypto-ffi/bindings/gradle.properties
+++ b/crypto-ffi/bindings/gradle.properties
@@ -13,6 +13,10 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
+# Enable Dokka 2.0
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+
+
 # gradle-maven-publish configuration
 GROUP=com.wire
 VERSION_NAME=7.0.0


### PR DESCRIPTION
# What's new in this PR

We were already importing dokka 2.0 but we were still using the old v1 gradle tasks. This PR enables the v2 gradle tasks and updates the build config to use them.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
