### PR TITLE
ci: create xcode simulators when running tests

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -327,21 +327,22 @@ jobs:
         with:
           name: ${{github.event.number}}-swift-ffi
           path: crypto-ffi/bindings/swift/WireCoreCryptoUniffi
+      - name: create simulator
+        run: |
+          echo "SIMULATOR=$(./scripts/create-ios-sim-device.sh "iPhone 16 e2e-interop-test")" >> $GITHUB_ENV
       - name: build & install iOS Interop client
         run: |
-          echo "INTEROP_SIMULATOR_DEVICE_1=$(./scripts/create-ios-sim-device.sh "iPhone 16 e2e-interop-test")" >> $GITHUB_ENV
           cd interop/src/clients/InteropClient
           xcodebuild -scheme InteropClient -sdk iphonesimulator -configuration Release \
                      -destination 'platform=iOS Simulator,name=iPhone 16 e2e-interop-test' clean build install DSTROOT=./Products
-          echo "INTEROP_SIMULATOR_DEVICE_2=$(./create_simulator.sh)" >> $GITHUB_ENV
+          ./install-interop-client.sh ${{ env.SIMULATOR }}
       - name: run e2e interop test
         run: cargo run --bin interop
-      - name: delete simulators
+        # we separate shutdown from deletion to make sure the device is always removed, even when shutdown failed
+      - name: delete simulator
         if: always()
         run: |
-          ./scripts/delete-ios-sim-device.sh ${{ env.INTEROP_SIMULATOR_DEVICE_1 }}
-          xcrun simctl shutdown ${{ env.INTEROP_SIMULATOR_DEVICE_2 }}
-          ./scripts/delete-ios-sim-device.sh ${{ env.INTEROP_SIMULATOR_DEVICE_2 }}
+          ./scripts/delete-ios-sim-device.sh ${{ env.SIMULATOR }}
 
   build-and-test-wasm:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -69,11 +69,21 @@ jobs:
         run: |
           swift format lint -r -s ./interop/src/clients/InteropClient
           swiftlint --strict ./interop/src/clients/InteropClient
+      - name: Create simulator
+        run: |
+          echo "SIMULATOR=$(sh ./scripts/create-ios-sim-device.sh "iPhone 16 test-ios")" >> $GITHUB_ENV
+
       - name: ios tests
         run: |
           cd crypto-ffi/bindings/swift/WireCoreCrypto
+
+          # run tests
           xcodebuild test -scheme TestHost -configuration Release -sdk iphonesimulator \
-                          -destination 'platform=iOS Simulator,name=iPhone 16'
+                          -destination 'platform=iOS Simulator,name=iPhone 16 test-ios'
+      - name: Delete simulator
+        if: always()
+        run: |
+          ./scripts/delete-ios-sim-device.sh ${{ env.SIMULATOR }}
 
   test-android:
     if: github.repository == 'wireapp/core-crypto' && github.event_name == 'pull_request'
@@ -319,17 +329,19 @@ jobs:
           path: crypto-ffi/bindings/swift/WireCoreCryptoUniffi
       - name: build & install iOS Interop client
         run: |
+          echo "INTEROP_SIMULATOR_DEVICE_1=$(./scripts/create-ios-sim-device.sh "iPhone 16 e2e-interop-test")" >> $GITHUB_ENV
           cd interop/src/clients/InteropClient
           xcodebuild -scheme InteropClient -sdk iphonesimulator -configuration Release \
-                     -destination 'platform=iOS Simulator,name=iPhone 16' clean build install DSTROOT=./Products
-          echo "INTEROP_SIMULATOR_DEVICE=$(./create_simulator.sh)" >> $GITHUB_ENV
+                     -destination 'platform=iOS Simulator,name=iPhone 16 e2e-interop-test' clean build install DSTROOT=./Products
+          echo "INTEROP_SIMULATOR_DEVICE_2=$(./create_simulator.sh)" >> $GITHUB_ENV
       - name: run e2e interop test
         run: cargo run --bin interop
-      - name: delete simulator
+      - name: delete simulators
         if: always()
         run: |
-          cd interop/src/clients/InteropClient
-          ./delete_simulator.sh ${{ env.INTEROP_SIMULATOR_DEVICE }}
+          ./scripts/delete-ios-sim-device.sh ${{ env.INTEROP_SIMULATOR_DEVICE_1 }}
+          xcrun simctl shutdown ${{ env.INTEROP_SIMULATOR_DEVICE_2 }}
+          ./scripts/delete-ios-sim-device.sh ${{ env.INTEROP_SIMULATOR_DEVICE_2 }}
 
   build-and-test-wasm:
     if: github.event_name == 'pull_request'

--- a/interop/src/clients/InteropClient/delete_simulator.sh
+++ b/interop/src/clients/InteropClient/delete_simulator.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-
-DEVICE=$1
-
-xcrun simctl shutdown $DEVICE
-xcrun simctl delete $DEVICE
-
-rm -rf ~/Library/Logs/CoreSimulator/$DEVICE
-rm -rf ~/Library/Developer/CoreSimulator/Devices/$DEVICE

--- a/interop/src/clients/InteropClient/install-interop-client.sh
+++ b/interop/src/clients/InteropClient/install-interop-client.sh
@@ -3,9 +3,8 @@
 # Fail on first error
 set -e
 
-SIMULATOR_NAME="Interop Simulator - `uuidgen`"
-SIMULATOR_UDID=`xcrun simctl create "$SIMULATOR_NAME" "iPhone 16"`
-echo "Creating new simulator" >&2
+SIMULATOR_UDID="$1"
+echo "Booting simulator" >&2
 xcrun simctl boot $SIMULATOR_UDID
 echo "Installing application" >&2
 xcrun simctl install $SIMULATOR_UDID Products/Applications/InteropClient.app

--- a/scripts/create-ios-sim-device.sh
+++ b/scripts/create-ios-sim-device.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NAME="$1"
+
+UDID=$(xcrun simctl create "$NAME" \
+        com.apple.CoreSimulator.SimDeviceType.iPhone-16 \
+        com.apple.CoreSimulator.SimRuntime.iOS-18-6)
+
+echo "$UDID"

--- a/scripts/delete-ios-sim-device.sh
+++ b/scripts/delete-ios-sim-device.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+UDID="$1"
+
+# Delete the simulator
+xcrun simctl delete "$UDID"
+
+# Clean up logs and device data
+rm -rf ~/Library/Logs/CoreSimulator/"$UDID"
+rm -rf ~/Library/Developer/CoreSimulator/Devices/"$UDID"


### PR DESCRIPTION
# What's new in this PR
With this PR ios tests with device specific xcode build destinations create a dedicated device for test first and remove it after finishing the test. This should avoid any CI errors related to non existent simulator devices when using xcodebuild. 

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
