### PR TITLE
ci: fix: pass secrets to release workflows

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -269,10 +269,21 @@ jobs:
   publish-jvm:
     needs: prepare-publish
     uses: ./.github/workflows/publish-jvm.yml
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
+      PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
+      PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+
 
   publish-android:
     needs: prepare-publish
     uses: ./.github/workflows/publish-android.yml
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      PGP_KEY_ID: ${{ secrets.PGP_KEY_ID }}
+      PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
+      PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
   publish-ios:
     needs: prepare-publish
@@ -281,3 +292,5 @@ jobs:
   publish-web:
     needs: prepare-publish
     uses: ./.github/workflows/publish-wasm.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -5,6 +5,15 @@ concurrency:
 
 on:
   workflow_call:
+    secrets:
+      SONATYPE_PASSWORD:
+        required: true
+      PGP_KEY_ID:
+        required: true
+      PGP_SIGNING_KEY:
+        required: true
+      PGP_PASSPHRASE:
+        required: true
 
 env:
   RELEASE: 1

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -5,6 +5,15 @@ concurrency:
 
 on:
   workflow_call:
+    secrets:
+      SONATYPE_PASSWORD:
+        required: true
+      PGP_KEY_ID:
+        required: true
+      PGP_SIGNING_KEY:
+        required: true
+      PGP_PASSPHRASE:
+        required: true
 
 env:
   RELEASE: 1

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -5,6 +5,9 @@ concurrency:
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 env:
   RELEASE: 1


### PR DESCRIPTION
Reusable workflows don't automatically get access to repository secrets: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
