### PR TITLE
ci: generate swift docs on self-hosted mac runner [WPB-19555]

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -205,7 +205,7 @@ jobs:
 
   docs-swift:
     needs: build-ios
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v5
       - name: download artifacts for ios


### PR DESCRIPTION
# What's new in this PR
This is to investigate why the `docs-swift` job is failing even on GitHub provided runners.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
