### PR TITLE
chore: upgrade refinery to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4632,8 +4632,9 @@ dependencies = [
 
 [[package]]
 name = "refinery"
-version = "0.9.0"
-source = "git+https://github.com/rust-db/refinery?rev=3abf61ec3836e835012346336fe144ca7fe9e9b7#3abf61ec3836e835012346336fe144ca7fe9e9b7"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee5133e5b207e5703c2a4a9dc9bd8c8f2cc74c4ac04ca5510acaa907012c77ac"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -4641,8 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-core"
-version = "0.9.0"
-source = "git+https://github.com/rust-db/refinery?rev=3abf61ec3836e835012346336fe144ca7fe9e9b7#3abf61ec3836e835012346336fe144ca7fe9e9b7"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a2a96d959c9b5b5da78e965bfdb1363b365bf5e84531a67d0eee827a702a3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4658,8 +4660,9 @@ dependencies = [
 
 [[package]]
 name = "refinery-macros"
-version = "0.9.0"
-source = "git+https://github.com/rust-db/refinery?rev=3abf61ec3836e835012346336fe144ca7fe9e9b7#3abf61ec3836e835012346336fe144ca7fe9e9b7"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56c2e960c8e47c7c5c30ad334afea8b5502da796a59e34d640d6239d876d924"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -36,9 +36,7 @@ openmls_x509_credential = { workspace = true }
 postcard = { version = "1.1", default-features = false, features = ["use-std"] }
 proteus-traits = { workspace = true, optional = true }
 rand = { workspace = true, features = ["getrandom"] }
-# we should depend on a real release instead of a git tag again once refinery
-# releases a version containing https://github.com/rust-db/refinery/commit/3abf61ec3836e835012346336fe144ca7fe9e9b7
-refinery = { version = "0.9", git = "https://github.com/rust-db/refinery", rev = "3abf61ec3836e835012346336fe144ca7fe9e9b7", default-features = false, features = [
+refinery = { version = "0.9.1", default-features = false, features = [
   "rusqlite",
 ] }
 rusqlite = { version = "0.38", default-features = false, features = [


### PR DESCRIPTION
Dependabot won't catch this because we needed to move from a git ref to a normal release.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
