### PR TITLE
chore(ffi): hand-write a `Display` impl for `SecretKey`

### DIFF
--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use core_crypto::{
     Ciphersuite as CryptoCiphersuite, CredentialFindFilters, MlsConversationConfiguration,
@@ -21,7 +21,16 @@ bytes_wrapper!(
     #[uniffi::export(Eq, Hash, Display)]
     SecretKey infallibly wraps core_crypto::mls::conversation::SecretKey; copy_bytes
 );
-impl_display_via_hex!(SecretKey);
+impl fmt::Display for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hash = obfuscate::compute_hash(&self.0);
+        let mut buffer = [0; 20];
+        hex::encode_to_slice(hash, &mut buffer).expect("hash has constant length 10 therefore encodes to 20 bytes");
+        // SAFETY: hex crate always produces valid utf-8
+        let data = unsafe { str::from_utf8_unchecked(&buffer) };
+        f.write_str(data)
+    }
+}
 
 bytes_wrapper!(
     /// The raw public key of an external sender.


### PR DESCRIPTION
This makes it slightly harder to accidentally reveal the secret value.

This also never does anything with the heap, which keeps it nicely lean / efficient.

Note that this does _not_ use `core_crypto_macros::Debug` because the macro has no good way to forward the `#[sensitive]` attribute, and if nothing is sensitive, then there's no point in using the CC version of the macro.


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
