### PR TITLE
ci: disable brew auto update during test-ios

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -162,6 +162,9 @@ jobs:
         with:
           xcode-version: '16.4.0'
       - name: Install swiftlint
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_UPGRADE: 1
         run: |
           brew install swiftlint
       - name: Format-check and lint swift bindings


### PR DESCRIPTION
# What's new in this PR
disables brew auto update during test-ios

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
