### PR TITLE
fix: warning about DYLIB_CURRENT_VERSION getting truncated

### DIFF
--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -23,7 +23,5 @@ mv ${js_path}/package.json.new ${js_path}/package.json
 sed -i "0,/^VERSION_NAME=[0-9.]\+$/{s//VERSION_NAME=${new_version}/;b;}" crypto-ffi/bindings/gradle.properties
 
 # Update Swift package version.
-IFS='.' read -r major minor patch <<< $new_version
-project_version=$((10000 * $major + 100 * $minor + $patch))
 sed -i "0,/^MARKETING_VERSION=[0-9.]\+$/{s//MARKETING_VERSION=${new_version}/;b;}" crypto-ffi/bindings/swift/BuildSettings.xcconfig
-sed -i "0,/^CURRENT_PROJECT_VERSION=[0-9.]\+$/{s//CURRENT_PROJECT_VERSION=${project_version}/;b;}" crypto-ffi/bindings/swift/BuildSettings.xcconfig
+sed -i "0,/^CURRENT_PROJECT_VERSION=[0-9.]\+$/{s//CURRENT_PROJECT_VERSION=${new_version}/;b;}" crypto-ffi/bindings/swift/BuildSettings.xcconfig


### PR DESCRIPTION
# What's new in this PR

When build the Swift bindings we get the following warning:

```
warning build: Truncating -current_version to fit in 32-bit space used by old mach-o format
```

This is because the `DYLIB_CURRENT_VERSION` is now larger (80000) than 65535, which is the calculated as major * 10000 + minor * 100 + patch.

We shouldn't convert our version into single integer but rather keep it as is since the acceptable format for this version is `xxxx.yy.zz`.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
