### PR TITLE
ci: use chrome headless shell when running ts browser benches

### DIFF
--- a/.github/workflows/benchmark-ts-browser.yml
+++ b/.github/workflows/benchmark-ts-browser.yml
@@ -65,13 +65,20 @@ jobs:
       BENCHMARK_CIPHER_SUITES: ${{ inputs.benchmark_cipher_suites }}
     steps:
       - uses: actions/checkout@v6
-      - uses: wireapp/setup-chrome@master
-        id: setup-chrome
-        with:
-          chrome-version: stable
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Install chrome-headless-shell
+        run: |
+          bun x @puppeteer/browsers install chrome-headless-shell@latest --path $PWD
+          echo "CHROME_PATH=$(echo $PWD/chrome-headless-shell/*/*/chrome-headless-shell)" >> $GITHUB_ENV
+
+      - name: Install chromedriver
+        run: |
+          bun x @puppeteer/browsers install chromedriver@latest --path $PWD
+          echo "CHROMEDRIVER_PATH=$(echo $PWD/chromedriver/*/*/chromedriver)" >> $GITHUB_ENV
 
       - name: download web files
         uses: ./.github/actions/make/ts/browser

--- a/crypto-ffi/bindings/js/packages/browser/benches/wdio.bench.conf.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/wdio.bench.conf.ts
@@ -1,8 +1,36 @@
 import { config as baseConfig } from "../test/wdio.test.conf.ts";
 
+const chromePath = process.env["CHROME_PATH"];
+const chromedriverPath = process.env["CHROMEDRIVER_PATH"];
+
+const withBrowserPaths = (
+    capabilities: WebdriverIO.Capabilities
+): WebdriverIO.Capabilities => {
+    const browserBenchCapability = { ...capabilities };
+
+    if (chromePath !== undefined) {
+        browserBenchCapability["goog:chromeOptions"] = {
+            ...browserBenchCapability["goog:chromeOptions"],
+            binary: chromePath,
+        };
+    }
+
+    if (chromedriverPath !== undefined) {
+        browserBenchCapability["wdio:chromedriverOptions"] = {
+            ...browserBenchCapability["wdio:chromedriverOptions"],
+            binary: chromedriverPath,
+        };
+    }
+
+    return browserBenchCapability;
+};
+
+const capabilities = baseConfig.capabilities.map(withBrowserPaths);
+
 export const config: WebdriverIO.Config = {
     ...baseConfig,
     specs: ["./*.bench.ts"],
+    capabilities,
     mochaOpts: {
         ...baseConfig.mochaOpts,
         timeout: 1_800_000, // 30 min

--- a/crypto-ffi/bindings/js/packages/browser/test/wdio.test.conf.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/wdio.test.conf.ts
@@ -1,6 +1,8 @@
+import type { Capabilities } from "@wdio/types";
+
 const STATIC_SERVER_URL = "http://localhost:3000/";
 
-export const config: WebdriverIO.Config = {
+export const config = {
     //
     // ====================
     // Runner Configuration
@@ -56,8 +58,6 @@ export const config: WebdriverIO.Config = {
         {
             browserName: "chrome", // or "firefox"
             "goog:chromeOptions": { args: ["--headless", "--disable-gpu"] },
-            // @ts-expect-error TS2353: Object literal may only specify known properties, and "goog:loggingPrefs" does
-            // not exist in type RequestedStandaloneCapabilities
             "goog:loggingPrefs": {
                 browser: "ALL",
                 performance: "ALL",
@@ -162,4 +162,9 @@ export const config: WebdriverIO.Config = {
         ui: "bdd",
         timeout: 60000,
     },
+} satisfies Omit<WebdriverIO.Config, "capabilities"> & {
+    capabilities: (WebdriverIO.Capabilities & {
+        // This member doesn't exist on WebdriverIO.Capabilities so we extend that type manually
+        "goog:loggingPrefs": Record<string, Capabilities.LoggingPreferenceType>;
+    })[];
 };


### PR DESCRIPTION
# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
