### PR TITLE
chore: ci: bump open PRs limit to 10 for Rust dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
       - "**"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
   - package-ecosystem: "bun"
     directory: "crypto-ffi/bindings/js"
     schedule:


### PR DESCRIPTION
We've had 4 open dependabot PRs for quite a while, which are essentially blocked on Rust ecosystem moving to rand 0.9. The default dependabot limit for number of opened PRs is 5, which means we only get 1 additional PR, slowing down our updates. So bump the limit to 10.
