### PR TITLE
ci: use swiftlint for code quality checks [WPB-17421]

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -53,15 +53,18 @@ jobs:
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-            xcode-version: '16.2.0'
-      - name: lint swift bindings
+          xcode-version: '16.2.0'
+      - name: Install swiftlint
         run: |
-            cd crypto-ffi/bindings/swift/WireCoreCrypto
-            swift format lint -r . -s
-      - name: lint swift interop client
+          brew install swiftlint
+      - name: Format-check and lint swift bindings
         run: |
-          cd interop/src/clients/InteropClient
-          swift format lint -r . -s
+          swift format lint -r -s ./crypto-ffi/bindings/swift/WireCoreCrypto
+          swiftlint --strict ./crypto-ffi/bindings/swift/WireCoreCrypto
+      - name: Format-check and lint swift interop client
+        run: |
+          swift format lint -r -s ./interop/src/clients/InteropClient
+          swiftlint --strict ./interop/src/clients/InteropClient
       - name: ios tests
         run: |
           cd crypto-ffi/bindings/swift/WireCoreCrypto

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,21 @@
+opt_in_rules:
+  - missing_docs
+
+missing_docs:
+  warning: true
+  included:
+    - class
+    - struct
+    - enum
+    - extension
+    - protocol
+    - function
+
+disabled_rules:
+  - opening_brace # enforced differently by swift-format
+  - trailing_comma # set by swift-format
+
+line_length:
+  error: 100 # match the line length of swift-format
+  ignores_comments: true
+  ignores_urls: true

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -89,13 +89,13 @@ public final class CoreCrypto: CoreCryptoProtocol {
     /// - Parameter key: secret key to unlock the encrypted key store
     ///
     public convenience init(keystorePath: String, key: DatabaseKey) async throws {
-        let cc =
+        let coreCrypto =
             try await WireCoreCryptoUniffi.coreCryptoDeferredInit(
                 path: keystorePath,
                 key: key,
                 entropySeed: nil
             )
-        self.init(cc, keystorePath: FilePath(stringLiteral: keystorePath))
+        self.init(coreCrypto, keystorePath: FilePath(stringLiteral: keystorePath))
     }
 
     /// Instantiate a history client.
@@ -103,9 +103,9 @@ public final class CoreCrypto: CoreCryptoProtocol {
     /// This client exposes the full interface of `CoreCrypto`, but it should only be used to decrypt messages.
     /// Other use is a logic error.
     public static func historyClient(_ historySecret: HistorySecret) async throws -> CoreCrypto {
-        let cc =
+        let coreCrypto =
             try await WireCoreCryptoUniffi.coreCryptoHistoryClient(historySecret: historySecret)
-        return self.init(cc)
+        return self.init(coreCrypto)
     }
 
     public func transaction<Result>(

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -1,6 +1,8 @@
 import System
 @_exported public import WireCoreCryptoUniffi
 
+/// Defines the protocol for a client.
+///
 public protocol CoreCryptoProtocol {
 
     /// Instantiate a history client.
@@ -254,6 +256,9 @@ final actor TransactionExecutor<Result>: WireCoreCryptoUniffi.CoreCryptoCommand 
 
 }
 
+/// Updates the key of the CoreCrypto database.
+/// To be used only once, when moving from CoreCrypto <= 5.x to CoreCrypto 6.x.
+///
 public func migrateDatabaseKeyTypeToBytes(path: String, oldKey: String, newKey: DatabaseKey)
     async throws
 {

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -9,11 +9,11 @@ public protocol CoreCryptoProtocol {
     /// Other use is a logic error.
     static func historyClient(_ historySecret: HistorySecret) async throws -> Self
 
-    /// Starts a transaction in Core Crypto. If the closure succeeds without throwing an error, it will be committed, otherwise, every operation
-    /// performed with the context will be discarded.
+    /// Starts a transaction in Core Crypto. If the closure succeeds without throwing an error,
+    /// it will be committed, otherwise, every operation performed with the context will be discarded.
     ///
-    /// - Parameter block: the closure to be executed within the transaction context. A ``CoreCryptoContext-swift.protocol``
-    ///  is provided on which any operations should be performed.
+    /// - Parameter block: the closure to be executed within the transaction context.
+    /// A ``CoreCryptoContext-swift.protocol`` is provided on which any operations should be performed.
     ///
     /// - Returns: Result value returned from the closure if any.
     ///
@@ -21,7 +21,8 @@ public protocol CoreCryptoProtocol {
         _ block: @escaping (_ context: CoreCryptoContextProtocol) async throws -> Result
     ) async throws -> Result
 
-    /// Register a callback which will be called when performing MLS operations which require communication with the delivery service.
+    /// Register a callback which will be called when performing MLS operations which require communication
+    /// with the delivery service.
     ///
     func provideTransport(transport: any MlsTransport) async throws
 

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -94,7 +94,8 @@ final class WireCoreCryptoTests: XCTestCase {
         let targetPath = tmpdir.appendingPathComponent(resourceURL.lastPathComponent)
         try FileManager.default.copyItem(at: resourceURL, to: targetPath)
 
-        // The keystore path has to be the same over different instances of the test, because of handle_ios_wal_compat().
+        // The keystore path has to be the same over different instances of the test,
+        // because of handle_ios_wal_compat().
         // Change the working directory so that we can use a relative path for the keystore path.
         let oldWorkingDirectory = FileManager.default.currentDirectoryPath
         FileManager.default.changeCurrentDirectoryPath(tmpdir.path())

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -18,7 +18,7 @@ final class WireCoreCryptoTests: XCTestCase {
 
     func testSetClientDataPersists() async throws {
         let coreCrypto = try await createCoreCrypto()
-        let data = "my message processing checkpoint".data(using: .utf8)!
+        let data = Data("my message processing checkpoint".utf8)
 
         try await coreCrypto.transaction { context in
             let previousData = try await context.getData()
@@ -108,7 +108,7 @@ final class WireCoreCryptoTests: XCTestCase {
         // Check if we can read the conversation from the migrated database
         let alice = try await CoreCrypto(
             keystorePath: targetPath.lastPathComponent, key: newKey)
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let epoch = try await alice.transaction {
             try await $0.conversationEpoch(conversationId: conversationId)
         }
@@ -121,7 +121,7 @@ final class WireCoreCryptoTests: XCTestCase {
 
     func testInteractionWithInvalidContextThrowsError() async throws {
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
-        let aliceId = ClientId(bytes: "alice1".data(using: .utf8)!)
+        let aliceId = ClientId(bytes: Data("alice1".utf8))
         let coreCrypto = try await createCoreCrypto()
         var context: CoreCryptoContextProtocol? = nil
 
@@ -154,8 +154,8 @@ final class WireCoreCryptoTests: XCTestCase {
     func testTransactionRollsBackOnError() async throws {
         struct MyError: Error, Equatable {}
 
-        let aliceId = ClientId(bytes: "alice1".data(using: .utf8)!)
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let aliceId = ClientId(bytes: Data("alice1".utf8))
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
             ciphersuite: ciphersuite,
@@ -294,7 +294,7 @@ final class WireCoreCryptoTests: XCTestCase {
     }
 
     func testErrorTypeMappingShouldWork() async throws {
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let alice = try await createClients("alice1")[0]
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
@@ -342,7 +342,7 @@ final class WireCoreCryptoTests: XCTestCase {
     }
 
     func testConversationExistsShouldReturnTrue() async throws {
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
             ciphersuite: ciphersuite,
@@ -367,7 +367,7 @@ final class WireCoreCryptoTests: XCTestCase {
     }
 
     func testUpdateKeyingMaterialShouldProcessTheCommitMessage() async throws {
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
             ciphersuite: ciphersuite,
@@ -420,7 +420,7 @@ final class WireCoreCryptoTests: XCTestCase {
     }
 
     func testEncryptMessageCanBeDecryptedByReceiver() async throws {
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
             ciphersuite: ciphersuite,
@@ -460,7 +460,7 @@ final class WireCoreCryptoTests: XCTestCase {
                 customConfiguration: configuration.custom
             ).id
         }
-        let message = "Hello World !".data(using: .utf8)!
+        let message = Data("Hello World !".utf8)
         let ciphertext = try await alice.transaction {
             try await $0.encryptMessage(
                 conversationId: conversationId,
@@ -495,8 +495,8 @@ final class WireCoreCryptoTests: XCTestCase {
             }
         }
 
-        let aliceId = ClientId(bytes: "alice1".data(using: .utf8)!)
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let aliceId = ClientId(bytes: Data("alice1".utf8))
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
             ciphersuite: ciphersuite,
@@ -551,8 +551,8 @@ final class WireCoreCryptoTests: XCTestCase {
             }
         }
 
-        let aliceId = ClientId(bytes: "alice1".data(using: .utf8)!)
-        let conversationId = ConversationId(bytes: "conversation1".data(using: .utf8)!)
+        let aliceId = ClientId(bytes: Data("alice1".utf8))
+        let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let configuration = ConversationConfiguration(
             ciphersuite: ciphersuite,
@@ -615,7 +615,7 @@ final class WireCoreCryptoTests: XCTestCase {
             -> WireCoreCryptoUniffi.MlsTransportData
         {
             lastHistorySecret = historySecret
-            return "secret".data(using: .utf8)!
+            return Data("secret".utf8)
         }
 
     }

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 @testable import WireCoreCrypto
 
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
 final class WireCoreCryptoTests: XCTestCase {
 
     var mockMlsTransport: MockMlsTransport = MockMlsTransport()
@@ -124,7 +126,7 @@ final class WireCoreCryptoTests: XCTestCase {
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
         let aliceId = ClientId(bytes: Data("alice1".utf8))
         let coreCrypto = try await createCoreCrypto()
-        var context: CoreCryptoContextProtocol? = nil
+        var context: CoreCryptoContextProtocol?
 
         try await coreCrypto.transaction { context = $0 }
 
@@ -420,6 +422,7 @@ final class WireCoreCryptoTests: XCTestCase {
         XCTAssertTrue(decrypted.hasEpochChanged)
     }
 
+    // swiftlint:disable:next function_body_length
     func testEncryptMessageCanBeDecryptedByReceiver() async throws {
         let conversationId = ConversationId(bytes: Data("conversation1".utf8))
         let ciphersuite = try ciphersuiteFromU16(discriminant: 2)
@@ -594,7 +597,7 @@ final class WireCoreCryptoTests: XCTestCase {
         XCTAssertEqual(recordedSecrets.first!.conversationId, conversationId)
     }
 
-    // MARK - helpers
+    // MARK: - helpers
 
     final actor MockMlsTransport: MlsTransport {
 
@@ -654,6 +657,7 @@ final class WireCoreCryptoTests: XCTestCase {
         var bytes = [UInt8](repeating: 0, count: 32)
         _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
         // constructor only fails if we have other than 32 bytes
+        // swiftlint:disable:next force_try
         return try! DatabaseKey(key: Data(bytes))
     }
 

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -656,6 +656,7 @@ final class WireCoreCryptoTests: XCTestCase {
         return try! DatabaseKey(key: Data(bytes))
     }
 
+    // swift-format-ignore: AlwaysUseLowerCamelCase
     /// Assert that an error is thrown when a block is performed.
     ///
     /// - Parameters:
@@ -664,8 +665,6 @@ final class WireCoreCryptoTests: XCTestCase {
     ///   - message: The error message to show when no error is thrown.
     ///   - file: The file name of the invoking test.
     ///   - line: The line number when this assertion is made.
-
-    // swift-format-ignore: AlwaysUseLowerCamelCase
     func XCTAssertThrowsErrorAsync<E: Error & Equatable>(
         _ expectedError: E,
         when expression: @escaping () async throws -> some Any,
@@ -696,6 +695,7 @@ final class WireCoreCryptoTests: XCTestCase {
         }
     }
 
+    // swift-format-ignore: AlwaysUseLowerCamelCase
     /// Assert that an error is thrown when a block is performed.
     ///
     /// - Parameters:
@@ -704,8 +704,6 @@ final class WireCoreCryptoTests: XCTestCase {
     ///   - file: The file name of the invoking test.
     ///   - line: The line number when this assertion is made.
     ///   - errorHandler: A handler for the thrown error.
-
-    // swift-format-ignore: AlwaysUseLowerCamelCase
     func XCTAssertThrowsErrorAsync(
         _ expression: () async throws -> some Any,
         _ message: String? = nil,

--- a/interop/src/clients/InteropClient/InteropClient/InteropAction.swift
+++ b/interop/src/clients/InteropClient/InteropClient/InteropAction.swift
@@ -23,6 +23,7 @@ enum InteropAction {
 }
 
 extension InteropAction {
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     init?(url: URL) {
         switch url.host() {
         case "init-mls":

--- a/interop/src/clients/InteropClient/InteropClient/InteropClientApp.swift
+++ b/interop/src/clients/InteropClient/InteropClient/InteropClientApp.swift
@@ -80,7 +80,7 @@ struct InteropClientApp: App {
 
         do {
             return .success(value: try await executeAction(action))
-        } catch (let error) {
+        } catch let error {
             return .failure(message: error.localizedDescription)
         }
     }
@@ -92,10 +92,11 @@ struct InteropClientApp: App {
         if status != errSecSuccess {
             throw InteropError.randomBytesError
         }
-
+        // swiftlint:disable:next force_try
         return try! WireCoreCrypto.DatabaseKey(key: Data(bytes))
     }
 
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     private func executeAction(_ action: InteropAction) async throws -> String {
         switch action {
         case .initMLS(let clientId, let ciphersuite):

--- a/interop/src/clients/InteropClient/InteropClient/InteropClientApp.swift
+++ b/interop/src/clients/InteropClient/InteropClient/InteropClientApp.swift
@@ -62,8 +62,15 @@ struct InteropClientApp: App {
 
     private func handleURL(url: URL) async throws {
         let response = await executeURL(url: url)
-        print(
-            String(decoding: try JSONEncoder().encode(response), as: UTF8.self))
+        let data = try JSONEncoder().encode(response)
+        guard let jsonString = String(data: data, encoding: .utf8) else {
+            throw EncodingError.invalidValue(
+                data,
+                EncodingError.Context(codingPath: [], debugDescription: "UTF-8 conversion failed")
+            )
+        }
+
+        print(jsonString)
     }
 
     private func executeURL(url: URL) async -> InteropResponse {


### PR DESCRIPTION
# What's new in this PR
This PR adds Swiftlint to report code quality issues during CI.
Swiftlint configs are added to the swift projects and configured to match settings of swift-format. 
Swiftlint uses --strict to fail on warnings.
A main feature of Swiftlint is the detection of undocumented items and other code guidelines that swift-format does can't check.
----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
