### PR TITLE
chore: add feature flags to silence hack warnings [WPB-19288]

### DIFF
--- a/crypto/src/group_store.rs
+++ b/crypto/src/group_store.rs
@@ -94,6 +94,7 @@ impl<V: GroupStoreEntity> std::ops::DerefMut for GroupStore<V> {
 }
 
 impl<V: GroupStoreEntity> GroupStore<V> {
+    #[cfg_attr(not(feature = "proteus"), expect(dead_code))]
     pub(crate) fn new_with_limit(len: u32) -> Self {
         let limiter = HybridMemoryLimiter::new(Some(len), None);
         let store = schnellru::LruMap::new(limiter);
@@ -152,6 +153,7 @@ impl<V: GroupStoreEntity> GroupStore<V> {
         self.insert_prepped(k, value_to_insert)
     }
 
+    #[cfg_attr(not(feature = "proteus"), expect(dead_code))]
     pub(crate) fn try_insert(&mut self, k: Vec<u8>, entity: V) -> Result<(), V> {
         let value_to_insert = Arc::new(async_lock::RwLock::new(entity));
 
@@ -167,6 +169,7 @@ impl<V: GroupStoreEntity> GroupStore<V> {
         self.0.remove(k)
     }
 
+    #[cfg_attr(not(feature = "proteus"), expect(dead_code))]
     pub(crate) fn get(&mut self, k: &[u8]) -> Option<&mut GroupStoreValue<V>> {
         self.0.get(k)
     }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -7,10 +7,10 @@
 #![cfg_attr(not(test), deny(missing_docs))]
 #![allow(clippy::single_component_path_imports)]
 
-use async_lock::Mutex;
 #[cfg(test)]
 pub use core_crypto_macros::{dispotent, durable, idempotent};
-use std::sync::Arc;
+#[cfg(feature = "proteus")]
+use {async_lock::Mutex, std::sync::Arc};
 
 pub use self::error::*;
 

--- a/crypto/src/transaction_context/mod.rs
+++ b/crypto/src/transaction_context/mod.rs
@@ -12,7 +12,9 @@ use crate::{
     mls::HasSessionAndCrypto,
     prelude::{ClientIdentifier, MlsCiphersuite},
 };
-use async_lock::{Mutex, RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
+#[cfg(feature = "proteus")]
+use async_lock::Mutex;
+use async_lock::{RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
 use core_crypto_keystore::{CryptoKeystoreError, connection::FetchFromDatabase, entities::ConsumerData};
 pub use error::{Error, Result};
 use mls_crypto_provider::{CryptoKeystore, MlsCryptoProvider};

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -1,12 +1,16 @@
+#[cfg(feature = "proteus")]
+use std::cell::Cell;
+use std::sync::Arc;
+
+use color_eyre::eyre::Result;
+use tempfile::NamedTempFile;
+
+use core_crypto_ffi::{ClientId, CoreCrypto, CredentialType, CustomConfiguration, TransactionHelper};
+
 use crate::{
     CIPHERSUITE_IN_USE,
     clients::{EmulatedClient, EmulatedClientProtocol, EmulatedClientType, EmulatedMlsClient},
 };
-use color_eyre::eyre::Result;
-use core_crypto_ffi::{ClientId, CoreCrypto, CredentialType, CustomConfiguration, TransactionHelper};
-use std::cell::Cell;
-use std::sync::Arc;
-use tempfile::NamedTempFile;
 
 #[derive(Debug)]
 pub(crate) struct CoreCryptoFfiClient {

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -1,14 +1,16 @@
-use color_eyre::eyre::Result;
+#[cfg(feature = "proteus")]
 use std::cell::Cell;
 use std::sync::Arc;
+
+use color_eyre::eyre::Result;
 use tls_codec::Serialize;
 
 use core_crypto::{DatabaseKey, prelude::*};
 
-use crate::util::MlsTransportSuccessProvider;
 use crate::{
     CIPHERSUITE_IN_USE,
     clients::{EmulatedClient, EmulatedClientProtocol, EmulatedClientType, EmulatedMlsClient},
+    util::MlsTransportSuccessProvider,
 };
 
 #[derive(Debug)]

--- a/interop/src/clients/corecrypto/web/mod.rs
+++ b/interop/src/clients/corecrypto/web/mod.rs
@@ -1,12 +1,19 @@
+#[cfg(feature = "proteus")]
+use std::cell::Cell;
+use std::{collections::HashMap, net::SocketAddr, sync::LazyLock};
+
+#[cfg(feature = "proteus")]
+use color_eyre::eyre::eyre;
+use color_eyre::eyre::{ContextCompat as _, Result};
+use tls_codec::Deserialize;
+use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator as _};
+
+use core_crypto::prelude::{KeyPackage, KeyPackageIn};
+
 use crate::{
     CIPHERSUITE_IN_USE,
     clients::{EmulatedClient, EmulatedClientProtocol, EmulatedClientType, EmulatedMlsClient},
 };
-use color_eyre::eyre::{ContextCompat as _, Result, eyre};
-use core_crypto::prelude::{KeyPackage, KeyPackageIn};
-use std::{cell::Cell, collections::HashMap, net::SocketAddr, sync::LazyLock};
-use tls_codec::Deserialize;
-use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator as _};
 
 /// Parse the source, returning all function bodies by function name
 ///


### PR DESCRIPTION
`cargo hack` runs our code under various combinations of feature flags, to ensure it still builds correctly under all combinations.

That it does, but we had some warnings. This should fix them.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
