### PR TITLE
fix: stop emitting warning on missing error fields [WPB-15468]

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCryptoError.ts
+++ b/crypto-ffi/bindings/js/src/CoreCryptoError.ts
@@ -38,14 +38,14 @@ export class CoreCryptoError extends Error {
         }
     }
 
-    private static fallback(msg: string, ...params: any[]): Error {
-        console.warn(
-            `Cannot build CoreCryptoError, falling back to standard Error! ctx: ${msg}`
-        );
-        return new Error(msg, ...params);
+    private static fallback(
+        message: string,
+        ...params: any[]
+    ): CoreCryptoError {
+        return new CoreCryptoError({ message }, ...params);
     }
 
-    static build(msg: string, ...params: unknown[]): CoreCryptoError | Error {
+    static build(msg: string, ...params: unknown[]): CoreCryptoError {
         try {
             const richError: CoreCryptoRichError = JSON.parse(msg);
             return new this(richError, ...params);
@@ -54,7 +54,7 @@ export class CoreCryptoError extends Error {
         }
     }
 
-    static fromStdError(e: Error): CoreCryptoError | Error {
+    static fromStdError(e: Error): CoreCryptoError {
         if (e instanceof CoreCryptoError) {
             return e;
         }

--- a/crypto-ffi/bindings/js/test/wdio/errors.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/errors.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import {
+    ConversationId,
     CoreCryptoError,
     type CoreCryptoRichError,
 } from "../../src/CoreCrypto";
@@ -22,7 +23,7 @@ afterEach(async () => {
 });
 
 describe("core crypto errors", () => {
-    it("should build correctly", async () => {
+    it("should build correctly when constructed manually", async () => {
         await ccInit(ALICE_ID);
         const result = await browser.execute(async () => {
             const CoreCryptoError = window.ccModule.CoreCryptoError;
@@ -52,6 +53,94 @@ describe("core crypto errors", () => {
         expect(result.isCorrectInstance).toBe(true);
         expect(result.proteusErrorCodeIsCorrect).toBe(true);
     });
+
+    it("should build correctly when constructed by cc", async () => {
+        await ccInit(ALICE_ID);
+        await createConversation(ALICE_ID, CONV_ID);
+
+        const result = await browser.execute(
+            async (clientName, convId) => {
+                const cc = window.ensureCcDefined(clientName);
+                const conversationId = new window.ccModule.ConversationId(
+                    new TextEncoder().encode(convId)
+                );
+                const CoreCryptoError = window.ccModule.CoreCryptoError;
+
+                try {
+                    await cc.transaction(async (cx) => {
+                        await cx.createConversation(
+                            conversationId,
+                            window.ccModule.CredentialType.Basic
+                        );
+                    });
+                    return {
+                        errorWasThrown: false,
+                    };
+                } catch (err) {
+                    const ccErr = CoreCryptoError.fromStdError(err as Error);
+
+                    const errorSerialized = JSON.stringify(err);
+                    const standardError = new Error(errorSerialized);
+                    const errorDeserialized =
+                        CoreCryptoError.fromStdError(standardError);
+                    return {
+                        errorWasThrown: true,
+                        isCorrectInstance: ccErr instanceof CoreCryptoError,
+                        errorTypeSurvivesSerialization:
+                            errorDeserialized instanceof CoreCryptoError,
+                    };
+                }
+            },
+            ALICE_ID,
+            CONV_ID
+        );
+
+        expect(result.errorWasThrown).toBe(true);
+        expect(result.isCorrectInstance).toBe(true);
+        expect(result.errorTypeSurvivesSerialization).toBe(true);
+    });
+});
+
+it("should build correctly when constructed by wasm bindgen", async () => {
+    await ccInit(ALICE_ID);
+    const result = await browser.execute(
+        async (clientName, convId) => {
+            const cc = window.ensureCcDefined(clientName);
+            const CoreCryptoError = window.ccModule.CoreCryptoError;
+
+            try {
+                await cc.transaction(async (cx) => {
+                    await cx.createConversation(
+                        // pass in a string argument instead of a `ConversationId` instance
+                        convId as unknown as ConversationId,
+                        window.ccModule.CredentialType.Basic
+                    );
+                });
+                return {
+                    errorWasThrown: false,
+                };
+            } catch (err) {
+                const ccErr = CoreCryptoError.fromStdError(err as Error);
+
+                const errorSerialized = JSON.stringify(err);
+                const standardError = new Error(errorSerialized);
+                const errorDeserialized =
+                    CoreCryptoError.fromStdError(standardError);
+                return {
+                    errorWasThrown: true,
+                    isCorrectInstance: ccErr instanceof CoreCryptoError,
+                    errorTypeSurvivesSerialization:
+                        errorDeserialized instanceof CoreCryptoError,
+                };
+            }
+        },
+        ALICE_ID,
+        CONV_ID
+    );
+
+    expect(result.errorWasThrown).toBe(true);
+    expect(result.isCorrectInstance).toBe(true);
+    expect(result.errorTypeSurvivesSerialization).toBe(true);
 });
 
 describe("Error type mapping", () => {


### PR DESCRIPTION
# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
