### PR TITLE
ci: for Android/JVM, don't delete artifacts after publish step

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -59,6 +59,8 @@ jobs:
             files: android.zip
             fail_on_unmatched_files: true
 
+      # For Android, we're not deleting the release artifacts after this step succeds,
+      # because publishing may still fail later.
       - name: publish package
         run: |
           cd crypto-ffi/bindings
@@ -69,8 +71,3 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}
-
-      - name: delete package from gh release
-        run: gh release delete-asset $GITHUB_REF_NAME android.zip --yes
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -77,6 +77,8 @@ jobs:
             files: jvm.zip
             fail_on_unmatched_files: true
 
+      # For JVM, we're not deleting the release artifacts after this step succeds,
+      # because publishing may still fail later.
       - name: publish package
         run: |
           cd crypto-ffi/bindings
@@ -87,8 +89,3 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}
-
-      - name: delete package from gh release
-        run: gh release delete-asset $GITHUB_REF_NAME jvm.zip --yes
-        env:
-          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Publishing may fail at a later time, even when the CI step succeeds, so we're keeping the artifacts on the release.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
