### PR TITLE
refactor: mark whole struct as sensitive

### DIFF
--- a/keystore/src/entities/mls.rs
+++ b/keystore/src/entities/mls.rs
@@ -169,20 +169,18 @@ impl MlsSignatureKeyPair {
 /// Entity representing a persisted `HpkePrivateKey` (related to LeafNode Private keys that the client is aware of)
 #[derive(core_crypto_macros::Debug, Clone, PartialEq, Eq, Zeroize, serde::Serialize, serde::Deserialize)]
 #[zeroize(drop)]
+#[sensitive]
 pub struct MlsHpkePrivateKey {
-    #[sensitive]
     pub sk: Vec<u8>,
-    #[sensitive]
     pub pk: Vec<u8>,
 }
 
 /// Entity representing a persisted `HpkePrivateKey` (related to LeafNode Private keys that the client is aware of)
 #[derive(core_crypto_macros::Debug, Clone, PartialEq, Eq, Zeroize, serde::Serialize, serde::Deserialize)]
 #[zeroize(drop)]
+#[sensitive]
 pub struct MlsEncryptionKeyPair {
-    #[sensitive]
     pub sk: Vec<u8>,
-    #[sensitive]
     pub pk: Vec<u8>,
 }
 
@@ -209,10 +207,9 @@ pub struct MlsEpochEncryptionKeyPair {
 /// Entity representing a persisted `SignatureKeyPair`
 #[derive(core_crypto_macros::Debug, Clone, PartialEq, Eq, Zeroize, serde::Serialize, serde::Deserialize)]
 #[zeroize(drop)]
+#[sensitive]
 pub struct MlsPskBundle {
-    #[sensitive]
     pub psk_id: Vec<u8>,
-    #[sensitive]
     pub psk: Vec<u8>,
 }
 

--- a/keystore/src/entities/proteus.rs
+++ b/keystore/src/entities/proteus.rs
@@ -4,10 +4,9 @@ use crate::connection::FetchFromDatabase;
 
 #[derive(core_crypto_macros::Debug, Clone, Zeroize, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[zeroize(drop)]
+#[sensitive]
 pub struct ProteusIdentity {
-    #[sensitive]
     pub sk: Vec<u8>,
-    #[sensitive]
     pub pk: Vec<u8>,
 }
 


### PR DESCRIPTION
Structs with only sensitive fields should use the container attribute.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
