### PR TITLE
chore: don't strip debug symbols in debug mode

### DIFF
--- a/make/android.mk
+++ b/make/android.mk
@@ -19,7 +19,7 @@ $(ANDROID_ARMv7): $(android-armv7-deps)
 	  --target armv7-linux-androideabi \
 	  --package core-crypto-ffi \
 	  --crate-type=cdylib --crate-type=staticlib \
-	  $(CARGO_BUILD_ARGS) -- -C strip=symbols
+	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 
 .PHONY: android-armv7
 android-armv7: $(ANDROID_ARMv7) ## Build core-crypto-ffi for armv7-linux-androideabi
@@ -32,7 +32,7 @@ $(ANDROID_ARMv8): $(android-armv8-deps)
 	  --target aarch64-linux-android \
 	  --package core-crypto-ffi \
 	  --crate-type=cdylib --crate-type=staticlib \
-	  $(CARGO_BUILD_ARGS) -- -C strip=symbols
+	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 
 .PHONY: android-armv8
 android-armv8: $(ANDROID_ARMv8) ## Build core-crypto-ffi for aarch64-linux-android
@@ -47,7 +47,7 @@ $(ANDROID_X86): $(android-x86-deps)
 	  --package core-crypto-ffi \
 	  --crate-type=cdylib --crate-type=staticlib \
 	  $(CARGO_BUILD_ARGS) -- \
-	  -C strip=symbols \
+	  $(RUST_STRIP_FLAGS) \
 	  -l static=clang_rt.builtins-x86_64-android \
 	  -L $$($(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(PLATFORM_DIR)/bin/clang --print-resource-dir)/lib/linux
 

--- a/make/config.mk
+++ b/make/config.mk
@@ -41,3 +41,8 @@ STAMPS := .stamps
 # We're writing a timestamp into the file because CI relies on file hashes to
 # change when the stamp files are updated.
 TOUCH_STAMP = @mkdir -p $(STAMPS) && echo "$$(date)" > $@
+
+RUST_STRIP_FLAGS :=
+ifeq ($(RELEASE_MODE),release)
+RUST_STRIP_FLAGS := -C strip=symbols
+endif

--- a/make/ios.mk
+++ b/make/ios.mk
@@ -11,7 +11,7 @@ $(IOS_DEVICE): $(ios-device-deps)
 	  --crate-type=cdylib \
 	  --crate-type=staticlib \
 	  --package core-crypto-ffi \
-	  $(CARGO_BUILD_ARGS) -- -C strip=symbols
+	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 
 .PHONY: ios-device
 ios-device: $(IOS_DEVICE) ## Build core-crypto-ffi for aarch64-apple-ios for iOS 16.4 (macOS only)
@@ -28,7 +28,7 @@ $(IOS_SIMULATOR_ARM): $(ios-simulator-arm-deps)
 	  --crate-type=cdylib \
 	  --crate-type=staticlib \
 	  --package core-crypto-ffi \
-	  $(CARGO_BUILD_ARGS) -- -C strip=symbols
+	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 
 .PHONY: ios-simulator-arm
 ios-simulator-arm: $(IOS_SIMULATOR_ARM) ## Build core-crypto-ffi for aarch64-apple-ios-sim, iOS 16.4 (macOS only)

--- a/make/jvm.mk
+++ b/make/jvm.mk
@@ -10,8 +10,7 @@ $(JVM_DARWIN_LIB): $(jvm-darwin-deps)
 	  --target aarch64-apple-darwin \
 	  --package core-crypto-ffi \
 	  --crate-type=cdylib --crate-type=staticlib \
-	  $(CARGO_BUILD_ARGS) -- -C strip=symbols
-
+	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 .PHONY: jvm-darwin
 jvm-darwin: $(JVM_DARWIN_LIB) ## Build core-crypto-ffi for JVM on aarch64-apple-darwin
 
@@ -23,7 +22,7 @@ $(JVM_LINUX_LIB): $(jvm-linux-deps)
 	  --target x86_64-unknown-linux-gnu \
 	  --package core-crypto-ffi \
 	  --crate-type=cdylib --crate-type=staticlib \
-	  $(CARGO_BUILD_ARGS) -- -C strip=symbols
+	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 
 .PHONY: jvm-linux
 jvm-linux: $(JVM_LINUX_LIB) ## Build core-crypto-ffi for JVM on x86_64-unknown-linux-gnu


### PR DESCRIPTION
# What's new in this PR
This PR removes debug symbol stripping from jvm, android, and ios debug builds.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
