### PR TITLE
ci: use GitHub Actions artifacts instead of caches for build artifacts [WPB-17419]

### DIFF
--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -1,5 +1,6 @@
 name: Fetch or make an artifact
-description: Fetch an artifact with a given key. If it doesn't exist, run the given command and upload it.
+description: Fetch the newest artifact (on the current branch or on main) with a given key.
+  If it doesn't exist, run the given command and upload it.
 inputs:
   key:
     description: The artifact key
@@ -10,24 +11,47 @@ inputs:
   target-path:
     description: The relative path of the final artifact(s)
     required: true
+  gh-token:
+    required: true
 
 runs:
   using: composite
   steps:
-    - name: Attempt to download the artifact
-      uses: actions/cache/restore@v4
-      with:
-        key: ${{ inputs.key }}
-        path: |
-          ${{ inputs.target-path }}
-          .stamps
-      id: artifact-download
-
-    # This is necessary because the github checkout action doesn't preserve
-    # timestamps on checked out files.
-    - name: Touch downloaded files to update timestamps
-      if: steps.artifact-download.outputs.cache-hit == 'true'
+    - name: Download artifact
       run: |
+        branch="${{ github.head_ref || github.ref_name }}"
+
+        runs_current_branch=$(gh run list --branch "$branch" --limit 10 -w bindings.yml --json databaseId | jq '.[].databaseId')
+        runs_main=$(gh run list --branch "$branch" --limit 10 -w bindings.yml --json databaseId | jq '.[].databaseId')
+
+        # Prioritize current branch over main
+        runs=$(printf "%s\n%s\n" "$runs_current_branch" "$runs_main")
+
+        artifact_name="${{ inputs.key }}"
+
+        echo "found=false" >> $GITHUB_ENV
+
+        # For each run in the sorted list of run ids, try downloading the artifact
+        # with the given name.
+        for run_id in $runs; do
+        if gh run download "$run_id" -n "$artifact_name" >/dev/null 2>&1; then
+            echo "Downloaded artifact $artifact_name from run with id: $run_id"
+            echo "found=true" >> $GITHUB_ENV
+            exit 0
+          fi
+        done
+
+        echo "No artifact '$artifact_name' found." >&2
+      env:
+        GITHUB_TOKEN: ${{ inputs.gh-token }}
+      shell: bash -euo pipefail {0}
+
+    - name: Unpack and touch downloaded files to update timestamps
+      if: env.found == 'true'
+      run: |
+        tar -xzf artifact.tar.gz
+        # This is necessary because the github checkout action doesn't preserve
+        # timestamps on checked out files.
         paths="${{ inputs.target-path }}"
         for dir in $paths; do
           touch "$dir"
@@ -35,15 +59,26 @@ runs:
       shell: bash -leo pipefail {0}
 
     - name: Run make ${{ inputs.make-rule }} if needed
-      if: steps.artifact-download.outputs.cache-hit != 'true'
+      if: env.found != true
       run: make ${{ inputs.make-rule }}
       shell: bash -leo pipefail {0}
 
-    - name: Upload artifact if needed
-      if: steps.artifact-download.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+    - name: Prepare artifact
+      run: |
+        mkdir -p .stamps
+        printf '%s\n' "${{ inputs.target-path }}" | tar -czf artifact.tar.gz -T - .stamps
+      shell: bash -leo pipefail {0}
+
+    # We re-upload to ensure we always the artifact on the most recent workflow run.
+    # This should be fine, as uploads are comparatively cheap.
+    - name: Always upload artifact
+      uses: actions/upload-artifact@v4
       with:
-        key: ${{ inputs.key }}
-        path: |
-          ${{ inputs.target-path }}
-          .stamps
+        name: ${{ inputs.key }}
+        path: artifact.tar.gz
+        overwrite: true
+
+    - name: Cleanup
+      run: |
+        rm artifact.tar.gz
+      shell: bash -leo pipefail {0}

--- a/.github/actions/make/android/lib/action.yml
+++ b/.github/actions/make/android/lib/action.yml
@@ -4,6 +4,8 @@ inputs:
   task:
     description: The make task
     required: true
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -35,3 +37,4 @@ runs:
         target-path: |
           target/${{ env.ANDROID_TARGET }}/release/libcore_crypto_ffi.a
           target/${{ env.ANDROID_TARGET }}/release/libcore_crypto_ffi.so
+        gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/android/package/action.yml
+++ b/.github/actions/make/android/package/action.yml
@@ -1,4 +1,7 @@
 name: Fetch or make android package
+inputs:
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -8,22 +11,29 @@ runs:
       uses: ./.github/actions/make/android/lib
       with:
         task: android-armv7
+        gh-token: ${{ inputs.gh-token }}
 
     - name: download aarch64-linux-android binaries
       uses: ./.github/actions/make/android/lib
       with:
         task: android-armv8
+        gh-token: ${{ inputs.gh-token }}
 
     - name: download x86_64-linux-android binaries
       uses: ./.github/actions/make/android/lib
       with:
         task: android-x86
+        gh-token: ${{ inputs.gh-token }}
 
     - name: fetch ffi library
       uses: ./.github/actions/make/ffi-library
+      with:
+        gh-token: ${{ inputs.gh-token }}
 
     - name: fetch uniffi bindgen artifact
       uses: ./.github/actions/make/uniffi-bindgen
+      with:
+        gh-token: ${{ inputs.gh-token }}
 
     - name: make android
       uses: ./.github/actions/make
@@ -33,3 +43,4 @@ runs:
         target-path: |
           crypto-ffi/bindings/android/build/outputs/aar
           crypto-ffi/bindings/android/src
+        gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/bindings-kotlin-jvm/action.yml
+++ b/.github/actions/make/bindings-kotlin-jvm/action.yml
@@ -1,4 +1,7 @@
 name: Fetch or make kotlin bindings for jvm
+inputs:
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -6,12 +9,17 @@ runs:
   steps:
     - name: fetch uniffi bindgen artifact
       uses: ./.github/actions/make/uniffi-bindgen
+      with:
+        gh-token: ${{ inputs.gh-token }}
 
     - name: fetch ffi library
       uses: ./.github/actions/make/ffi-library
+      with:
+        gh-token: ${{ inputs.gh-token }}
 
     - uses: ./.github/actions/make
       with:
         key: bindings-kotlin-jvm-${{ github.sha }}
         make-rule: bindings-kotlin-jvm
         target-path: crypto-ffi/bindings
+        gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/bindings-swift/action.yml
+++ b/.github/actions/make/bindings-swift/action.yml
@@ -1,4 +1,7 @@
 name: Fetch or make swift bindings
+inputs:
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -6,12 +9,17 @@ runs:
   steps:
       - name: fetch uniffi bindgen artifact
         uses: ./.github/actions/make/uniffi-bindgen
+        with:
+          gh-token: ${{ inputs.gh-token }}
 
       - name: fetch ffi library
         uses: ./.github/actions/make/ffi-library
+        with:
+          gh-token: ${{ inputs.gh-token }}
 
       - uses: ./.github/actions/make
         with:
           key: bindings-swift-${{ github.sha }}
           make-rule: bindings-swift
           target-path: crypto-ffi/bindings/swift/WireCoreCryptoUniffi/WireCoreCryptoUniffi
+          gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/ffi-library/action.yml
+++ b/.github/actions/make/ffi-library/action.yml
@@ -1,5 +1,9 @@
 name: Fetch or make ffi library
 
+inputs:
+  gh-token:
+    required: true
+
 runs:
   using: composite
 
@@ -21,3 +25,4 @@ runs:
         key: libcore_crypto_ffi.${{ env.LIBRARY_EXTENSION }}-${{ github.sha }}
         make-rule: ffi-library
         target-path: target/release/libcore_crypto_ffi.${{ env.LIBRARY_EXTENSION }}
+        gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/ios/action.yml
+++ b/.github/actions/make/ios/action.yml
@@ -4,6 +4,8 @@ inputs:
   task:
     description: The make task
     required: true
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -32,3 +34,4 @@ runs:
         target-path: |
           target/${{ env.IOS_TARGET }}/release/libcore_crypto_ffi.a
           target/${{ env.IOS_TARGET }}/release/libcore_crypto_ffi.dylib
+        gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/jvm-linux/action.yml
+++ b/.github/actions/make/jvm-linux/action.yml
@@ -1,4 +1,7 @@
 name: Fetch or make the ffi lib for jvm linux
+inputs:
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -9,3 +12,4 @@ runs:
           key: jvm-linux-${{ github.sha }}
           make-rule: jvm-linux
           target-path: target/x86_64-unknown-linux-gnu/release/libcore_crypto_ffi.so
+          gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/make/uniffi-bindgen/action.yml
+++ b/.github/actions/make/uniffi-bindgen/action.yml
@@ -1,4 +1,7 @@
 name: Fetch or make uniffi-bindgen binary
+inputs:
+  gh-token:
+    required: true
 
 runs:
   using: composite
@@ -16,6 +19,7 @@ runs:
         key: ${{ env.ARTIFACT_NAME }}
         make-rule: uniffi-bindgen
         target-path: target/release/uniffi-bindgen
+        gh-token: ${{ inputs.gh-token }}
 
     - run: chmod +x target/release/uniffi-bindgen
       shell: bash -leo pipefail {0}

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
       - uses: ./.github/actions/make/uniffi-bindgen
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
   ffi-library-linux:
     if: github.repository == 'wireapp/core-crypto'
@@ -38,6 +40,8 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
       - uses: ./.github/actions/make/ffi-library
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
   bindings-swift:
     if: github.repository == 'wireapp/core-crypto'
@@ -46,6 +50,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-and-cache-rust
       - uses: ./.github/actions/make/bindings-swift
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-android:
     if: github.event_name == 'pull_request'
@@ -77,6 +83,8 @@ jobs:
       - name: install ndk
         run: echo "y" | sdkmanager --install "ndk;$ANDROID_NDK_VERSION"
       - uses: ./.github/actions/make/android/package
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-jvm-linux:
     if: github.repository == 'wireapp/core-crypto'
@@ -87,6 +95,8 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
       - uses: ./.github/actions/make/jvm-linux
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
   bindings-jvm:
     needs:
@@ -100,6 +110,8 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
       - uses: ./.github/actions/make/bindings-kotlin-jvm
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-ios:
     uses: ./.github/workflows/build-ios.yml
@@ -120,22 +132,30 @@ jobs:
 
       - name: fetch uniffi bindgen artifact
         uses: ./.github/actions/make/uniffi-bindgen
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: fetch ffi library
         uses: ./.github/actions/make/ffi-library
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download artifacts for ios device
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
 
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -193,6 +213,8 @@ jobs:
 
       - name: download android package
         uses: ./.github/actions/make/android/package
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: android instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -222,9 +244,13 @@ jobs:
 
       - name: download linux library
         uses: ./.github/actions/make/jvm-linux
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download linux bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run detekt
         run: |
@@ -255,9 +281,13 @@ jobs:
 
       - name: download linux library
         uses: ./.github/actions/make/jvm-linux
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download linux bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run dokka
         run: |
@@ -288,15 +318,19 @@ jobs:
       - name: download artifacts for ios device
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
 
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -317,15 +351,19 @@ jobs:
 
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: download artifacts for ios device
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
 
       - name: setup Xcode
@@ -397,15 +435,19 @@ jobs:
       - name: download artifacts for ios device
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
 
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: create simulator
         run: |

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -28,4 +28,5 @@ jobs:
       - name: build android lib
         uses: ./.github/actions/make/android/lib
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ${{ matrix.task }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -34,4 +34,5 @@ jobs:
       - name: build ${{ matrix.task }}
         uses: ./.github/actions/make/ios
         with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ${{ matrix.task }}


### PR DESCRIPTION
# What's new in this PR
See title

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
