### PR TITLE
test(kotlin): wait for epoch observer callback

### DIFF
--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -420,10 +420,13 @@ class MLSTest : HasMockDeliveryService() {
 
             class Observer : EpochObserver {
                 val observedEvents = emptyList<ObserverEvent>().toMutableList()
+                val firstObservedEvent = CompletableDeferred<ObserverEvent>()
 
                 override suspend fun epochChanged(conversationId: ConversationId, epoch: ULong) {
                     val conversationEpoch = alice.conversationEpoch(conversationId)
-                    observedEvents.add(ObserverEvent(epoch, conversationEpoch))
+                    val observerEvent = ObserverEvent(epoch, conversationEpoch)
+                    observedEvents.add(observerEvent)
+                    firstObservedEvent.complete(observerEvent)
                 }
             }
 
@@ -436,11 +439,14 @@ class MLSTest : HasMockDeliveryService() {
 
             alice.transaction { it.updateKeyingMaterial(id) }
             val laterEpoch = alice.conversationEpoch(id)
+            val observedEvent = aliceObserver.firstObservedEvent.await()
 
             assertEquals(initialEpoch + 1U, laterEpoch)
             assertEquals(1, aliceObserver.observedEvents.size, "we triggered exactly 1 epoch change and must have observed that")
-            assertTrue(
-                aliceObserver.observedEvents.all { it.eventEpoch == it.conversationEpoch && it.eventEpoch == laterEpoch },
+            assertEquals(laterEpoch, observedEvent.eventEpoch, "event epoch must equal the epoch after the transaction")
+            assertEquals(
+                observedEvent.eventEpoch,
+                observedEvent.conversationEpoch,
                 "event epoch must equal the epoch read during the event"
             )
         }


### PR DESCRIPTION
The Kotlin epoch observer wrapper reports events by launching the user callback into the provided CoroutineScope. That means the native epoch change notification can return, and the transaction can complete, before the launched callback has run.

epochObserverEvent_shouldAllowReadingData asserted on the observer's mutable list immediately after updateKeyingMaterial. In CI this occasionally raced with the launched callback and observed zero events even though the epoch change was correctly scheduled.

Use a CompletableDeferred that is completed only after the observer callback has read the conversation epoch and recorded the event. The test now waits for that callback completion before checking the event count and epoch values, preserving the behavior under test without depending on scheduler timing.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
