### PR TITLE
chore: pacify cargo-deny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,12 +2250,12 @@ dependencies = [
 name = "interop"
 version = "8.0.0"
 dependencies = [
+ "anyhow",
  "async-fs",
  "async-trait",
  "base64 0.22.1",
  "bitflags",
  "cc",
- "color-eyre",
  "const_format",
  "core-crypto",
  "core-crypto-ffi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,33 +691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-eyre"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,9 +2386,9 @@ dependencies = [
 name = "keystore-dump"
 version = "8.0.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
- "color-eyre",
  "core-crypto",
  "core-crypto-keystore",
  "hex",
@@ -2893,12 +2866,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "p256"
@@ -3882,15 +3849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,16 +4214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "time"
 version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,28 +4392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -4739,12 +4665,6 @@ dependencies = [
  "sha1_smol",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"

--- a/deny.toml
+++ b/deny.toml
@@ -38,7 +38,6 @@ allow = [
   "MPL-2.0",
   "GPL-3.0",
   "GPL-3.0-only",
-  "CC0-1.0",
   "BSD-3-Clause",
   "Apache-2.0 WITH LLVM-exception",
   "ISC",

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -12,7 +12,7 @@ proteus = ["dep:proteus-wasm", "core-crypto/proteus"]
 workspace = true
 
 [dependencies]
-color-eyre = "0.6"
+anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"
 core-crypto = { path = "../crypto" }

--- a/interop/src/clients/corecrypto/ffi.rs
+++ b/interop/src/clients/corecrypto/ffi.rs
@@ -2,7 +2,7 @@
 use std::cell::Cell;
 use std::sync::Arc;
 
-use color_eyre::eyre::Result;
+use anyhow::Result;
 use tempfile::NamedTempFile;
 
 use core_crypto_ffi::{ClientId, CoreCrypto, CredentialType, CustomConfiguration, TransactionHelper};

--- a/interop/src/clients/corecrypto/ios.rs
+++ b/interop/src/clients/corecrypto/ios.rs
@@ -2,8 +2,8 @@ use crate::{
     CIPHERSUITE_IN_USE,
     clients::{EmulatedClient, EmulatedClientProtocol, EmulatedClientType, EmulatedMlsClient},
 };
+use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose};
-use color_eyre::eyre::Result;
 use core_crypto::prelude::{KeyPackage, KeyPackageIn};
 use std::cell::{Cell, RefCell};
 use std::fs;

--- a/interop/src/clients/corecrypto/native.rs
+++ b/interop/src/clients/corecrypto/native.rs
@@ -2,7 +2,7 @@
 use std::cell::Cell;
 use std::sync::Arc;
 
-use color_eyre::eyre::Result;
+use anyhow::Result;
 use tls_codec::Serialize;
 
 use core_crypto::{DatabaseKey, prelude::*};

--- a/interop/src/clients/corecrypto/web/mod.rs
+++ b/interop/src/clients/corecrypto/web/mod.rs
@@ -3,8 +3,8 @@ use std::cell::Cell;
 use std::{collections::HashMap, net::SocketAddr, sync::LazyLock};
 
 #[cfg(feature = "proteus")]
-use color_eyre::eyre::eyre;
-use color_eyre::eyre::{ContextCompat as _, Result};
+use anyhow::anyhow;
+use anyhow::{Context as _, Result};
 use tls_codec::Deserialize;
 use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator as _};
 
@@ -291,6 +291,6 @@ impl crate::clients::EmulatedProteusClient for CoreCryptoWebClient {
             .await?
             .as_str()
             .map(ToOwned::to_owned)
-            .ok_or(eyre!("no proteus fingerprint returned"))
+            .ok_or(anyhow!("no proteus fingerprint returned"))
     }
 }

--- a/interop/src/clients/mod.rs
+++ b/interop/src/clients/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern)]
 
-use color_eyre::eyre::Result;
+use anyhow::Result;
 use core_crypto::prelude::MlsCiphersuite;
 
 pub(crate) mod corecrypto;

--- a/interop/src/main.rs
+++ b/interop/src/main.rs
@@ -4,7 +4,7 @@ use core_crypto::DatabaseKey;
 
 #[cfg(not(target_family = "wasm"))]
 use crate::util::{MlsTransportSuccessProvider, MlsTransportTestExt};
-use color_eyre::eyre::{Result, eyre};
+use anyhow::{Result, anyhow};
 use core_crypto::prelude::CiphersuiteName;
 use std::sync::Arc;
 use tls_codec::Serialize;
@@ -78,7 +78,6 @@ fn run_test() -> Result<()> {
 
     use tokio::net::{TcpListener, TcpStream};
 
-    color_eyre::install()?;
     env_logger::init();
 
     // Check if we have a correct pwd
@@ -228,7 +227,7 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr, web_server: &st
                 .decrypt_message(&conversation_id, &message_to_decrypt)
                 .await?
                 .ok_or_else(|| {
-                    eyre!(
+                    anyhow!(
                         "[MLS] No message, something went very wrong [Client = {}]",
                         c.client_type()
                     )
@@ -262,7 +261,7 @@ async fn run_mls_test(chrome_driver_addr: &std::net::SocketAddr, web_server: &st
             .decrypt_message(message_to_decrypt)
             .await?
             .app_msg
-            .ok_or_else(|| eyre!("[MLS] No message received on master client"))?;
+            .ok_or_else(|| anyhow!("[MLS] No message received on master client"))?;
 
         let decrypted_master = String::from_utf8(decrypted_master_raw)?;
 

--- a/interop/src/util.rs
+++ b/interop/src/util.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::Result;
+use anyhow::Result;
 use core_crypto::{
     MlsTransport,
     prelude::{HistorySecret, MlsCommitBundle},

--- a/keystore-dump/Cargo.toml
+++ b/keystore-dump/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-color-eyre = "0.6"
+anyhow = "1.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 core-crypto-keystore = { workspace = true }


### PR DESCRIPTION
This moves interop and keystore-dump from color-eyre to anyhow. We don't really need color-eyre.