### PR TITLE
ci: continue if an uploaded artifact already exists on a run

### DIFF
--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -72,6 +72,11 @@ runs:
     # We re-upload to ensure we always the artifact on the most recent workflow run.
     # This should be fine, as uploads are comparatively cheap.
     - name: Always upload artifact
+      # If the artifact already exists on this workflow run, continue.
+      # In most cases, the error is prevented by overwrite: true,
+      # howevever, we still need this, because of actions/upload-artifact#506
+      # (the _overwrite_ behavior is not atomic).
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.key }}


### PR DESCRIPTION
This is a workaround for actions/upload-artifact#506 (overwrite behavior is not atomic). The reason why we're getting in this situation is that we want to use the same composite action whenever we want to guarantee that an artifact exists. This makes our workflows more robust in cases where the artifacts that were uploadded by different workflow runs have expired (e.g., a retry several days later).

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
