### PR TITLE
build: replace `tokio` with `smol` in direct deps, except interop [WPB-16939]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "js-sys",
  "log",
  "log-reload",
+ "macro_rules_attribute",
  "paste",
  "proteus-wasm",
  "rmp-serde",
@@ -874,11 +875,11 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
+ "smol-macros",
  "strum",
  "testing_logger",
  "thiserror 2.0.14",
  "tls_codec",
- "tokio",
  "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2431,6 +2432,7 @@ dependencies = [
  "core-crypto",
  "core-crypto-keystore",
  "hex",
+ "macro_rules_attribute",
  "openmls",
  "openmls_basic_credential",
  "openmls_traits",
@@ -2440,8 +2442,8 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
+ "smol-macros",
  "tls_codec",
- "tokio",
 ]
 
 [[package]]
@@ -2509,9 +2511,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2957,9 +2959,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2967,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3348,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -21,10 +21,7 @@ workspace = true
 
 [features]
 default = ["proteus"]
-proteus = [
-    "core-crypto/proteus",
-    "dep:proteus-wasm",
-]
+proteus = ["core-crypto/proteus", "dep:proteus-wasm"]
 
 [dependencies]
 thiserror.workspace = true
@@ -88,7 +85,5 @@ wasm-opt = [
 
 [dev-dependencies]
 testing_logger = "0.1.1"
-tokio = { version = "1.47.1", default-features = false, features = [
-    "macros",
-    "rt",
-] }
+macro_rules_attribute.workspace = true
+smol-macros.workspace = true

--- a/crypto-ffi/src/error/mod.rs
+++ b/crypto-ffi/src/error/mod.rs
@@ -93,7 +93,7 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
+    #[macro_rules_attribute::apply(smol_macros::test)]
     async fn test_error_is_logged() {
         testing_logger::setup();
         // we shouldn't be able to create a SQLite DB in `/root` unless we are running this test as root

--- a/keystore-dump/Cargo.toml
+++ b/keystore-dump/Cargo.toml
@@ -17,12 +17,13 @@ core-crypto-keystore = { workspace = true }
 core-crypto = { path = "../crypto" }
 
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
 serde_json.workspace = true
 serde.workspace = true
 postcard = { version = "1.1", default-features = false, features = ["use-std"] }
 hex.workspace = true
 serde-transcode = "1"
+macro_rules_attribute.workspace = true
+smol-macros.workspace = true
 
 openmls = { workspace = true, features = ["crypto-subtle"] }
 openmls_traits.workspace = true
@@ -30,7 +31,10 @@ openmls_basic_credential.workspace = true
 openmls_x509_credential.workspace = true
 tls_codec.workspace = true
 
-chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "std",
+    "serde",
+] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.proteus-wasm]
 workspace = true

--- a/keystore-dump/src/main.rs
+++ b/keystore-dump/src/main.rs
@@ -6,7 +6,7 @@ fn main() -> Result<()> {
 }
 
 #[cfg(not(target_family = "wasm"))]
-#[tokio::main]
+#[macro_rules_attribute::apply(smol_macros::main)]
 async fn main() -> Result<()> {
     #[derive(Debug, clap::Parser)]
     #[command(author, version, about, long_about = None)]
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    if !tokio::fs::try_exists(&args.path).await.unwrap_or_default() {
+    if !std::path::Path::new(&args.path).exists() {
         return Err(eyre!("File not found: {}", args.path));
     }
 


### PR DESCRIPTION
It turns out that while `smol` is fine for abstract async execution,
the rust web development community has as a whole chosen `tokio` for
servers. This is relevant because interop runs a tiny little server
for the wasm stuff.

I could not find _any_ approach higher-level than a `TcpStream`
which did not require Tokio, had been updated in the last 3 years,
and had a non-trivial userbase. There are various personal projects,
and there are old projects that generate supply-chain errors, and
then there's Tokio.

As long as interop needs to provide a web server, I think we're
stuck with Tokio.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
