### PR TITLE
fix(conversation): don't eagerly emit epoch change events [WPB-25113]

### DIFF
--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -420,13 +420,10 @@ class MLSTest : HasMockDeliveryService() {
 
             class Observer : EpochObserver {
                 val observedEvents = emptyList<ObserverEvent>().toMutableList()
-                val firstObservedEvent = CompletableDeferred<ObserverEvent>()
 
                 override suspend fun epochChanged(conversationId: ConversationId, epoch: ULong) {
                     val conversationEpoch = alice.conversationEpoch(conversationId)
-                    val observerEvent = ObserverEvent(epoch, conversationEpoch)
-                    observedEvents.add(observerEvent)
-                    firstObservedEvent.complete(observerEvent)
+                    observedEvents.add(ObserverEvent(epoch, conversationEpoch))
                 }
             }
 
@@ -439,14 +436,11 @@ class MLSTest : HasMockDeliveryService() {
 
             alice.transaction { it.updateKeyingMaterial(id) }
             val laterEpoch = alice.conversationEpoch(id)
-            val observedEvent = aliceObserver.firstObservedEvent.await()
 
             assertEquals(initialEpoch + 1U, laterEpoch)
             assertEquals(1, aliceObserver.observedEvents.size, "we triggered exactly 1 epoch change and must have observed that")
-            assertEquals(laterEpoch, observedEvent.eventEpoch, "event epoch must equal the epoch after the transaction")
-            assertEquals(
-                observedEvent.eventEpoch,
-                observedEvent.conversationEpoch,
+            assertTrue(
+                aliceObserver.observedEvents.all { it.eventEpoch == it.conversationEpoch && it.eventEpoch == laterEpoch },
                 "event epoch must equal the epoch read during the event"
             )
         }

--- a/crypto/src/mls/conversation/conversation_guard/commit.rs
+++ b/crypto/src/mls/conversation/conversation_guard/commit.rs
@@ -30,10 +30,18 @@ impl ConversationGuard {
     }
 
     pub(super) async fn merge_commit(&mut self) -> Result<()> {
-        let client = self.session().await?;
         let provider = self.crypto_provider().await?;
-        self.conversation_mut(async |conversation| conversation.commit_accepted(&client, &provider).await)
+        let (conversation_id, epoch) = self
+            .conversation_mut(async |conversation| {
+                conversation.commit_accepted(&provider).await?;
+                Ok((conversation.id().to_owned(), conversation.group.epoch().as_u64()))
+            })
+            .await?;
+        self.central_context
+            .queue_epoch_changed(conversation_id, epoch)
             .await
+            .map_err(RecursiveError::transaction("queueing epoch changed notification"))?;
+        Ok(())
     }
 
     /// Send the commit via [crate::MlsTransport] and handle the response.

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/buffer_messages.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/buffer_messages.rs
@@ -226,18 +226,6 @@ mod tests {
                     assert!(msg.app_msg.is_none());
                 }
             }
-            let observed_epochs = observer
-                .observed_epochs()
-                .await
-                .into_iter()
-                .map(|(_conversation_id, epoch)| epoch)
-                .collect::<Vec<_>>();
-            dbg!(&observed_epochs);
-            assert_eq!(
-                observed_epochs.len(),
-                2,
-                "there was 1 buffered commit changing the epoch plus the outer commit changing the epoch"
-            );
 
             assert_eq!(conversation.member_count().await, 4);
             assert!(
@@ -248,6 +236,17 @@ mod tests {
 
             // After merging we should erase all those pending messages
             assert_eq!(bob.transaction.count_entities().await.pending_messages, 0);
+
+            bob.transaction.finish().await.unwrap();
+
+            let observed_epochs = observer
+                .observed_epochs()
+                .await
+                .into_iter()
+                .map(|(_conversation_id, epoch)| epoch)
+                .collect::<Vec<_>>();
+            dbg!(&observed_epochs);
+            assert_eq!(observed_epochs.len(), 1, "there was 1 commit changing the epoch");
         })
         .await
     }
@@ -336,6 +335,18 @@ mod tests {
                 }
             }
 
+            assert_eq!(conversation.member_count().await, 4);
+            assert!(
+                conversation
+                    .is_functional_and_contains([&alice, &bob, &charlie, &debbie])
+                    .await
+            );
+
+            // After merging we should erase all those pending messages
+            assert_eq!(alice.transaction.count_entities().await.pending_messages, 0);
+
+            alice.transaction.finish().await.unwrap();
+
             let observed_epochs = observer
                 .observed_epochs()
                 .await
@@ -348,16 +359,6 @@ mod tests {
                 2,
                 "there was 1 buffered commit changing the epoch plus the outer commit changing the epoch"
             );
-
-            assert_eq!(conversation.member_count().await, 4);
-            assert!(
-                conversation
-                    .is_functional_and_contains([&alice, &bob, &charlie, &debbie])
-                    .await
-            );
-
-            // After merging we should erase all those pending messages
-            assert_eq!(alice.transaction.count_entities().await.pending_messages, 0);
         })
         .await
     }

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -327,7 +327,10 @@ impl ConversationGuard {
                     proposals:? = staged_commit.queued_proposals().map(Obfuscated::from).collect::<Vec<_>>();
                     "Epoch advanced"
                 );
-                session.notify_epoch_changed(group_id, epoch).await;
+                self.central_context
+                    .queue_epoch_changed(group_id, epoch)
+                    .await
+                    .map_err(RecursiveError::transaction("queueing epoch changed notification"))?;
 
                 MlsDecryptMessage {
                     app_msg: None,

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -563,13 +563,14 @@ mod tests {
 
                 let epoch_after = commit.finish().guard_of(&bob).await.epoch().await;
                 assert_eq!(epoch_after, epoch_before + 1);
-                assert!(bob_observer.has_changed().await);
                 assert!(decrypted.delay.is_none());
                 assert!(decrypted.app_msg.is_none());
 
                 alice
                     .verify_sender_identity(&case, &alice.initial_credential, &decrypted)
                     .await;
+                bob.transaction.finish().await.unwrap();
+                assert!(bob_observer.has_changed().await);
             })
             .await
         }

--- a/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/conversation_guard/decrypt/mod.rs
@@ -145,7 +145,6 @@ impl ConversationGuard {
         message: MlsMessageIn,
         recursion_policy: RecursionPolicy,
     ) -> Result<MlsDecryptMessage> {
-        let session = &self.session().await?;
         let provider = &self.crypto_provider().await?;
         let parsed_message = self.parse_message(message.clone()).await?;
 
@@ -161,7 +160,7 @@ impl ConversationGuard {
             let mut decrypted_message = self
                 .conversation_mut(async |conversation| {
                     let ct = conversation.extract_confirmation_tag_from_own_commit(&message)?;
-                    conversation.handle_own_commit(session, provider, ct).await
+                    conversation.handle_own_commit(provider, ct).await
                 })
                 .await?;
             debug_assert!(

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -37,10 +37,6 @@ impl MlsConversation {
             let _ = backend.key_store().remove_borrowed::<StoredEncryptionKeyPair>(ek).await;
         }
 
-        session
-            .notify_epoch_changed(self.id.clone(), self.group.epoch().as_u64())
-            .await;
-
         Ok(())
     }
 }

--- a/crypto/src/mls/conversation/merge.rs
+++ b/crypto/src/mls/conversation/merge.rs
@@ -10,31 +10,30 @@
 //! | 0 pend. Proposal  | ❌              | ✅              |
 //! | 1+ pend. Proposal | ❌              | ✅              |
 
-use core_crypto_keystore::{Database, entities::StoredEncryptionKeyPair};
+use core_crypto_keystore::entities::StoredEncryptionKeyPair;
 use openmls_traits::OpenMlsCryptoProvider;
 
 use super::Result;
-use crate::{MlsError, Session, mls::MlsConversation, mls_provider::MlsCryptoProvider};
+use crate::{MlsError, mls::MlsConversation, mls_provider::MlsCryptoProvider};
 
 /// Abstraction over a MLS group capable of merging a commit
 impl MlsConversation {
-    pub(crate) async fn commit_accepted(
-        &mut self,
-        session: &Session<Database>,
-        backend: &MlsCryptoProvider,
-    ) -> Result<()> {
+    pub(crate) async fn commit_accepted(&mut self, provider: &MlsCryptoProvider) -> Result<()> {
         // openmls stores here all the encryption keypairs used for update proposals..
         let previous_own_leaf_nodes = self.group.own_leaf_nodes.clone();
 
         self.group
-            .merge_pending_commit(backend)
+            .merge_pending_commit(provider)
             .await
             .map_err(MlsError::wrap("merging pending commit"))?;
 
         // ..so if there's any, we clear them after the commit is merged
         for oln in &previous_own_leaf_nodes {
             let ek = oln.encryption_key().as_slice();
-            let _ = backend.key_store().remove_borrowed::<StoredEncryptionKeyPair>(ek).await;
+            let _ = provider
+                .key_store()
+                .remove_borrowed::<StoredEncryptionKeyPair>(ek)
+                .await;
         }
 
         Ok(())
@@ -58,13 +57,13 @@ mod tests {
 
                 assert!(conversation.has_pending_commit().await);
 
-                let session = alice.session().await;
-
                 conversation
                     .guard()
                     .await
                     .conversation_mut(async |conversation| {
-                        conversation.commit_accepted(&session, &session.crypto_provider).await
+                        conversation
+                            .commit_accepted(&alice.session().await.crypto_provider)
+                            .await
                     })
                     .await
                     .unwrap();
@@ -92,13 +91,13 @@ mod tests {
                 assert!(conversation.has_pending_proposals().await);
                 assert!(conversation.has_pending_commit().await);
 
-                let session = alice.session().await;
-
                 conversation
                     .guard()
                     .await
                     .conversation_mut(async |conversation| {
-                        conversation.commit_accepted(&session, &session.crypto_provider).await
+                        conversation
+                            .commit_accepted(&alice.session().await.crypto_provider)
+                            .await
                     })
                     .await
                     .unwrap();

--- a/crypto/src/mls/conversation/own_commit.rs
+++ b/crypto/src/mls/conversation/own_commit.rs
@@ -1,4 +1,3 @@
-use core_crypto_keystore::Database;
 use openmls::prelude::{
     ConfirmationTag, ContentType, CredentialWithKey, FramedContentBodyIn, MlsMessageIn, MlsMessageInBody, Sender,
 };
@@ -6,7 +5,7 @@ use openmls_traits::OpenMlsCryptoProvider as _;
 
 use super::{Error, Result};
 use crate::{
-    MlsConversation, MlsDecryptMessage, RecursiveError, Session, mls::credential::ext::CredentialExt,
+    MlsConversation, MlsDecryptMessage, RecursiveError, mls::credential::ext::CredentialExt,
     mls_provider::MlsCryptoProvider,
 };
 
@@ -46,7 +45,6 @@ impl MlsConversation {
 
     pub(crate) async fn handle_own_commit(
         &mut self,
-        client: &Session<Database>,
         provider: &MlsCryptoProvider,
         ct: &ConfirmationTag,
     ) -> Result<MlsDecryptMessage> {
@@ -66,7 +64,7 @@ impl MlsConversation {
 
         // incoming is from ourselves and it's the same as the local pending commit
         // => merge the pending commit & continue
-        self.merge_pending_commit(client, provider).await
+        self.merge_pending_commit(provider).await
     }
 
     /// Compare incoming commit with local pending commit
@@ -80,12 +78,8 @@ impl MlsConversation {
     /// When the incoming commit is sent by ourselves and it's the same as the local pending commit.
     /// This adapts [Self::commit_accepted] to return the same as
     /// [crate::mls::conversation::ConversationGuard::decrypt_message]
-    pub(crate) async fn merge_pending_commit(
-        &mut self,
-        client: &Session<Database>,
-        provider: &MlsCryptoProvider,
-    ) -> Result<MlsDecryptMessage> {
-        self.commit_accepted(client, provider).await?;
+    pub(crate) async fn merge_pending_commit(&mut self, provider: &MlsCryptoProvider) -> Result<MlsDecryptMessage> {
+        self.commit_accepted(provider).await?;
 
         let own_leaf = self
             .group
@@ -97,7 +91,7 @@ impl MlsConversation {
             credential: own_leaf.credential().clone(),
             signature_key: own_leaf.signature_key().clone(),
         };
-        let provider = client.crypto_provider.authentication_service();
+        let provider = provider.authentication_service();
         let identity = own_leaf_credential_with_key
             .extract_identity(self.ciphersuite(), provider.borrow().await.as_ref())
             .map_err(RecursiveError::mls_credential("extracting identity"))?;

--- a/crypto/src/mls/conversation/pending_conversation.rs
+++ b/crypto/src/mls/conversation/pending_conversation.rs
@@ -381,14 +381,6 @@ mod tests {
                 panic!("Alice's messages should have been restored at this point");
             };
 
-            let observed_epochs = observer.observed_epochs().await;
-            assert_eq!(
-                observed_epochs.len(),
-                1,
-                "we should see exactly 1 epoch change in these 4 messages"
-            );
-            assert_eq!(observed_epochs[0].0, *conversation.id(), "conversation id must match");
-
             for (idx, msg) in restored_messages.iter().enumerate() {
                 if idx == 0 {
                     // the only application message
@@ -407,6 +399,16 @@ mod tests {
 
             // After merging we should erase all those pending messages
             assert_eq!(bob.transaction.count_entities().await.pending_messages, 0);
+
+            bob.transaction.finish().await.unwrap();
+
+            let observed_epochs = observer.observed_epochs().await;
+            assert_eq!(
+                observed_epochs.len(),
+                1,
+                "we should see exactly 1 epoch change in these 4 messages"
+            );
+            assert_eq!(observed_epochs[0].0, *conversation.id(), "conversation id must match");
         })
         .await
     }

--- a/crypto/src/mls/session/epoch_observer.rs
+++ b/crypto/src/mls/session/epoch_observer.rs
@@ -68,6 +68,7 @@ mod tests {
 
             // trigger an epoch
             let id = test_conv.advance_epoch().await.id;
+            session_context.transaction.finish().await.unwrap();
 
             // ensure we have observed the epoch change
             let observed_epochs = observer.observed_epochs().await;
@@ -100,6 +101,7 @@ mod tests {
 
             // alice triggers an epoch
             let id = test_conv.advance_epoch().await.id;
+            bob.transaction.finish().await.unwrap();
 
             // ensure we have observed the epoch change
             let observed_epochs = observer.observed_epochs().await;

--- a/crypto/src/transaction_context/mod.rs
+++ b/crypto/src/transaction_context/mod.rs
@@ -3,9 +3,7 @@
 
 use std::sync::Arc;
 
-#[cfg(feature = "proteus")]
-use async_lock::Mutex;
-use async_lock::{RwLock, RwLockWriteGuardArc};
+use async_lock::{Mutex, RwLock, RwLockWriteGuardArc};
 use core_crypto_keystore::{CryptoKeystoreError, entities::ConsumerData, traits::FetchFromDatabase as _};
 pub use error::{Error, Result};
 use openmls_traits::OpenMlsCryptoProvider as _;
@@ -14,8 +12,8 @@ use wire_e2e_identity::pki_env::PkiEnvironment;
 #[cfg(feature = "proteus")]
 use crate::proteus::ProteusCentral;
 use crate::{
-    ClientId, CoreCrypto, CredentialFindFilters, CredentialRef, KeystoreError, MlsConversation, MlsError, MlsTransport,
-    RecursiveError, Session,
+    ClientId, ConversationId, CoreCrypto, CredentialFindFilters, CredentialRef, KeystoreError, MlsConversation,
+    MlsError, MlsTransport, RecursiveError, Session,
     group_store::GroupStore,
     mls::{self, HasSessionAndCrypto},
     mls_provider::{Database, MlsCryptoProvider},
@@ -51,6 +49,7 @@ enum TransactionContextInner {
         database: Database,
         mls_session: Arc<RwLock<Option<Session<Database>>>>,
         mls_groups: Arc<RwLock<GroupStore<MlsConversation>>>,
+        pending_epoch_changes: Arc<Mutex<Vec<(ConversationId, u64)>>>,
         #[cfg(feature = "proteus")]
         proteus_central: Arc<Mutex<Option<ProteusCentral>>>,
     },
@@ -110,6 +109,7 @@ impl TransactionContext {
                     pki_environment,
                     mls_session: mls_session.clone(),
                     mls_groups,
+                    pending_epoch_changes: Default::default(),
                     #[cfg(feature = "proteus")]
                     proteus_central,
                 }
@@ -213,6 +213,18 @@ impl TransactionContext {
         }
     }
 
+    pub(crate) async fn queue_epoch_changed(&self, conversation_id: ConversationId, epoch: u64) -> Result<()> {
+        match &*self.inner.read().await {
+            TransactionContextInner::Valid {
+                pending_epoch_changes, ..
+            } => {
+                pending_epoch_changes.lock().await.push((conversation_id, epoch));
+                Ok(())
+            }
+            TransactionContextInner::Invalid => Err(Error::InvalidTransactionContext),
+        }
+    }
+
     #[cfg(feature = "proteus")]
     pub(crate) async fn proteus_central(&self) -> Result<Arc<Mutex<Option<ProteusCentral>>>> {
         match &*self.inner.read().await {
@@ -226,15 +238,33 @@ impl TransactionContext {
     /// something is called from this object.
     pub async fn finish(&self) -> Result<()> {
         let mut guard = self.inner.write().await;
-        let TransactionContextInner::Valid { database: keystore, .. } = &*guard else {
+        let TransactionContextInner::Valid {
+            database,
+            pending_epoch_changes,
+            mls_session,
+            ..
+        } = &*guard
+        else {
             return Err(Error::InvalidTransactionContext);
         };
 
-        let commit_result = keystore
+        let commit_result = database
             .commit_transaction()
             .await
             .map_err(KeystoreError::wrap("commiting transaction"))
             .map_err(Into::into);
+
+        if let Some(session) = mls_session.read_arc().await.clone()
+            && commit_result.is_ok()
+        {
+            // We need owned values, so we could just clone the conversation ids, but we don't need the events anymore,
+            // so draining the vector works, too.
+            let mut epoch_changes = pending_epoch_changes.lock().await;
+            let epoch_changes = epoch_changes.drain(..);
+            for (conversation_id, epoch) in epoch_changes {
+                session.notify_epoch_changed(conversation_id, epoch).await;
+            }
+        }
 
         *guard = TransactionContextInner::Invalid;
         commit_result


### PR DESCRIPTION
# What's new in this PR
Instead, use the new transaction context API to queue them. From that queue, they'll emitted only if the transaction is actually committed.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
