### PR TITLE
Do not use same IDs across different tests

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -279,9 +279,6 @@ jobs:
         run: |
           bun x @puppeteer/browsers install chromedriver@latest --path $PWD
           echo "CHROMEDRIVER_PATH=$(echo $PWD/chromedriver/*/*/chromedriver)" >> $GITHUB_ENV
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
       - name: build wasm artifacts
         run: |
           cd crypto-ffi
@@ -328,9 +325,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
       - name: install wasm-pack
         uses: taiki-e/install-action@v2
         with:

--- a/crypto-ffi/bindings/js/benches/CoreCrypto.bench.ts
+++ b/crypto-ffi/bindings/js/benches/CoreCrypto.bench.ts
@@ -1,8 +1,5 @@
 import {
-    ALICE_ID,
-    BOB_ID,
     ccInit,
-    CONV_ID,
     createConversation,
     invite,
     setup,
@@ -72,18 +69,21 @@ async function measureDecryption(
 describe("messages", () => {
     const MESSAGE_COUNT = 1000;
     it(`decrypt ${MESSAGE_COUNT} messages`, async () => {
-        await ccInit(ALICE_ID);
-        await ccInit(BOB_ID);
-        await createConversation(ALICE_ID, CONV_ID);
-        await invite(ALICE_ID, BOB_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await ccInit(bob);
+        await createConversation(alice, convId);
+        await invite(alice, bob, convId);
 
         const MESSAGE = "Hello world!";
         const { decryptedMessages, durationMilliSeconds: duration } =
             await browser.execute(
                 measureDecryption,
-                ALICE_ID,
-                BOB_ID,
-                CONV_ID,
+                alice,
+                bob,
+                convId,
                 MESSAGE,
                 MESSAGE_COUNT
             );

--- a/crypto-ffi/bindings/js/test/bun/utils.ts
+++ b/crypto-ffi/bindings/js/test/bun/utils.ts
@@ -16,10 +16,6 @@ import {
     initWasmModule,
     ClientId,
 } from "../../src/CoreCrypto";
-import { CONV_ID as WEB_CONV_ID } from "../wdio/utils";
-
-export { ALICE_ID, BOB_ID, SESSION_ID } from "../wdio/utils";
-export const CONV_ID = new TextEncoder().encode(WEB_CONV_ID);
 
 const CC_INSTANCES: CoreCrypto[] = [];
 

--- a/crypto-ffi/bindings/js/test/wdio/clientIdentity.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/clientIdentity.test.ts
@@ -1,5 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import { ALICE_ID, ccInit, setup, teardown } from "./utils";
+import { ccInit, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 
 beforeEach(async () => {
@@ -12,7 +12,8 @@ afterEach(async () => {
 
 describe("client identity", () => {
     it("get client public key should work", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(async (clientName) => {
             const cc = window.ensureCcDefined(clientName);
             return (
@@ -21,12 +22,13 @@ describe("client identity", () => {
                     window.ccModule.CredentialType.Basic
                 )
             ).length;
-        }, ALICE_ID);
+        }, alice);
         expect(result).toBe(32);
     });
 
     it("requesting client key packages should work", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(async (clientName) => {
             const cc = window.ensureCcDefined(clientName);
             return (
@@ -38,7 +40,7 @@ describe("client identity", () => {
                     );
                 })
             ).length;
-        }, ALICE_ID);
+        }, alice);
         expect(result).toBe(20);
     });
 });

--- a/crypto-ffi/bindings/js/test/wdio/conversation.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/conversation.test.ts
@@ -1,9 +1,6 @@
 import { expect } from "@wdio/globals";
 import {
-    ALICE_ID,
-    BOB_ID,
     ccInit,
-    CONV_ID,
     createConversation,
     invite,
     roundTripMessage,
@@ -23,10 +20,13 @@ afterEach(async () => {
 
 describe("conversation", () => {
     it("should allow inviting members", async () => {
-        await ccInit(ALICE_ID);
-        await ccInit(BOB_ID);
-        await createConversation(ALICE_ID, CONV_ID);
-        const groupInfo = await invite(ALICE_ID, BOB_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await ccInit(bob);
+        await createConversation(alice, convId);
+        const groupInfo = await invite(alice, bob, convId);
         expect(groupInfo.encryptionType).toBe(
             GroupInfoEncryptionType.Plaintext
         );
@@ -34,15 +34,18 @@ describe("conversation", () => {
     });
 
     it("should allow sending messages", async () => {
-        await ccInit(ALICE_ID);
-        await ccInit(BOB_ID);
-        await createConversation(ALICE_ID, CONV_ID);
-        await invite(ALICE_ID, BOB_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await ccInit(bob);
+        await createConversation(alice, convId);
+        await invite(alice, bob, convId);
         const messageText = "Hello world!";
         const [decryptedByAlice, decryptedByBob] = await roundTripMessage(
-            ALICE_ID,
-            BOB_ID,
-            CONV_ID,
+            alice,
+            bob,
+            convId,
             messageText
         );
         expect(decryptedByAlice).toBe(messageText);

--- a/crypto-ffi/bindings/js/test/wdio/e2ei.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/e2ei.test.ts
@@ -1,12 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import {
-    ALICE_ID,
-    ccInit,
-    CONV_ID,
-    createConversation,
-    setup,
-    teardown,
-} from "./utils";
+import { ccInit, createConversation, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import { E2eiConversationState } from "../../src/CoreCrypto";
 
@@ -20,7 +13,8 @@ afterEach(async () => {
 
 describe("end to end identity", () => {
     it("enrollment flow should succeed", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
         await browser.execute(async (clientName) => {
             const cc = window.ensureCcDefined(clientName);
             const ciphersuite = window.defaultCipherSuite;
@@ -250,12 +244,14 @@ describe("end to end identity", () => {
 
                 await enrollment.certificateRequest(previousNonce);
             });
-        }, ALICE_ID);
+        }, alice);
     });
 
     it("should not be enabled on conversation with basic credential", async () => {
-        await ccInit(ALICE_ID);
-        await createConversation(ALICE_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await createConversation(alice, convId);
         const conversationState = await browser.execute(
             async (clientName, conversationId) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -266,15 +262,17 @@ describe("end to end identity", () => {
                     return await ctx.e2eiConversationState(cid);
                 });
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
         expect(conversationState).toBe(E2eiConversationState.NotEnabled);
     });
 
     it("identities can be queried by client id", async () => {
-        await ccInit(ALICE_ID);
-        await createConversation(ALICE_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await createConversation(alice, convId);
         const identities = await browser.execute(
             async (clientName, conversationId) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -292,16 +290,17 @@ describe("end to end identity", () => {
 
                 return identities.pop()?.clientId;
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
-        expect(identities).toBe(ALICE_ID);
+        expect(identities).toBe(alice);
     });
 
     it("identities can be queried by user id", async () => {
-        const ALICE_ID = "LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com";
-        await ccInit(ALICE_ID);
-        await createConversation(ALICE_ID, CONV_ID);
+        const alice = "LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com";
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await createConversation(alice, convId);
         const identities = await browser.execute(
             async (clientName, conversationId) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -316,9 +315,9 @@ describe("end to end identity", () => {
 
                 return identities.values().next().value?.pop()?.clientId;
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
-        expect(identities).toBe(ALICE_ID);
+        expect(identities).toBe(alice);
     });
 });

--- a/crypto-ffi/bindings/js/test/wdio/epochObserver.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/epochObserver.test.ts
@@ -1,5 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import { ALICE_ID, ccInit, CONV_ID, setup, teardown } from "./utils";
+import { ccInit, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 
 beforeEach(async () => {
@@ -12,7 +12,9 @@ afterEach(async () => {
 
 describe("epoch observer", () => {
     it("should observe new epochs", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
         const { length, first_id_hex } = await browser.execute(
             async (clientName, conv_id_str) => {
                 const conv_id = new window.ccModule.ConversationId(
@@ -72,11 +74,11 @@ describe("epoch observer", () => {
                 ).join("");
                 return { length: observer.observations.length, first_id_hex };
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
 
-        const expect_conversation_id = new TextEncoder().encode(CONV_ID);
+        const expect_conversation_id = new TextEncoder().encode(convId);
         const expect_conversation_id_hex = Array.from(
             expect_conversation_id,
             (byte) => {

--- a/crypto-ffi/bindings/js/test/wdio/errors.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/errors.test.ts
@@ -1,12 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import {
-    ALICE_ID,
-    ccInit,
-    CONV_ID,
-    createConversation,
-    setup,
-    teardown,
-} from "./utils";
+import { ccInit, createConversation, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import {
     ConversationId,
@@ -24,7 +17,8 @@ afterEach(async () => {
 
 describe("core crypto errors", () => {
     it("should build correctly when constructed manually", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(async () => {
             const CoreCryptoError = window.ccModule.CoreCryptoError;
             const richErrorJSON: CoreCryptoRichError = {
@@ -55,8 +49,10 @@ describe("core crypto errors", () => {
     });
 
     it("should build correctly when constructed by cc", async () => {
-        await ccInit(ALICE_ID);
-        await createConversation(ALICE_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await createConversation(alice, convId);
 
         const result = await browser.execute(
             async (clientName, convId) => {
@@ -91,8 +87,8 @@ describe("core crypto errors", () => {
                     };
                 }
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
 
         expect(result.errorWasThrown).toBe(true);
@@ -102,7 +98,9 @@ describe("core crypto errors", () => {
 });
 
 it("should build correctly when constructed by wasm bindgen", async () => {
-    await ccInit(ALICE_ID);
+    const alice = crypto.randomUUID();
+    const convId = crypto.randomUUID();
+    await ccInit(alice);
     const result = await browser.execute(
         async (clientName, convId) => {
             const cc = window.ensureCcDefined(clientName);
@@ -134,8 +132,8 @@ it("should build correctly when constructed by wasm bindgen", async () => {
                 };
             }
         },
-        ALICE_ID,
-        CONV_ID
+        alice,
+        convId
     );
 
     expect(result.errorWasThrown).toBe(true);
@@ -145,13 +143,15 @@ it("should build correctly when constructed by wasm bindgen", async () => {
 
 describe("Error type mapping", () => {
     it("should work for conversation already exists", async () => {
-        await ccInit(ALICE_ID);
-        await createConversation(ALICE_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await createConversation(alice, convId);
 
         const expectedErrorMessage = "Conversation already exists";
 
         await expect(
-            createConversation(ALICE_ID, CONV_ID)
+            createConversation(alice, convId)
             // wdio wraps the error and prepends the original message with
             // the error type as prefix
         ).rejects.toThrow(

--- a/crypto-ffi/bindings/js/test/wdio/externalEntropy.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/externalEntropy.test.ts
@@ -1,5 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import { ALICE_ID, ccInit, setup, teardown } from "./utils";
+import { ccInit, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 
 beforeEach(async () => {
@@ -27,7 +27,8 @@ describe("external entropy", () => {
             0x6f4d794b,
         ]);
 
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
 
         const [result1, result2] = await browser.execute(
             async (clientName, length1, length2) => {
@@ -40,7 +41,7 @@ describe("external entropy", () => {
                 const produced2 = await cc.randomBytes(length2);
                 return [Array.from(produced1), Array.from(produced2)];
             },
-            ALICE_ID,
+            alice,
             vector1.length * vector1.BYTES_PER_ELEMENT,
             vector2.length * vector2.BYTES_PER_ELEMENT
         );

--- a/crypto-ffi/bindings/js/test/wdio/historySharing.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/historySharing.test.ts
@@ -1,5 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import { ALICE_ID, ccInit, CONV_ID, setup, teardown } from "./utils";
+import { ccInit, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import { ConversationId, type HistorySecret } from "../../src/CoreCrypto";
 
@@ -13,7 +13,9 @@ afterEach(async () => {
 
 describe("history sharing", () => {
     it("enable and disable should work", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(
             async (clientName, convIdStr) => {
                 const convId = new window.ccModule.ConversationId(
@@ -88,14 +90,14 @@ describe("history sharing", () => {
                     commitHasEncryptedMessage,
                 };
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
 
         expect(result.length).toBe(1);
         expect(result.enabledBeforeEnabling).toBe(false);
         expect(result.enabledAfterEnabling).toBe(true);
-        expect(result.firstIdString).toBe(CONV_ID);
+        expect(result.firstIdString).toBe(convId);
         expect(result.commitHasEncryptedMessage).toBe(true);
     });
 });

--- a/crypto-ffi/bindings/js/test/wdio/logger.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/logger.test.ts
@@ -1,14 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import {
-    ALICE_ID,
-    BOB_ID,
-    ccInit,
-    CONV_ID,
-    createConversation,
-    invite,
-    setup,
-    teardown,
-} from "./utils";
+import { ccInit, createConversation, invite, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 
 beforeEach(async () => {
@@ -28,7 +19,9 @@ describe("logger", () => {
     };
 
     it("forwards logs when registered", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(
             async (clientName, conversationId) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -53,15 +46,17 @@ describe("logger", () => {
                 });
                 return logs;
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
 
         expect(result.length).toBeGreaterThan(0);
     });
 
     it("can be replaced", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(
             async (clientName, conversationId) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -91,15 +86,17 @@ describe("logger", () => {
                 });
                 return logs;
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
 
         expect(result.length).toBeGreaterThan(0);
     });
 
     it("doesn't forward logs below log level when registered", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
         const result = await browser.execute(
             async (clientName, conversationId) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -124,16 +121,18 @@ describe("logger", () => {
                 });
                 return logs;
             },
-            ALICE_ID,
-            CONV_ID
+            alice,
+            convId
         );
 
         expect(result.length).toBe(0);
     });
 
     it("when throwing errors they're reported as errors", async () => {
+        const alice = crypto.randomUUID();
+        const convId = crypto.randomUUID();
         const expectedErrorMessage = "expected test error in logger test";
-        await ccInit(ALICE_ID);
+        await ccInit(alice);
         await browser.execute(
             async (clientName, conversationId, expectedErrorMessage) => {
                 const cc = window.ensureCcDefined(clientName);
@@ -156,8 +155,8 @@ describe("logger", () => {
                     );
                 });
             },
-            ALICE_ID,
-            CONV_ID,
+            alice,
+            convId,
             expectedErrorMessage
         );
 
@@ -173,10 +172,13 @@ describe("logger", () => {
     });
 
     it("forwards logs with context key/value pairs", async () => {
-        await ccInit(ALICE_ID);
-        await createConversation(ALICE_ID, CONV_ID);
-        await ccInit(BOB_ID);
-        await invite(ALICE_ID, BOB_ID, CONV_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const convId = crypto.randomUUID();
+        await ccInit(alice);
+        await createConversation(alice, convId);
+        await ccInit(bob);
+        await invite(alice, bob, convId);
         const result = await browser.execute(
             async (aliceName, bobName, conversationId) => {
                 const { setMaxLogLevel, CoreCryptoLogLevel, setLogger } =
@@ -218,9 +220,9 @@ describe("logger", () => {
 
                 return logs;
             },
-            ALICE_ID,
-            BOB_ID,
-            CONV_ID
+            alice,
+            bob,
+            convId
         );
 
         const proteusErrorLog = result.find(

--- a/crypto-ffi/bindings/js/test/wdio/proteus.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/proteus.test.ts
@@ -1,11 +1,8 @@
 import { browser, expect } from "@wdio/globals";
 import {
-    ALICE_ID,
-    BOB_ID,
     newProteusSessionFromMessage,
     newProteusSessionFromPrekey,
     proteusInit,
-    SESSION_ID,
     setup,
     teardown,
 } from "./utils";
@@ -21,7 +18,8 @@ afterEach(async () => {
 
 describe("proteus", () => {
     it("should initialize correctly", async () => {
-        await proteusInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await proteusInit(alice);
         const result = await browser.execute(async (clientName) => {
             const lastResortPrekeyId =
                 window.ccModule.CoreCrypto.proteusLastResortPrekeyId();
@@ -37,7 +35,7 @@ describe("proteus", () => {
                 lastResortPrekey1: Array.from(prekey1),
                 lastResortPrekey2: Array.from(prekey2),
             };
-        }, ALICE_ID);
+        }, alice);
 
         const u16MAX = Math.pow(2, 16) - 1;
 
@@ -48,44 +46,53 @@ describe("proteus", () => {
     });
 
     it("new session from prekey should succeed", async () => {
-        await proteusInit(ALICE_ID);
-        await proteusInit(BOB_ID);
-        await newProteusSessionFromPrekey(ALICE_ID, BOB_ID, SESSION_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const sessionId = crypto.randomUUID();
+        await proteusInit(alice);
+        await proteusInit(bob);
+        await newProteusSessionFromPrekey(alice, bob, sessionId);
     });
 
     it("new session from message should succeed", async () => {
-        await proteusInit(ALICE_ID);
-        await proteusInit(BOB_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const sessionId = crypto.randomUUID();
+        await proteusInit(alice);
+        await proteusInit(bob);
         // Session for alice
-        await newProteusSessionFromPrekey(ALICE_ID, BOB_ID, SESSION_ID);
+        await newProteusSessionFromPrekey(alice, bob, sessionId);
         const message = "Hello, world!";
         // Session for bob
         const decryptedMessage = await newProteusSessionFromMessage(
-            ALICE_ID,
-            BOB_ID,
-            SESSION_ID,
+            alice,
+            bob,
+            sessionId,
             message
         );
         expect(decryptedMessage).toBe(message);
     });
 
     it("initializing same session twice should fail", async () => {
-        await proteusInit(ALICE_ID);
-        await proteusInit(BOB_ID);
+        const alice = crypto.randomUUID();
+        const bob = crypto.randomUUID();
+        const sessionId = crypto.randomUUID();
+        await proteusInit(alice);
+        await proteusInit(bob);
         // Session for alice
-        await newProteusSessionFromPrekey(ALICE_ID, BOB_ID, SESSION_ID);
+        await newProteusSessionFromPrekey(alice, bob, sessionId);
         const message = "Hello, world!";
         // Session for bob
         const decryptedMessage = await newProteusSessionFromMessage(
-            ALICE_ID,
-            BOB_ID,
-            SESSION_ID,
+            alice,
+            bob,
+            sessionId,
             message
         );
         expect(decryptedMessage).toBe(message);
 
         await expect(
-            newProteusSessionFromMessage(ALICE_ID, BOB_ID, SESSION_ID, message)
+            newProteusSessionFromMessage(alice, bob, sessionId, message)
         ).rejects.toThrow(
             // wdio wraps the error and prepends the original message with
             // the error type as prefix

--- a/crypto-ffi/bindings/js/test/wdio/setData.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/setData.test.ts
@@ -1,5 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import { ALICE_ID, ccInit, setup, teardown } from "./utils";
+import { ccInit, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 
 beforeEach(async () => {
@@ -13,8 +13,9 @@ afterEach(async () => {
 describe("set_data()", () => {
     it("should persist data to DB", async () => {
         const text = "my message processing checkpoint";
+        const alice = crypto.randomUUID();
 
-        await ccInit(ALICE_ID);
+        await ccInit(alice);
 
         const result = await browser.execute(
             async (clientName, text) => {
@@ -35,7 +36,7 @@ describe("set_data()", () => {
                     afterSet: decoder.decode(dbResultAfterSet),
                 };
             },
-            ALICE_ID,
+            alice,
             text
         );
 

--- a/crypto-ffi/bindings/js/test/wdio/transactionContext.test.ts
+++ b/crypto-ffi/bindings/js/test/wdio/transactionContext.test.ts
@@ -1,5 +1,5 @@
 import { browser, expect } from "@wdio/globals";
-import { ALICE_ID, ccInit, setup, teardown } from "./utils";
+import { ccInit, setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import { CoreCryptoError, CoreCryptoContext } from "../../src/CoreCrypto";
 
@@ -13,9 +13,10 @@ afterEach(async () => {
 
 describe("transaction context", () => {
     it("should propagate JS error", async () => {
+        const alice = crypto.randomUUID();
         const expectedErrorMessage = "Message of expected error";
 
-        await ccInit(ALICE_ID);
+        await ccInit(alice);
 
         await expect(
             browser.execute(
@@ -26,7 +27,7 @@ describe("transaction context", () => {
                         throw new Error(expectedMessage);
                     });
                 },
-                ALICE_ID,
+                alice,
                 expectedErrorMessage
             )
             // wdio wraps the error and prepends the original message with
@@ -35,7 +36,8 @@ describe("transaction context", () => {
     });
 
     it("should throw error when using invalid context", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
 
         const error = await browser.execute(async (clientName) => {
             const cc = window.ensureCcDefined(clientName);
@@ -56,7 +58,7 @@ describe("transaction context", () => {
                 return { name: error.name, message: error.message };
             }
             return null;
-        }, ALICE_ID);
+        }, alice);
         expect(error).not.toBeNull();
         expect(error?.name).toEqual("MlsErrorOther");
         expect(error?.message).toEqual(
@@ -65,7 +67,8 @@ describe("transaction context", () => {
     });
 
     it("should roll back transaction after error", async () => {
-        await ccInit(ALICE_ID);
+        const alice = crypto.randomUUID();
+        await ccInit(alice);
 
         const error = await browser.execute(async (clientName) => {
             const cc = window.ensureCcDefined(clientName);
@@ -112,7 +115,7 @@ describe("transaction context", () => {
                 return { name: error.name, message: error.message };
             }
             throw new Error("Expected 'Conversation already exists' error");
-        }, ALICE_ID);
+        }, alice);
         expect(error.message).toBe("Conversation already exists");
     });
 });

--- a/crypto-ffi/bindings/js/test/wdio/utils.ts
+++ b/crypto-ffi/bindings/js/test/wdio/utils.ts
@@ -13,11 +13,6 @@ import {
 
 type ccModuleType = typeof import("../../src/CoreCrypto");
 
-export const ALICE_ID = "alice";
-export const BOB_ID = "bob";
-export const CONV_ID = "convId";
-export const SESSION_ID = "proteusSessionId";
-
 // Logging can be adjusted via the CC_TEST_LOG_LEVEL variable:
 // 0 = no logs
 // 1 = browser logs


### PR DESCRIPTION
The browser instance is reused, which may lead to conflicts and unexpected behaviour.