### PR TITLE
docs: add android ndk installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ and add an alias to your shell configuration file: `alias sed=gsed` (e.g. to `~/
 
 ### Android
 
-Install Android SDK and Build-Tools for API level 30+
+[Install Android SDK](https://developer.android.com/studio) and Build-Tools for API level 30+
 
 > [!important]
 > If you are building on macOS you'll need to setup `$ANDROID_SDK_ROOT` path variable manually:
 > ```ignore
 > export ANDROID_SDK_ROOT=~/Android/Sdk
 > ```
+
+[Install the Android NDK](https://developer.android.com/studio/projects/install-ndk)
 
 Install android rust targets:
 ```ignore


### PR DESCRIPTION
# What's new in this PR
This PR adds the missing step of installing the android ndk to the android build prerequisites.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
