### PR TITLE
feat: salt obfuscated values

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -63,6 +63,7 @@ sha2 = "0.10.9"
 core-crypto-keystore.workspace = true
 typed-builder.workspace = true
 core-crypto-macros = { workspace = true }
+rand.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 async-fs = { version = "2.1", optional = true }
@@ -74,7 +75,6 @@ serde-wasm-bindgen = "0.6"
 [dev-dependencies]
 itertools.workspace = true
 uuid = { workspace = true, features = ["v4", "v5"] }
-rand.workspace = true
 tempfile = "3.21"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"


### PR DESCRIPTION
Obfuscated values should change "regularly" for some definition of that term. Our goal is to compromise between debugging utility, for which pure determinism is nice, and customer privacy, for which we would simply never reveal any part of any sensitive value.

This solution means that the same value obfuscated on two devices will appear differently in the logs. It also means that the same value obfuscated between restarts of the client will appear differently.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
