### PR TITLE
ci: only take what is really necessary for the `android` artifact [WPB-19386]

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           name: android
           path: |
-            crypto-ffi/bindings
-            target/*android*
+            crypto-ffi/bindings/android/build/outputs/aar
+            crypto-ffi/bindings/android/src
+            target/*android*/release/libcore_crypto_ffi.so
           retention-days: 1


### PR DESCRIPTION
This cuts the artifact size from ~224 MB to ~47 MB.