### PR TITLE
feat: protect key store with file lock during transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- In our Swift bindings we are now protecting against concurrent access from multiple core crypto instances.
+
 ## v8.0.0 - 2025-07-17
 
 ### Highlights

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -1,21 +1,3 @@
-//
-// Wire
-// Copyright (C) 2025 Wire Swiss GmbH
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
 import System
 @_exported public import WireCoreCryptoUniffi
 

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/FilePath+Absolute.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/FilePath+Absolute.swift
@@ -1,21 +1,3 @@
-//
-// Wire
-// Copyright (C) 2025 Wire Swiss GmbH
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program. If not, see http://www.gnu.org/licenses/.
-//
-
 import System
 
 extension FilePath {

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/FilePath+Absolute.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/FilePath+Absolute.swift
@@ -1,0 +1,31 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import System
+
+extension FilePath {
+
+    /// Turn a relative path into an absolute path. If the path is already absolute `self` is returned.
+    func absolutePath() -> FilePath {
+        if isRelative {
+            FilePath(FileManager.default.currentDirectoryPath).pushing(self)
+        } else {
+            self
+        }
+    }
+}

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -489,7 +489,7 @@ final class WireCoreCryptoTests: XCTestCase {
             let epoch: UInt64
         }
 
-        class EpochRecoder: EpochObserver {
+        final class EpochRecorder: EpochObserver {
             var epochs: [Epoch] = []
             func epochChanged(conversationId: ConversationId, epoch: UInt64) async throws {
                 epochs.append(Epoch(conversationId: conversationId, epoch: epoch))
@@ -524,7 +524,7 @@ final class WireCoreCryptoTests: XCTestCase {
         }
 
         // register the observer
-        let epochRecorder = EpochRecoder()
+        let epochRecorder = EpochRecorder()
         try await coreCrypto.registerEpochObserver(epochRecorder)
 
         // in another transaction, change the epoch
@@ -541,7 +541,7 @@ final class WireCoreCryptoTests: XCTestCase {
             let clientId: ClientId
         }
 
-        class HistoryRecoder: HistoryObserver {
+        final class HistoryRecorder: HistoryObserver {
             var secrets: [Secret] = []
             func historyClientCreated(conversationId: ConversationId, secret: HistorySecret)
                 async throws
@@ -578,7 +578,7 @@ final class WireCoreCryptoTests: XCTestCase {
         }
 
         // register the observer
-        let historyRecorder = HistoryRecoder()
+        let historyRecorder = HistoryRecorder()
         try await coreCrypto.registerHistoryObserver(historyRecorder)
 
         // in another transaction, enable history sharing
@@ -592,7 +592,7 @@ final class WireCoreCryptoTests: XCTestCase {
 
     // MARK - helpers
 
-    class MockMlsTransport: MlsTransport {
+    final class MockMlsTransport: MlsTransport {
 
         var lastCommitBundle: CommitBundle?
         var lastMlsMessage: Data?

--- a/crypto/src/transaction_context/proteus.rs
+++ b/crypto/src/transaction_context/proteus.rs
@@ -34,7 +34,7 @@ impl TransactionContext {
     pub async fn proteus_reload_sessions(&self) -> Result<()> {
         let arc = self.proteus_central().await?;
         let mut mutex = arc.lock().await;
-        let proteus = mutex.as_mut().ok_or(Error::ProteusNotInitialized)?;
+        let Some(proteus) = mutex.as_mut() else { return Ok(()) };
         let keystore = self.keystore().await?;
         proteus
             .reload_sessions(&keystore)


### PR DESCRIPTION
# What's new in this PR

Protect against multiple core crypto instances accessing the same key store by holding a file lock on it during a transaction.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
