### PR TITLE
test: add scheduled test of all features to run nightly on main [WPB-10280]

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,26 @@
+name: scheduled
+
+
+on:
+  schedule:
+    # runs these jobs on the default branch (main) at 0132 daily UTC (0332 Berlin time)
+    - cron: "32 1 * * *"
+  workflow_dispatch:
+    # runs these jobs when triggered manually
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  all-features:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-and-cache-rust
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --locked --all-features --no-fail-fast --retries 5
+        # certain tests are flaky when run in parallel like this, but
+        # experiments suggest 5 is enough retries that they'll generally pass eventually


### PR DESCRIPTION
This takes 20-ish minutes to run, but it will turn CI red for us if we have broken some tests not covered by a normal run.

Note that this test cannot be demonstrated before merging, as neither `schedule` nor `workflow_dispatch` will do anything until the test is on the default branch, which for us is `main`. 

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
