### PR TITLE
build: replace `async-std` with `smol` [WPB-16567]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smol",
  "tinytemplate",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,6 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
- "smol",
  "smol-macros",
  "thiserror 2.0.14",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -175,27 +175,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "winnow 0.7.10",
-]
-
-[[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -235,21 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,9 +238,38 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -287,34 +280,25 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
-name = "async-std"
-version = "1.13.1"
+name = "async-signal"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
 dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
  "async-io",
  "async-lock",
- "crossbeam-utils",
- "futures-channel",
+ "atomic-waker",
+ "cfg-if",
  "futures-core",
  "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
+ "rustix 1.0.7",
+ "signal-hook-registry",
  "slab",
- "wasm-bindgen-futures",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -331,7 +315,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -421,7 +405,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -655,7 +639,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -813,7 +797,6 @@ dependencies = [
  "async-fs",
  "async-lock",
  "async-recursion",
- "async-std",
  "async-trait",
  "base64 0.22.1",
  "cfg-if",
@@ -829,6 +812,7 @@ dependencies = [
  "itertools 0.13.0",
  "js-sys",
  "log",
+ "macro_rules_attribute",
  "mls-crypto-provider",
  "openmls",
  "openmls_basic_credential",
@@ -847,6 +831,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
+ "smol",
+ "smol-macros",
  "strum",
  "tempfile",
  "thiserror 2.0.14",
@@ -868,7 +854,7 @@ dependencies = [
 name = "core-crypto-ffi"
 version = "8.0.0"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-lock",
  "async-trait",
  "cfg-if",
@@ -907,7 +893,6 @@ dependencies = [
  "aes-gcm",
  "async-fs",
  "async-lock",
- "async-std",
  "async-trait",
  "blocking",
  "cfg-if",
@@ -925,6 +910,7 @@ dependencies = [
  "itertools 0.13.0",
  "js-sys",
  "log",
+ "macro_rules_attribute",
  "mls-crypto-provider",
  "openmls",
  "openmls_basic_credential",
@@ -944,6 +930,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
+ "smol",
+ "smol-macros",
  "thiserror 2.0.14",
  "uuid",
  "wasm-bindgen",
@@ -961,7 +949,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1015,7 +1003,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
- "async-std",
  "cast",
  "ciborium",
  "clap",
@@ -1136,7 +1123,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1160,7 +1147,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1171,7 +1158,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1205,7 +1192,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1236,7 +1223,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1246,7 +1233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1266,7 +1253,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1290,7 +1277,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1432,12 +1419,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -1453,7 +1434,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1645,7 +1626,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1742,18 +1723,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "goblin"
@@ -2198,7 +2167,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2386,7 +2355,7 @@ checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2473,15 +2442,6 @@ dependencies = [
  "serde_json",
  "tls_codec",
  "tokio",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -2577,6 +2537,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,7 +2627,6 @@ version = "8.0.0"
 dependencies = [
  "aes-gcm",
  "async-lock",
- "async-std",
  "async-trait",
  "cfg-if",
  "chacha20poly1305",
@@ -2664,6 +2639,7 @@ dependencies = [
  "hkdf 0.12.4",
  "hmac",
  "hpke",
+ "macro_rules_attribute",
  "openmls",
  "openmls_traits",
  "p256",
@@ -2677,6 +2653,7 @@ dependencies = [
  "sha1",
  "sha2",
  "signature",
+ "smol-macros",
  "spki",
  "thiserror 2.0.14",
  "tls_codec",
@@ -2897,7 +2874,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3049,7 +3026,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3098,7 +3075,7 @@ source = "git+https://github.com/wireapp/rust-pki.git?branch=wire%2Fstable#b08b3
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3366,7 +3343,7 @@ checksum = "a25d631e41bfb5fdcde1d4e2215f62f7f0afa3ff11e26563765bd6ea1d229aeb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3417,7 +3394,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3512,7 +3489,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.104",
+ "syn",
  "unicode-ident",
 ]
 
@@ -3524,7 +3501,7 @@ checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
  "rand",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3730,7 +3707,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3839,7 +3816,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3983,6 +3960,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "smol-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcaedb62e0475a6898988138995ec7b1e5d116167a72bb12c7b59d0649fbbc2"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "event-listener",
+ "futures-lite",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,7 +4090,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4178,17 +4185,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -4206,7 +4202,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4266,7 +4262,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4277,7 +4273,7 @@ checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4363,7 +4359,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4394,7 +4390,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4568,7 +4564,7 @@ checksum = "6a840d281b4e2b22f6ca51168a373c06e7044e06420f0f12fe0e7b62c28df2f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4678,7 +4674,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4693,7 +4689,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.104",
+ "syn",
  "toml",
  "uniffi_meta",
 ]
@@ -4973,7 +4969,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5008,7 +5004,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5043,7 +5039,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -5116,6 +5112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5143,6 +5145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5166,11 +5177,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5186,6 +5214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,6 +5230,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5210,10 +5250,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5228,6 +5280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,6 +5296,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5252,6 +5316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,6 +5332,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -5384,7 +5460,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "synstructure",
 ]
 
@@ -5406,7 +5482,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -5426,7 +5502,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "synstructure",
 ]
 
@@ -5448,7 +5524,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -5470,5 +5546,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 members = [
-  "crypto",
-  "crypto-ffi",
-  "crypto-macros",
-  "keystore",
-  "keystore-dump",
-  "mls-provider",
-  "interop",
-  "decode",
+    "crypto",
+    "crypto-ffi",
+    "crypto-macros",
+    "keystore",
+    "keystore-dump",
+    "mls-provider",
+    "interop",
+    "decode",
 ]
 resolver = "2"
 
@@ -17,14 +17,13 @@ undocumented_unsafe_blocks = "deny"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(wasm_bindgen_unstable_test_coverage)',
+    'cfg(wasm_bindgen_unstable_test_coverage)',
 ] }
 
 [workspace.dependencies]
 async-channel = "2.5.0"
 async-lock = "3.4"
 async-recursion = "1"
-async-std = "1.13"
 async-trait = "0.1"
 base64 = "0.22"
 bitflags = "2.9"
@@ -35,15 +34,15 @@ core-crypto = { path = "crypto" }
 core-crypto-keystore = { path = "keystore" }
 core-crypto-macros = { path = "crypto-macros" }
 derive_more = { version = "2.0", features = [
-  "from",
-  "into",
-  "try_from",
-  "constructor",
-  "display",
-  "debug",
-  "as_ref",
-  "deref",
-  "deref_mut",
+    "from",
+    "into",
+    "try_from",
+    "constructor",
+    "display",
+    "debug",
+    "as_ref",
+    "deref",
+    "deref_mut",
 ] }
 futures-util = "0.3"
 hex = "0.4"
@@ -52,6 +51,7 @@ indexmap = "2"
 itertools = "0.13"
 log = { version = "0.4", features = ["kv_serde"] }
 log-reload = "0.1.3"
+macro_rules_attribute = "0.2"
 mls-crypto-provider = { path = "mls-provider" }
 pem = "3.0"
 rand = { version = "0.8", features = ["getrandom"] }
@@ -61,6 +61,8 @@ serde = "1.0"
 serde_json = "1.0"
 sha1 = "0.10"
 sha2 = "0.10"
+smol = "2.0"
+smol-macros = "0.1"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "2.0"
 tls_codec = "0.4.2"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -81,7 +81,6 @@ js-sys = "0.3"
 rstest = "0.26"
 rstest_reuse = "0.7"
 env_logger = "0.11"
-async-std = { workspace = true, features = ["attributes"] }
 futures-util = { workspace = true, features = ["std", "alloc"] }
 proteus-traits = { workspace = true }
 async-trait.workspace = true
@@ -91,13 +90,16 @@ time = { version = "0.3", features = ["wasm-bindgen"] }
 core-crypto-keystore = { workspace = true, features = ["dummy-entity"] }
 core-crypto-macros = { workspace = true }
 rmp-serde = { workspace = true }
+smol.workspace = true
+smol-macros.workspace = true
+macro_rules_attribute.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 proteus = { git = "https://github.com/wireapp/proteus", branch = "otak/fix-1.0.3" }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies.criterion]
 version = "0.7"
-features = ["async_std", "html_reports"]
+features = ["html_reports"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -99,7 +99,7 @@ proteus = { git = "https://github.com/wireapp/proteus", branch = "otak/fix-1.0.3
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies.criterion]
 version = "0.7"
-features = ["html_reports"]
+features = ["async_smol", "html_reports"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -19,7 +19,7 @@ fn commit_add_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             let (kp, _) = rand_key_package(ciphersuite).await;
@@ -47,7 +47,7 @@ fn commit_add_n_clients_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, _) = setup_mls(ciphersuite, credential.as_ref(), in_memory).await;
                             let mut kps = Vec::with_capacity(*i);
                             for _ in 0..*i {
@@ -79,7 +79,7 @@ fn commit_remove_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, client_ids, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             (central, id, client_ids)
@@ -116,7 +116,7 @@ fn commit_remove_n_clients_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, client_ids, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, GROUP_MAX).await;
                             let to_remove = client_ids[..*i].to_vec();
@@ -153,7 +153,7 @@ fn commit_update_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             (central, id)
@@ -190,7 +190,7 @@ fn commit_pending_proposals_bench_var_n_proposals(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, GROUP_MAX).await;
 
@@ -235,7 +235,7 @@ fn commit_pending_proposals_bench_var_group_size(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             let context = central.new_transaction().await.unwrap();

--- a/crypto/benches/commit.rs
+++ b/crypto/benches/commit.rs
@@ -3,7 +3,7 @@
 use std::hint::black_box;
 
 use criterion::{
-    BatchSize, Criterion, async_executor::AsyncStdExecutor as FuturesExecutor, criterion_group, criterion_main,
+    BatchSize, Criterion, async_executor::SmolExecutor as FuturesExecutor, criterion_group, criterion_main,
 };
 
 use crate::utils::*;

--- a/crypto/benches/create_group.rs
+++ b/crypto/benches/create_group.rs
@@ -1,8 +1,7 @@
 use std::hint::black_box;
 
 use criterion::{
-    BatchSize, BenchmarkId, Criterion, async_executor::AsyncStdExecutor as FuturesExecutor, criterion_group,
-    criterion_main,
+    BatchSize, BenchmarkId, Criterion, async_executor::SmolExecutor as FuturesExecutor, criterion_group, criterion_main,
 };
 
 use core_crypto::prelude::{MlsConversationConfiguration, MlsCredentialType, MlsCustomConfiguration};

--- a/crypto/benches/create_group.rs
+++ b/crypto/benches/create_group.rs
@@ -22,7 +22,7 @@ fn create_group_bench(c: &mut Criterion) {
             |b, ciphersuite| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, ..) = new_central(*ciphersuite, credential.as_ref(), in_memory).await;
                             let id = conversation_id();
                             let cfg = MlsConversationConfiguration {
@@ -57,7 +57,7 @@ fn join_from_welcome_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (alice_central, id, _, _, delivery_service) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
 
@@ -108,7 +108,7 @@ fn join_from_group_info_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (_, _, _, group_info, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             let (bob_central, ..) = new_central(ciphersuite, credential.as_ref(), in_memory).await;

--- a/crypto/benches/encryption.rs
+++ b/crypto/benches/encryption.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use criterion::{
-    BatchSize, Criterion, async_executor::AsyncStdExecutor as FuturesExecutor, criterion_group, criterion_main,
+    BatchSize, Criterion, async_executor::SmolExecutor as FuturesExecutor, criterion_group, criterion_main,
 };
 use rand::distributions::{Alphanumeric, DistString};
 

--- a/crypto/benches/encryption.rs
+++ b/crypto/benches/encryption.rs
@@ -17,7 +17,7 @@ fn encryption_bench_var_group_size(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             let text = Alphanumeric.sample_string(&mut rand::thread_rng(), MSG_MAX);
@@ -52,7 +52,7 @@ fn encryption_bench_var_msg_size(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, GROUP_MAX).await;
                             let text = Alphanumeric.sample_string(&mut rand::thread_rng(), *i);
@@ -87,7 +87,7 @@ fn decryption_bench_var_msg_size(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (mut alice_central, id, delivery_service) =
                                 setup_mls(ciphersuite, credential.as_ref(), in_memory).await;
                             let (mut bob_central, ..) = new_central(ciphersuite, credential.as_ref(), in_memory).await;

--- a/crypto/benches/key_package.rs
+++ b/crypto/benches/key_package.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use core_crypto::prelude::MlsCredentialType;
 use criterion::{
-    BatchSize, Criterion, async_executor::AsyncStdExecutor as FuturesExecutor, criterion_group, criterion_main,
+    BatchSize, Criterion, async_executor::SmolExecutor as FuturesExecutor, criterion_group, criterion_main,
 };
 
 use crate::utils::*;

--- a/crypto/benches/key_package.rs
+++ b/crypto/benches/key_package.rs
@@ -20,7 +20,7 @@ fn generate_key_package_bench(c: &mut Criterion) {
         for i in (GROUP_RANGE).step_by(GROUP_STEP) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
-                    || async_std::task::block_on(setup_mls(ciphersuite, credential.as_ref(), in_memory)),
+                    || smol::block_on(setup_mls(ciphersuite, credential.as_ref(), in_memory)),
                     |(central, _, _)| async move {
                         let context = central.new_transaction().await.unwrap();
                         black_box(
@@ -50,7 +50,7 @@ fn count_key_packages_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, ..) = setup_mls(ciphersuite, credential.as_ref(), in_memory).await;
 
                             let context = central.new_transaction().await.unwrap();

--- a/crypto/benches/proposal.rs
+++ b/crypto/benches/proposal.rs
@@ -16,7 +16,7 @@ fn proposal_add_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             let (kp, ..) = rand_key_package(ciphersuite).await;
@@ -43,7 +43,7 @@ fn proposal_remove_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, client_ids, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             (central, id, client_ids.first().unwrap().clone())
@@ -69,7 +69,7 @@ fn proposal_update_bench(c: &mut Criterion) {
             group.bench_with_input(case.benchmark_id(i + 1, in_memory), &i, |b, i| {
                 b.to_async(FuturesExecutor).iter_batched(
                     || {
-                        async_std::task::block_on(async {
+                        smol::block_on(async {
                             let (central, id, ..) =
                                 setup_mls_and_add_clients(ciphersuite, credential.as_ref(), in_memory, *i).await;
                             (central, id)

--- a/crypto/benches/proposal.rs
+++ b/crypto/benches/proposal.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use criterion::{
-    BatchSize, Criterion, async_executor::AsyncStdExecutor as FuturesExecutor, criterion_group, criterion_main,
+    BatchSize, Criterion, async_executor::SmolExecutor as FuturesExecutor, criterion_group, criterion_main,
 };
 
 use crate::utils::*;

--- a/crypto/benches/transaction.rs
+++ b/crypto/benches/transaction.rs
@@ -26,7 +26,7 @@ fn decrypt_transaction(c: &mut Criterion) {
         group.bench_with_input(id, &transactional, |b, transactional| {
             b.to_async(FuturesExecutor).iter_batched(
                 || {
-                    async_std::task::block_on(async {
+                    smol::block_on(async {
                         let (mut alice_central, id, delivery_service) =
                             setup_mls(ciphersuite, credential.as_ref(), in_memory).await;
                         let (mut bob_central, ..) = new_central(ciphersuite, credential.as_ref(), in_memory).await;

--- a/crypto/src/group_store.rs
+++ b/crypto/src/group_store.rs
@@ -253,7 +253,7 @@ mod tests {
 
     type TestGroupStore = GroupStore<DummyValue>;
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn group_store_init() {
         let store = TestGroupStore::new_with_limit(1);
         assert_eq!(store.len(), 0);
@@ -269,7 +269,7 @@ mod tests {
         assert_eq!(store.len(), 0);
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn group_store_common_ops() {
         let mut store = TestGroupStore::new(Some(u32::MAX), Some(usize::MAX));
         for i in 1..=3 {
@@ -292,7 +292,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn group_store_operations_len_limiter() {
         let mut store = TestGroupStore::new_with_limit(2);
         assert!(store.try_insert(b"1".to_vec(), "1".into()).is_ok());
@@ -308,7 +308,7 @@ mod tests {
         assert_eq!(store.len(), 2);
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn group_store_operations_mem_limiter() {
         use schnellru::{LruMap, UnlimitedCompact};
         let mut lru: LruMap<Vec<u8>, DummyValue, UnlimitedCompact> =

--- a/crypto/src/mls/conversation/config.rs
+++ b/crypto/src/mls/conversation/config.rs
@@ -198,8 +198,8 @@ mod tests {
     use crate::mls::conversation::ConversationWithMls as _;
     use crate::{prelude::MlsConversationConfiguration, test_utils::*};
 
-    #[async_std::test]
-    pub async fn group_should_have_required_capabilities() {
+    #[macro_rules_attribute::apply(smol_macros::test)]
+    async fn group_should_have_required_capabilities() {
         let case = TestContext::default();
 
         let [session] = case.sessions().await;

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -620,7 +620,7 @@ mod tests {
             );
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_read_device_identities() {
             let case = TestContext::default_x509();
 
@@ -679,7 +679,7 @@ mod tests {
             .await
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_read_revoked_device_cross_signed() {
             let case = TestContext::default_x509();
             let alice_user_id = uuid::Uuid::new_v4();
@@ -734,7 +734,7 @@ mod tests {
             .await
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_read_revoked_device() {
             let case = TestContext::default_x509();
             let rupert_user_id = uuid::Uuid::new_v4();
@@ -780,7 +780,7 @@ mod tests {
             .await
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_not_fail_when_basic() {
             let case = TestContext::default();
 
@@ -822,7 +822,7 @@ mod tests {
 
         // this test is a duplicate of its counterpart but taking federation into account
         // The heavy lifting of cross-signing the certificates is being done by the test utils.
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_read_users_cross_signed() {
             let case = TestContext::default_x509();
             let [alice_1_id, alice_2_id] = case.x509_client_ids_for_user(&uuid::Uuid::new_v4());
@@ -886,7 +886,7 @@ mod tests {
             .await
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_read_users() {
             let case = TestContext::default_x509();
             let [alice_android, alice_ios] = case.x509_client_ids_for_user(&uuid::Uuid::new_v4());
@@ -939,7 +939,7 @@ mod tests {
             .await
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_exchange_messages_cross_signed() {
             let case = TestContext::default_x509();
             let sessions = case.sessions_x509_cross_signed::<3, 3>().await;

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -266,7 +266,7 @@ mod tests {
             let elapsed = start.elapsed();
             // Give time to the certificate to expire
             if expiration_time > elapsed {
-                async_std::task::sleep(expiration_time - elapsed + core::time::Duration::from_secs(2)).await;
+                smol::Timer::after(expiration_time - elapsed + core::time::Duration::from_secs(2)).await;
             }
 
             assert!(conversation.is_functional_and_contains([&alice, &bob]).await);

--- a/crypto/src/mls/mod.rs
+++ b/crypto/src/mls/mod.rs
@@ -107,7 +107,7 @@ mod tests {
             assert!(matches!(config_err, mls::Error::MalformedIdentifier(msg) if msg.contains("path")));
         }
 
-        #[async_std::test]
+        #[macro_rules_attribute::apply(smol_macros::test)]
         async fn client_id_should_not_be_empty() {
             let mut case = TestContext::default();
             let tmp_dir = case.tmp_dir().await;

--- a/crypto/src/mls/session/identities.rs
+++ b/crypto/src/mls/session/identities.rs
@@ -142,7 +142,7 @@ mod tests {
                 let old = central.new_credential_bundle(&case, cert.as_ref()).await;
 
                 // wait to make sure we're not in the same second
-                async_std::task::sleep(core::time::Duration::from_secs(1)).await;
+                smol::Timer::after(core::time::Duration::from_secs(1)).await;
 
                 let new = central.new_credential_bundle(&case, cert.as_ref()).await;
                 assert_ne!(old, new);

--- a/crypto/src/mls/session/key_package.rs
+++ b/crypto/src/mls/session/key_package.rs
@@ -381,7 +381,7 @@ mod tests {
             .unwrap();
         let kp_1s_exp = session.generate_one_keypackage(&backend, cs, ct).await.unwrap();
         // Sleep 2 seconds to make sure we make the kp expire
-        async_std::task::sleep(std::time::Duration::from_secs(2)).await;
+        smol::Timer::after(std::time::Duration::from_secs(2)).await;
         assert!(Session::is_mls_keypackage_expired(&kp_1s_exp));
     }
 
@@ -582,7 +582,7 @@ mod tests {
         assert_eq!(partially_expired_kpbs.len(), EXPIRED_COUNT);
 
         // Sleep to trigger the expiration
-        async_std::task::sleep(std::time::Duration::from_secs(10)).await;
+        smol::Timer::after(std::time::Duration::from_secs(10)).await;
 
         // Request the same number of keypackages. The automatic lifetime-based expiration should take
         // place and remove old expired keypackages and generate fresh ones instead

--- a/crypto/src/mls/session/user_id.rs
+++ b/crypto/src/mls/session/user_id.rs
@@ -49,14 +49,14 @@ impl TryFrom<UserId<'_>> for String {
 mod tests {
     use super::*;
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn should_parse_client_id() {
         let user_id = "LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com";
         let user_id = UserId::try_from(user_id).unwrap();
         assert_eq!(user_id, UserId("LcksJb74Tm6N12cDjFy7lQ".as_bytes()));
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn should_fail_when_invalid() {
         let user_id = "LcksJb74Tm6N12cDjFy7lQ/8e6424430d3b28be@world.com";
         let user_id = UserId::try_from(user_id);

--- a/crypto/src/proteus.rs
+++ b/crypto/src/proteus.rs
@@ -672,7 +672,7 @@ mod tests {
         drop(db_file);
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn can_init() {
         #[cfg(not(target_family = "wasm"))]
         let (path, db_file) = tmp_db_file();
@@ -700,7 +700,7 @@ mod tests {
         drop(db_file);
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn can_talk_with_proteus() {
         #[cfg(not(target_family = "wasm"))]
         let (path, db_file) = tmp_db_file();
@@ -741,7 +741,7 @@ mod tests {
         drop(db_file);
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn can_produce_proteus_consumed_prekeys() {
         #[cfg(not(target_family = "wasm"))]
         let (path, db_file) = tmp_db_file();
@@ -782,7 +782,7 @@ mod tests {
         drop(db_file);
     }
 
-    #[async_std::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn auto_prekeys_are_sequential() {
         use core_crypto_keystore::entities::ProteusPrekey;
         const GAP_AMOUNT: u16 = 5;

--- a/crypto/src/test_utils/test_context.rs
+++ b/crypto/src/test_utils/test_context.rs
@@ -71,7 +71,7 @@ use super::{
     )),
     case::pure_ciphertext(TestContext::default_cipher()),
 )]
-#[async_std::test]
+#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
 #[allow(non_snake_case)]
 pub fn all_cred_cipher(case: TestContext) {}
 

--- a/crypto/src/transaction_context/e2e_identity/conversation_state.rs
+++ b/crypto/src/transaction_context/e2e_identity/conversation_state.rs
@@ -190,7 +190,7 @@ mod tests {
             let elapsed = start.elapsed();
             // Give time to the certificate to expire
             if expiration_time > elapsed {
-                async_std::task::sleep(expiration_time - elapsed + core::time::Duration::from_secs(1)).await;
+                smol::Timer::after(expiration_time - elapsed + core::time::Duration::from_secs(1)).await;
             }
 
             let alice_state = conversation.e2ei_state().await;
@@ -249,7 +249,7 @@ mod tests {
             let elapsed = start.elapsed();
             // Give time to the certificate to expire
             if expiration_time > elapsed {
-                async_std::task::sleep(expiration_time - elapsed + core::time::Duration::from_secs(1)).await;
+                smol::Timer::after(expiration_time - elapsed + core::time::Duration::from_secs(1)).await;
             }
 
             let alice_state = conversation.e2ei_state().await;

--- a/crypto/src/transaction_context/e2e_identity/rotate.rs
+++ b/crypto/src/transaction_context/e2e_identity/rotate.rs
@@ -443,7 +443,7 @@ mod tests {
 
                 // simulate a real rotation where both credential are not created within the same second
                 // we only have a precision of 1 second for the `created_at` field of the Credential
-                async_std::task::sleep(core::time::Duration::from_secs(1)).await;
+                smol::Timer::after(core::time::Duration::from_secs(1)).await;
 
                 let is_renewal = case.credential_type == MlsCredentialType::X509;
 

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -91,7 +91,6 @@ openmls = { workspace = true, features = ["crypto-subtle"] }
 mls-crypto-provider.workspace = true
 rstest = "0.26"
 rstest_reuse = "0.7"
-async-std = { workspace = true, features = ["attributes"] }
 futures-lite = "2.6"
 core-crypto-keystore = { path = ".", features = [
     "idb-regression-test",
@@ -99,6 +98,9 @@ core-crypto-keystore = { path = ".", features = [
 ] }
 env_logger = "0.11"
 proteus-wasm = { workspace = true }
+smol.workspace = true
+smol-macros.workspace = true
+macro_rules_attribute.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies.criterion]
 version = "0.7"

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -98,7 +98,8 @@ core-crypto-keystore = { path = ".", features = [
 ] }
 env_logger = "0.11"
 proteus-wasm = { workspace = true }
-smol.workspace = true
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 smol-macros.workspace = true
 macro_rules_attribute.workspace = true
 

--- a/keystore/tests/common.rs
+++ b/keystore/tests/common.rs
@@ -57,7 +57,7 @@ impl KeystoreTestContext {
 impl Drop for KeystoreTestContext {
     fn drop(&mut self) {
         if let Some(store) = self.store.take() {
-            async_std::task::block_on(async {
+            smol::block_on(async {
                 store.commit_transaction().await.expect("Could not commit transaction");
                 store.wipe().await.expect("Could not wipe store");
             });
@@ -69,5 +69,5 @@ impl Drop for KeystoreTestContext {
 #[rstest]
 #[case::persistent(setup(store_name(), false).await)]
 #[case::in_memory(setup(store_name(), true).await)]
-#[async_std::test]
+#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
 pub async fn all_storage_types(#[case] context: KeystoreTestContext) {}

--- a/keystore/tests/common.rs
+++ b/keystore/tests/common.rs
@@ -57,7 +57,7 @@ impl KeystoreTestContext {
 impl Drop for KeystoreTestContext {
     fn drop(&mut self) {
         if let Some(store) = self.store.take() {
-            smol::block_on(async {
+            futures_lite::future::block_on(async {
                 store.commit_transaction().await.expect("Could not commit transaction");
                 store.wipe().await.expect("Could not wipe store");
             });
@@ -69,5 +69,9 @@ impl Drop for KeystoreTestContext {
 #[rstest]
 #[case::persistent(setup(store_name(), false).await)]
 #[case::in_memory(setup(store_name(), true).await)]
-#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
+#[cfg_attr(
+    not(target_family = "wasm"),
+    test_attr(macro_rules_attribute::apply(smol_macros::test))
+)]
+#[cfg_attr(target_family = "wasm", test_attr(wasm_bindgen_test))]
 pub async fn all_storage_types(#[case] context: KeystoreTestContext) {}

--- a/keystore/tests/general.rs
+++ b/keystore/tests/general.rs
@@ -19,7 +19,7 @@ mod tests {
     }
 
     #[cfg(target_os = "ios")]
-    #[cfg_attr(not(target_family = "wasm"), async_std::test)]
+    #[cfg_attr(not(target_family = "wasm"), macro_rules_attribute::apply(smol_macros::test))]
     async fn can_preserve_wal_compat_for_ios() {
         let store1 = setup("ios-wal-compat", false).await;
         drop(store1);

--- a/keystore/tests/general.rs
+++ b/keystore/tests/general.rs
@@ -13,7 +13,6 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[apply(all_storage_types)]
-    #[wasm_bindgen_test]
     pub async fn can_create_and_init_store(_context: KeystoreTestContext) {
         // just runs the setup and teardown, which creates the store and wipes it afterward.
     }

--- a/keystore/tests/mls.rs
+++ b/keystore/tests/mls.rs
@@ -62,7 +62,6 @@ mod tests {
     }
 
     #[apply(all_storage_types)]
-    #[wasm_bindgen_test]
     pub async fn can_add_read_delete_credential_bundle_openmls_traits(context: KeystoreTestContext) {
         use core_crypto_keystore::connection::FetchFromDatabase;
         use itertools::Itertools as _;

--- a/keystore/tests/proteus.rs
+++ b/keystore/tests/proteus.rs
@@ -25,7 +25,6 @@ mod tests {
     }
 
     #[apply(all_storage_types)]
-    #[wasm_bindgen_test]
     pub async fn can_add_read_delete_prekey_traits(mut context: KeystoreTestContext) {
         use core_crypto_keystore::CryptoKeystoreProteus as _;
         use proteus_traits::PreKeyStore as _;

--- a/keystore/tests/z_entities.rs
+++ b/keystore/tests/z_entities.rs
@@ -17,7 +17,6 @@ macro_rules! pat_to_bool {
 macro_rules! test_for_entity {
     ($test_name:ident, $entity:ident $(ignore_entity_count:$ignore_entity_count:literal)? $(ignore_update:$ignore_update:literal)? $(ignore_find_many:$ignore_find_many:literal)?) => {
         #[apply(all_storage_types)]
-        #[wasm_bindgen_test]
         async fn $test_name(context: KeystoreTestContext) {
             let store = context.store();
             let _ = env_logger::try_init();
@@ -181,7 +180,6 @@ mod tests {
     }
 
     #[apply(all_storage_types)]
-    #[wasm_bindgen_test]
     pub async fn update_e2ei_enrollment_emits_error(context: KeystoreTestContext) {
         let store = context.store();
 

--- a/keystore/tests/z_entities.rs
+++ b/keystore/tests/z_entities.rs
@@ -179,6 +179,10 @@ mod tests {
         }
     }
 
+    // This test cannot pass on WASM: if you grep through the codebase, you'll note that
+    // `CoreCryptoKeystore::AlreadyExists` is only produced in one place: in the entity derive macro,
+    // in the non-wasm branch of the derive implementation.
+    #[cfg_attr(target_family = "wasm", should_panic)]
     #[apply(all_storage_types)]
     pub async fn update_e2ei_enrollment_emits_error(context: KeystoreTestContext) {
         let store = context.store();

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -57,5 +57,7 @@ rstest = "0.26"
 rstest_reuse = "0.7"
 cfg-if.workspace = true
 hex-literal = "1.0"
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 smol-macros.workspace = true
 macro_rules_attribute.workspace = true

--- a/mls-provider/Cargo.toml
+++ b/mls-provider/Cargo.toml
@@ -55,6 +55,7 @@ uuid = { workspace = true, features = ["v4", "js"] }
 openmls.workspace = true
 rstest = "0.26"
 rstest_reuse = "0.7"
-async-std = { workspace = true, features = ["attributes"] }
 cfg-if.workspace = true
 hex-literal = "1.0"
+smol-macros.workspace = true
+macro_rules_attribute.workspace = true

--- a/mls-provider/tests/crypto.rs
+++ b/mls-provider/tests/crypto.rs
@@ -22,7 +22,6 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn ciphersuite_support_is_consistent(backend: MlsCryptoProvider) {
         let backend = backend.await;
         let crypto = backend.crypto();
@@ -35,7 +34,6 @@ mod tests {
     }
 
     #[apply(all_storage_types_and_ciphersuites)]
-    #[wasm_bindgen_test]
     async fn hkdf_is_consistent(
         backend: MlsCryptoProvider,
         ciphersuite: Ciphersuite,
@@ -68,7 +66,6 @@ mod tests {
     }
 
     #[apply(all_storage_types_and_ciphersuites)]
-    #[wasm_bindgen_test]
     async fn hash_is_consistent(
         backend: MlsCryptoProvider,
         ciphersuite: Ciphersuite,
@@ -87,7 +84,6 @@ mod tests {
     }
 
     #[apply(all_storage_types_and_ciphersuites)]
-    #[wasm_bindgen_test]
     async fn aead_is_consistent_and_can_roundtrip(
         backend: MlsCryptoProvider,
         ciphersuite: Ciphersuite,
@@ -121,7 +117,6 @@ mod tests {
     }
 
     #[apply(all_storage_types_and_ciphersuites)]
-    #[wasm_bindgen_test]
     async fn signature_is_consistent(
         backend: MlsCryptoProvider,
         ciphersuite: Ciphersuite,
@@ -145,7 +140,6 @@ mod tests {
     }
 
     #[apply(all_storage_types_and_ciphersuites)]
-    #[wasm_bindgen_test]
     async fn hpke_is_consistent(
         backend: MlsCryptoProvider,
         ciphersuite: Ciphersuite,

--- a/mls-provider/tests/fixtures.rs
+++ b/mls-provider/tests/fixtures.rs
@@ -39,7 +39,11 @@ pub(crate) async fn setup(#[default(false)] in_memory: bool) -> MlsCryptoProvide
 
 #[template]
 #[rstest]
-#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
+#[cfg_attr(
+    not(target_family = "wasm"),
+    test_attr(macro_rules_attribute::apply(smol_macros::test))
+)]
+#[cfg_attr(target_family = "wasm", test_attr(wasm_bindgen_test))]
 async fn use_provider(
     #[from(setup)]
     #[with(true)]
@@ -157,7 +161,11 @@ pub fn entropy() -> EntropySeed {
     openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
     Some(entropy())
 )]
-#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
+#[cfg_attr(
+    not(target_family = "wasm"),
+    test_attr(macro_rules_attribute::apply(smol_macros::test))
+)]
+#[cfg_attr(target_family = "wasm", test_attr(wasm_bindgen_test))]
 pub fn all_storage_types_and_ciphersuites(
     #[case]
     #[future]

--- a/mls-provider/tests/fixtures.rs
+++ b/mls-provider/tests/fixtures.rs
@@ -39,7 +39,7 @@ pub(crate) async fn setup(#[default(false)] in_memory: bool) -> MlsCryptoProvide
 
 #[template]
 #[rstest]
-#[async_std::test]
+#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
 async fn use_provider(
     #[from(setup)]
     #[with(true)]
@@ -157,7 +157,7 @@ pub fn entropy() -> EntropySeed {
     openmls::prelude::Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
     Some(entropy())
 )]
-#[async_std::test]
+#[test_attr(macro_rules_attribute::apply(smol_macros::test))]
 pub fn all_storage_types_and_ciphersuites(
     #[case]
     #[future]

--- a/mls-provider/tests/randomness.rs
+++ b/mls-provider/tests/randomness.rs
@@ -51,7 +51,6 @@ mod tests {
     }
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn can_generate_sufficient_randomness_ext_entropy(backend: MlsCryptoProvider) {
         let mut backend = backend.await;
         test_randomness(&mut backend, Some(entropy()));
@@ -59,7 +58,6 @@ mod tests {
     }
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn can_generate_sufficient_randomness_sys_entropy(backend: MlsCryptoProvider) {
         let mut backend = backend.await;
         test_randomness(&mut backend, None);
@@ -69,7 +67,6 @@ mod tests {
     // ? Test vectors taken from https://github.com/rust-random/rand/blob/c797f070b125084d727dc0ba5104bbdae966ba78/rand_chacha/src/chacha.rs#L411
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn can_be_externally_seeded_ietf_vectors_1_2(backend: MlsCryptoProvider) {
         let backend = backend.await;
         // Test vectors 1 and 2 from
@@ -103,7 +100,6 @@ mod tests {
     }
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn can_be_externally_seeded_ietf_vector_3(backend: MlsCryptoProvider) {
         let backend = backend.await;
         // Test vector 3 from
@@ -135,7 +131,6 @@ mod tests {
     }
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn can_be_externally_seeded_ietf_vector_4(backend: MlsCryptoProvider) {
         let backend = backend.await;
         // Test vector 4 from
@@ -192,7 +187,6 @@ mod tests {
     }
 
     #[apply(use_provider)]
-    #[wasm_bindgen_test]
     async fn can_be_externally_seeded_ietf_vector_5(backend: MlsCryptoProvider) {
         let backend = backend.await;
         // Test vector 5 from


### PR DESCRIPTION
`async-std` has been archived and deprecated in favor of `smol`. This commit updates `core-crypto` to apply that update.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
