### PR TITLE
chore: drop key normalization functions [WPB-23594]

### DIFF
--- a/crypto/src/e2e_identity/enrollment/crypto.rs
+++ b/crypto/src/e2e_identity/enrollment/crypto.rs
@@ -1,4 +1,4 @@
-use mls_crypto_provider::{MlsCryptoProvider, RustCrypto};
+use mls_crypto_provider::MlsCryptoProvider;
 use openmls::prelude::SignatureScheme;
 use openmls_traits::{OpenMlsCryptoProvider as _, crypto::OpenMlsCrypto as _};
 
@@ -20,11 +20,8 @@ impl super::E2eiEnrollment {
     pub(crate) fn get_sign_key_for_mls(&self) -> Result<Vec<u8>> {
         let sk = match self.ciphersuite.signature_algorithm() {
             SignatureScheme::ECDSA_SECP256R1_SHA256 | SignatureScheme::ECDSA_SECP384R1_SHA384 => self.sign_sk.to_vec(),
-            SignatureScheme::ECDSA_SECP521R1_SHA512 => RustCrypto::normalize_p521_secret_key(&self.sign_sk).to_vec(),
-            SignatureScheme::ED25519 => RustCrypto::normalize_ed25519_key(self.sign_sk.as_slice())
-                .map_err(MlsError::wrap("normalizing ed25519 key"))?
-                .to_bytes()
-                .to_vec(),
+            SignatureScheme::ECDSA_SECP521R1_SHA512 => self.sign_sk.to_vec(),
+            SignatureScheme::ED25519 => self.sign_sk.to_vec(),
             SignatureScheme::ED448 => return Err(Error::NotYetSupported),
         };
         Ok(sk)

--- a/mls-provider/src/crypto_provider.rs
+++ b/mls-provider/src/crypto_provider.rs
@@ -34,13 +34,6 @@ impl Default for RustCrypto {
     }
 }
 
-#[inline]
-fn normalize_p521_secret_key(sk: &[u8]) -> zeroize::Zeroizing<[u8; 66]> {
-    let mut sk_buf = zeroize::Zeroizing::new([0u8; 66]);
-    sk_buf[66 - sk.len()..].copy_from_slice(sk);
-    sk_buf
-}
-
 impl RustCrypto {
     pub fn new_with_seed(seed: EntropySeed) -> Self {
         Self {
@@ -52,28 +45,6 @@ impl RustCrypto {
         let mut val = self.rng.write().map_err(|_| MlsProviderError::RngLockPoison)?;
         *val = rand_chacha::ChaCha20Rng::from_seed(seed.unwrap_or_default().0);
         Ok(())
-    }
-
-    pub fn normalize_p521_secret_key(sk: &[u8]) -> zeroize::Zeroizing<[u8; 66]> {
-        normalize_p521_secret_key(sk)
-    }
-
-    pub fn normalize_ed25519_key(key: &[u8]) -> Result<ed25519_dalek::SigningKey, CryptoError> {
-        let k = match key.len() {
-            // Compat layer for legacy keypairs [seed, pk]
-            ed25519_dalek::KEYPAIR_LENGTH => {
-                let mut sk = zeroize::Zeroizing::new([0u8; ed25519_dalek::KEYPAIR_LENGTH]);
-                sk.copy_from_slice(key);
-                ed25519_dalek::SigningKey::from_keypair_bytes(&sk).map_err(|_| CryptoError::CryptoLibraryError)?
-            }
-            ed25519_dalek::SECRET_KEY_LENGTH => {
-                let mut sk = zeroize::Zeroizing::new([0u8; ed25519_dalek::SECRET_KEY_LENGTH]);
-                sk.copy_from_slice(key);
-                ed25519_dalek::SigningKey::from_bytes(&sk)
-            }
-            _ => return Err(CryptoError::CryptoLibraryError),
-        };
-        Ok(k)
     }
 }
 
@@ -330,36 +301,8 @@ impl OpenMlsCrypto for RustCrypto {
         }
     }
 
-    fn sign(&self, alg: SignatureScheme, data: &[u8], key: &[u8]) -> Result<Vec<u8>, CryptoError> {
-        use signature::Signer as _;
-
-        match alg {
-            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
-                let k = p256::ecdsa::SigningKey::from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
-                let signature: p256::ecdsa::DerSignature =
-                    k.try_sign(data).map_err(|_| CryptoError::CryptoLibraryError)?;
-                Ok(signature.to_bytes().into())
-            }
-            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
-                let k = p384::ecdsa::SigningKey::from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
-                let signature: p384::ecdsa::DerSignature =
-                    k.try_sign(data).map_err(|_| CryptoError::CryptoLibraryError)?;
-                Ok(signature.to_bytes().into())
-            }
-            SignatureScheme::ECDSA_SECP521R1_SHA512 => {
-                let k = p521::ecdsa::SigningKey::from_slice(&*normalize_p521_secret_key(key))
-                    .map_err(|_| CryptoError::CryptoLibraryError)?;
-                let signature: p521::ecdsa::DerSignature =
-                    k.try_sign(data).map_err(|_| CryptoError::CryptoLibraryError)?.to_der();
-                Ok(signature.to_bytes().into())
-            }
-            SignatureScheme::ED25519 => {
-                let k = Self::normalize_ed25519_key(key)?;
-                let signature = k.try_sign(data).map_err(|_| CryptoError::CryptoLibraryError)?;
-                Ok(signature.to_bytes().into())
-            }
-            _ => Err(CryptoError::UnsupportedSignatureScheme),
-        }
+    fn sign(&self, _alg: SignatureScheme, _data: &[u8], _key: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        unimplemented!("This is never used by openmls, so we don't make the effort of implementing it.");
     }
 
     fn hpke_seal(

--- a/mls-provider/src/pki.rs
+++ b/mls-provider/src/pki.rs
@@ -431,8 +431,11 @@ impl PkiKeypair {
                     .map_err(|_| MlsProviderError::CertificateGenerationError)?,
             ))),
             SignatureScheme::ED25519 => Ok(PkiKeypair::Ed25519(Ed25519PkiKeypair(
-                crate::RustCrypto::normalize_ed25519_key(sk.as_slice())
-                    .map_err(|_| MlsProviderError::CertificateGenerationError)?,
+                ed25519_dalek::SigningKey::from_bytes(
+                    sk.as_slice()
+                        .try_into()
+                        .map_err(|_| MlsProviderError::CertificateGenerationError)?,
+                ),
             ))),
             _ => Err(MlsProviderError::UnsupportedSignatureScheme),
         }

--- a/mls-provider/tests/crypto.rs
+++ b/mls-provider/tests/crypto.rs
@@ -117,29 +117,6 @@ mod tests {
     }
 
     #[apply(all_storage_types_and_ciphersuites)]
-    async fn signature_is_consistent(
-        backend: MlsCryptoProvider,
-        ciphersuite: Ciphersuite,
-        entropy_seed: Option<EntropySeed>,
-    ) {
-        let backend = backend.await;
-        backend.reseed(entropy_seed).unwrap();
-
-        let len = rand::thread_rng().gen_range(LEN_RANGE);
-        let data = backend.rand().random_vec(len).unwrap();
-
-        let crypto = backend.crypto();
-        let (sk, pk) = crypto.signature_key_gen(ciphersuite.signature_algorithm()).unwrap();
-
-        let signature = crypto.sign(ciphersuite.signature_algorithm(), &data, &sk).unwrap();
-        crypto
-            .verify_signature(ciphersuite.signature_algorithm(), &data, &pk, &signature)
-            .unwrap();
-
-        teardown(backend).await;
-    }
-
-    #[apply(all_storage_types_and_ciphersuites)]
     async fn hpke_is_consistent(
         backend: MlsCryptoProvider,
         ciphersuite: Ciphersuite,


### PR DESCRIPTION
This is the 9.x version of 3cd53fdb4b6bf35296b94c5a453324690851382e. In addition to just dropping the `sign()` implementation of the openmls trait, we're dropping the key normalization ussages in other places, too. Each ciphersuite's sign key is now trated the same.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
