### PR TITLE
chore: crypto-ffi: fix typedoc warning

### DIFF
--- a/crypto-ffi/bindings/js/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/src/CoreCrypto.ts
@@ -110,7 +110,7 @@ export async function initWasmModule(location: string | undefined = undefined) {
         );
         const file = await fs.open(path);
         const buffer = await file.readFile();
-        const module = new WebAssembly.Module(buffer);
+        const module = new WebAssembly.Module(new Uint8Array(buffer));
         await initWasm({ module_or_path: module });
     }
 }


### PR DESCRIPTION
This fixes the following:

  error TS2345: Argument of type 'Buffer<ArrayBufferLike>' is not assignable
  to parameter of type 'BufferSource'.
