### PR TITLE
build: test `--all-features` in our ci [WPB-10280]

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,14 +52,15 @@ jobs:
         with:
           files: target/nextest/default/junit.xml
 
-  proteus-test:
+  all-features:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-and-cache-rust
       - uses: taiki-e/install-action@nextest
-      - name: "test corecrypto's proteus implementation"
-        run: cargo nextest run --locked --verbose --features proteus,proteus-keystore proteus
+      - run: cargo nextest run --locked --all-features --no-fail-fast --retries 5
+        # certain tests are flaky when run in parallel like this, but
+        # experiments suggest 5 is enough retries that they'll generally pass eventually
 
   wasm-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Frustratingly, there are two flaky tests that I could not figure out the root cause of. Demonstrated behaviors:

- running `cargo nextest run --all-features --no-fail-fast -p core-crypto` reliably fails `mls::session::key_package::tests::automatically_prunes_lifetime_expired_keypackages::case_09_basic_cs7` and `mls::session::key_package::tests::automatically_prunes_lifetime_expired_keypackages::case_10_cert_cs7`
- it's not fundamental to cs7 because it works just fine if we do `cargo nextest run --all-features --no-fail-fast -p core-crypto mls`
- but it shouldn't matter if some other tests are running simultaneously either, because I don't see how they can interact: each test is being run in its own process, on an in-memory keystore
- running with `--retries 5` is sufficient on my local machine. It looks like somehow, despite being run in what looks like complete isolation, some other test is conflicting with these two tests.

Having said that, `--retries 5` is technically sufficient to get this working reliably locally, so I'm going to leave it there for now.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
