### PR TITLE
ci: explicitly set make or gmake [WPB-20142]

### DIFF
--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -17,11 +17,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set MAKE
+      uses: ./.github/actions/make/set-make-executable
+
     - name: compute artifact key
       shell: bash -euo pipefail {0}
       id: compute-key
       run: |
-        files_hash=$(make "${{ inputs.make-rule }}"-hash-deps)
+        files_hash=$($MAKE "${{ inputs.make-rule }}"-hash-deps)
         echo "key=${{ inputs.key }}-$files_hash" >> "$GITHUB_OUTPUT"
 
     - name: branch name
@@ -89,18 +92,18 @@ runs:
             touch "$dir"
           fi
         done
-      shell: bash -leo pipefail {0}
+      shell: bash -euo pipefail {0}
 
     - name: Run make ${{ inputs.make-rule }} if needed
       if: env.found != 'true'
-      run: make ${{ inputs.make-rule }}
-      shell: bash -leo pipefail {0}
+      run: $MAKE ${{ inputs.make-rule }}
+      shell: bash -euo pipefail {0}
 
     - name: Prepare artifact
       run: |
         mkdir -p .stamps
         printf '%s\n' "${{ inputs.target-path }}" | tar -czf artifact.tar.gz -T - .stamps
-      shell: bash -leo pipefail {0}
+      shell: bash -euo pipefail {0}
 
     - name: Upload artifact if it doesn't exist for this workflow run
       if: env.found_in_this_run != 'true'
@@ -112,4 +115,4 @@ runs:
     - name: Cleanup
       run: |
         rm artifact.tar.gz
-      shell: bash -leo pipefail {0}
+      shell: bash -euo pipefail {0}

--- a/.github/actions/make/ffi-library/action.yml
+++ b/.github/actions/make/ffi-library/action.yml
@@ -18,7 +18,7 @@ runs:
           library_extension="dylib"
         fi
         echo "LIBRARY_EXTENSION=${library_extension}" >> $GITHUB_ENV
-      shell: bash -leo pipefail {0}
+      shell: bash -euo pipefail {0}
 
     - uses: ./.github/actions/make
       with:

--- a/.github/actions/make/ffi-library/action.yml
+++ b/.github/actions/make/ffi-library/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: ffi library extension
       run: |
         os="$(uname -s)"
-        echo "ARTIFACT_NAME=uniffi-${os}-${uniffi_version}" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=uniffi-${os}" >> $GITHUB_ENV
         if [ "$os" = "Linux" ]; then
           library_extension="so"
         elif [ "$os" = "Darwin" ]; then

--- a/.github/actions/make/jvm/action.yml
+++ b/.github/actions/make/jvm/action.yml
@@ -22,7 +22,7 @@ runs:
           fi
           echo "target-path=target/${target}/release/libcore_crypto_ffi.${library_extension}" >> $GITHUB_OUTPUT
           echo "rule=${rule}" >> $GITHUB_OUTPUT
-        shell: bash -leo pipefail {0}
+        shell: bash -euo pipefail {0}
       - uses: ./.github/actions/make
         with:
           key: ${{ steps.platform-specs.outputs.rule }}

--- a/.github/actions/make/set-make-executable/action.yml
+++ b/.github/actions/make/set-make-executable/action.yml
@@ -1,0 +1,15 @@
+name: Set make executable based on OS
+
+runs:
+  using: composite
+
+  steps:
+    - name: set make executable based on OS
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          MAKE_CMD="gmake"
+        else
+          MAKE_CMD="make"
+        fi
+        echo "MAKE=$MAKE_CMD" >> $GITHUB_ENV

--- a/.github/actions/make/uniffi-bindgen/action.yml
+++ b/.github/actions/make/uniffi-bindgen/action.yml
@@ -7,16 +7,19 @@ runs:
   using: composite
 
   steps:
+    - name: Set MAKE
+      uses: ./.github/actions/make/set-make-executable
+
     - name: write uniffi version file
-      run: make .stamps/uniffi-version
-      shell: bash -leo pipefail {0}
+      run: $MAKE .stamps/uniffi-version
+      shell: bash -euo pipefail {0}
 
     - name: uniffi bindgen artifact name
       id: get-artifact-name
       run: |
         os="$(uname -s)"
         echo "artifact-name=uniffi-${os}" >> $GITHUB_OUTPUT
-      shell: bash -leo pipefail {0}
+      shell: bash -euo pipefail {0}
 
     - uses: ./.github/actions/make
       with:
@@ -26,4 +29,4 @@ runs:
         gh-token: ${{ inputs.gh-token }}
 
     - run: chmod +x target/release/uniffi-bindgen
-      shell: bash -leo pipefail {0}
+      shell: bash -euo pipefail {0}

--- a/.github/actions/make/web/ts/action.yml
+++ b/.github/actions/make/web/ts/action.yml
@@ -7,6 +7,9 @@ runs:
   using: composite
 
   steps:
+      - name: Set MAKE
+        uses: ./.github/actions/make/set-make-executable
+
       - name: download wasm binary
         uses: ./.github/actions/make/web/wasm
         with:
@@ -15,8 +18,8 @@ runs:
       # ensure bun deps are installed freshly before any command using bun is invoked
       - name: install bun deps
         run: |
-          make bun-deps
-        shell: bash -leo pipefail {0}
+          $MAKE bun-deps
+        shell: bash -euo pipefail {0}
 
       - name: make js bindings
         uses: ./.github/actions/make

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash -leo pipefail {0}
+    shell: bash -euo pipefail {0}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # This is only needed because of our composite actions calling gmake on ios
+      # to support our local runners without bash configs.
+      - name: Install gmake
+        run: brew install make
+
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
         with:

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash -leo pipefail {0}
+    shell: bash -euo pipefail {0}
 
 env:
   RELEASE: 1

--- a/.github/workflows/package-ios.yml
+++ b/.github/workflows/package-ios.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash -leo pipefail {0}
+    shell: bash -euo pipefail {0}
 
 env:
   RELEASE: 1

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash -leo pipefail {0}
+    shell: bash -euo pipefail {0}
 
 env:
   RELEASE: 1


### PR DESCRIPTION
login shell was needed so that the runners load bash configs. Instead of relying on hidden configs on our local runners we rather set the make executable in our workflow files.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
