### PR TITLE
chore: explicitly allow "GPL-3.0-only" license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,7 @@ allow = [
   "MIT",
   "MPL-2.0",
   "GPL-3.0",
+  "GPL-3.0-only",
   "CC0-1.0",
   "BSD-3-Clause",
   "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
We're currently seeing CI failures on our own projects, because we use a license that we hadn't previously allowed.

https://github.com/wireapp/core-crypto/actions/runs/16984950658/job/48151939776

That's silly.

So here we are: this commit permits code licensed under the license we use.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
