### PR TITLE
chore: add ts native benchmark for encrypting messages [WPB-24572]

### DIFF
--- a/crypto-ffi/bindings/js/packages/browser/benches/createMessage.bench.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/createMessage.bench.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe } from "mocha";
 import { browser } from "@wdio/globals";
-import { setup, benchmarkParameters } from "./utils";
+import { setup } from "./utils";
+import { benchmarkParameters } from "../../shared/benches/utils";
 
 beforeEach(async () => {
     await setup();

--- a/crypto-ffi/bindings/js/packages/browser/benches/processMessage.bench.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/processMessage.bench.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe } from "mocha";
 import { browser } from "@wdio/globals";
-import { setup, benchmarkParameters } from "./utils";
+import { setup } from "./utils";
+import { benchmarkParameters } from "../../shared/benches/utils";
 
 beforeEach(async () => {
     await setup();

--- a/crypto-ffi/bindings/js/packages/browser/benches/utils.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/utils.ts
@@ -119,36 +119,6 @@ interface BenchmarkHelpers {
     setupCc: (cipherSuite: Ciphersuite) => Promise<CoreCrypto>;
 }
 
-type ParameterSet = {
-    count: number;
-    size: number;
-    cipherSuite: number;
-};
-
-export async function benchmarkParameters(): Promise<ParameterSet[]> {
-    const messageCounts = [1, 10, 100];
-    const messageSizes = [16, 1024, 65536];
-    const cipherSuites = [
-        Ciphersuite.Mls128Dhkemx25519Aes128gcmSha256Ed25519,
-        Ciphersuite.Mls128Dhkemx25519Chacha20poly1305Sha256Ed25519,
-        Ciphersuite.Mls128Dhkemp256Aes128gcmSha256P256,
-        Ciphersuite.Mls256Dhkemp384Aes256gcmSha384P384,
-        Ciphersuite.Mls256Dhkemp521Aes256gcmSha512P521,
-    ];
-
-    function* benchmarkCombinations() {
-        for (const count of messageCounts) {
-            for (const size of messageSizes) {
-                for (const cipherSuite of cipherSuites) {
-                    yield { count, size, cipherSuite };
-                }
-            }
-        }
-    }
-
-    return Array.from(benchmarkCombinations()) as ParameterSet[]; // return as plain array
-}
-
 function logEvents(entry: local.LogEntry) {
     if (logLevel >= 1) {
         console.log(`[${entry.level}] ${entry.text}`);

--- a/crypto-ffi/bindings/js/packages/native/benches/createMessage.bench.ts
+++ b/crypto-ffi/bindings/js/packages/native/benches/createMessage.bench.ts
@@ -1,0 +1,67 @@
+import { Bench } from "tinybench";
+import {
+    Ciphersuite,
+    ClientId,
+    ConversationId,
+    Credential,
+} from "@wireapp/core-crypto/native";
+import {
+    benchmarkParameters,
+    tinybench_setup,
+} from "../../shared/benches/utils";
+import { ccInit, setup, teardown } from "../test/napi/utils";
+
+async function run() {
+    await setup();
+    const parameters = await benchmarkParameters();
+    const bench = new Bench({
+        name: "Create Messages Benchmark",
+        time: 1000,
+        iterations: 5,
+        warmupIterations: 1,
+        setup: tinybench_setup,
+        teardown: teardown,
+    });
+
+    for (const { count, size, cipherSuite } of parameters) {
+        const message = new Uint8Array(size);
+        const clientId = new ClientId(Buffer.from(crypto.randomUUID()).buffer);
+        const cc = await ccInit(clientId);
+        const conversationIdStr = crypto.randomUUID();
+        const conversationId = new ConversationId(
+            new TextEncoder().encode(conversationIdStr).buffer
+        );
+
+        const credential = Credential.basic(cipherSuite, clientId);
+
+        await cc.transaction(async (ctx) => {
+            await ctx.addCredential(credential);
+        });
+
+        await cc.transaction(async (ctx) => {
+            const [credentialRef] = await ctx.getCredentials();
+            await ctx.createConversation(conversationId, credentialRef!);
+        });
+
+        bench.add(
+            `cipherSuite=${Ciphersuite[cipherSuite]} size=${size}B count=${count}`,
+            async () => {
+                await cc.transaction(async (ctx) => {
+                    for (let i = 0; i < count; i++) {
+                        await ctx.encryptMessage(
+                            conversationId,
+                            message.buffer
+                        );
+                    }
+                });
+            }
+        );
+    }
+    console.log(`Starting ${bench.name}`);
+    await bench.run();
+
+    console.log(bench.name);
+    console.table(bench.table());
+}
+
+await run();

--- a/crypto-ffi/bindings/js/packages/native/tsconfig.json
+++ b/crypto-ffi/bindings/js/packages/native/tsconfig.json
@@ -3,5 +3,10 @@
     "compilerOptions": {
         "customConditions": ["cc-native"]
     },
-    "include": ["../shared/src/**/*.ts", "src/**/*.ts", "test/napi/**/*.ts"]
+    "include": [
+        "../shared/src/**/*.ts",
+        "src/**/*.ts",
+        "test/napi/**/*.ts",
+        "benches/**/*.ts"
+    ]
 }

--- a/crypto-ffi/bindings/js/packages/shared/benches/utils.ts
+++ b/crypto-ffi/bindings/js/packages/shared/benches/utils.ts
@@ -1,0 +1,31 @@
+import { Ciphersuite } from "../src/CoreCrypto";
+
+type ParameterSet = {
+    count: number;
+    size: number;
+    cipherSuite: number;
+};
+
+export async function benchmarkParameters(): Promise<ParameterSet[]> {
+    const messageCounts = [1, 10, 100];
+    const messageSizes = [16, 1024, 65536];
+    const cipherSuites = [
+        Ciphersuite.Mls128Dhkemx25519Aes128gcmSha256Ed25519,
+        Ciphersuite.Mls128Dhkemx25519Chacha20poly1305Sha256Ed25519,
+        Ciphersuite.Mls128Dhkemp256Aes128gcmSha256P256,
+        Ciphersuite.Mls256Dhkemp384Aes256gcmSha384P384,
+        Ciphersuite.Mls256Dhkemp521Aes256gcmSha512P521,
+    ];
+
+    function* benchmarkCombinations() {
+        for (const count of messageCounts) {
+            for (const size of messageSizes) {
+                for (const cipherSuite of cipherSuites) {
+                    yield { count, size, cipherSuite };
+                }
+            }
+        }
+    }
+
+    return Array.from(benchmarkCombinations()) as ParameterSet[]; // return as plain array
+}

--- a/crypto-ffi/bindings/js/packages/shared/benches/utils.ts
+++ b/crypto-ffi/bindings/js/packages/shared/benches/utils.ts
@@ -1,4 +1,9 @@
+import type { Task } from "tinybench";
 import { Ciphersuite } from "../src/CoreCrypto";
+
+export function tinybench_setup(task?: Task, mode?: string) {
+    console.log(`Executing ${mode} ${task?.name}`);
+}
 
 type ParameterSet = {
     count: number;

--- a/make/sources.mk
+++ b/make/sources.mk
@@ -82,4 +82,7 @@ TS_BROWSER_TEST_FILES := $(sort \
 	$(shell find $(TS_NATIVE_DIR)/test/wasm -type f -name '*.ts' 2>/dev/null | LC_ALL=C sort) \
 	$(shell find $(TS_BROWSER_DIR)/test -type f -name '*.ts' 2>/dev/null | LC_ALL=C sort))
 TS_TEST_FILES := $(sort $(TS_NATIVE_TEST_FILES) $(TS_BROWSER_TEST_FILES))
-TS_BENCH_FILES := $(shell find $(TS_BROWSER_DIR)/benches -type f -name '*.ts' 2>/dev/null | LC_ALL=C sort)
+TS_NATIVE_BENCH_FILES := $(shell find $(TS_NATIVE_DIR)/benches -type f -name '*.ts' 2>/dev/null | LC_ALL=C sort)
+TS_BROWSER_BENCH_FILES := $(shell find $(TS_BROWSER_DIR)/benches -type f -name '*.ts' 2>/dev/null | LC_ALL=C sort)
+
+TS_BENCH_FILES := $(sort $(TS_NATIVE_BENCH_FILES) $(TS_BROWSER_BENCH_FILES))

--- a/make/ts.mk
+++ b/make/ts.mk
@@ -197,8 +197,8 @@ $(STAMPS)/ts-test:
 	$(TOUCH_STAMP)
 
 # run WebDriver benches
-.PHONY: ts-bench
-ts-bench: $(BROWSER_OUT) ## Run TypeScript wrapper benches in Chrome via wdio
+.PHONY: ts-browser-bench
+ts-browser-bench: $(BROWSER_OUT) ## Run TypeScript wrapper benches in Chrome via wdio
 	@set -euo pipefail; \
 	cd $(JS_DIR) && \
 	if [ -n "$(BENCH)" ]; then \
@@ -206,6 +206,17 @@ ts-bench: $(BROWSER_OUT) ## Run TypeScript wrapper benches in Chrome via wdio
 	else \
 		bun x wdio run ./packages/browser/benches/wdio.bench.conf.ts --log-level warn; \
 	fi
+
+.PHONY: ts-native-bench
+ts-native-bench: $(TS_NATIVE_OUT)
+	@set -euo pipefail; \
+	cd $(JS_DIR) && \
+	if [ -n "$(BENCH)" ]; then \
+		bun --conditions=cc-native run ./packages/native/benches/*$(BENCH)*.bench.ts; \
+	else \
+		bun --conditions=cc-native run ./packages/native/benches/*.bench.ts; \
+	fi
+
 
 .PHONY: ts-package
 ts-package: $(TS_OUT)  ## Package the ready-to-release tarball


### PR DESCRIPTION
# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
