### PR TITLE
chore: remove Sendable warnings in the Swift bindings

### DIFF
--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -114,9 +114,9 @@ public final class CoreCrypto: CoreCryptoProtocol {
         do {
             try await coreCrypto.transaction(command: transactionExecutor)
         } catch {
-            throw transactionExecutor.innerError ?? error
+            throw await transactionExecutor.innerError ?? error
         }
-        return transactionExecutor.result!
+        return await transactionExecutor.result!
     }
 
     public func provideTransport(transport: any MlsTransport) async throws {
@@ -191,7 +191,7 @@ final class HistoryObserverIndirector: HistoryObserver {
     }
 }
 
-final class TransactionExecutor<Result>: WireCoreCryptoUniffi.CoreCryptoCommand {
+final actor TransactionExecutor<Result>: WireCoreCryptoUniffi.CoreCryptoCommand {
 
     let block: (_ context: CoreCryptoContextProtocol) async throws -> Result
     var result: Result?


### PR DESCRIPTION
# What's new in this PR

The swift compiler gave warnings for classes marked as Sendable and had mutable state. We can resolve the warnings by turning the classes into actors which protect the mutable state.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
