### PR TITLE
ci: don't build android package on push to main

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build-android:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/build-android.yml
 
   build-jvm-linux:


### PR DESCRIPTION
It's quite expensive to build and we only need it for testing, which we only do on PRs.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
