### PR TITLE
chore: fix rs file discovery

### DIFF
--- a/make/sources.mk
+++ b/make/sources.mk
@@ -15,7 +15,11 @@ WORKSPACE_CARGO_FILES := Cargo.toml Cargo.lock
 CRATE_MANIFESTS := $(addsuffix /Cargo.toml,$(CRATES))
 
 # Enumerate all .rs files in relevant crates
-RUST_RS_FILES := $(shell find $(CRATES) \( -type d \( -name $(BINDINGS_DIR) ./interop/.* \) \) -prune -o \
+RUST_RS_FILES := $(shell find $(CRATES) \
+	\( -type d \( \
+	-name $(BINDINGS_DIR) -o \
+	-name .gradle \
+	\) \) -prune -o \
     -type f -name '*.rs' -print 2>/dev/null | LC_ALL=C sort)
 
 # Files relevant to build interop


### PR DESCRIPTION
The previous wildcard syntax was wrong. We also only care about .gradle folders and it missed an OR.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
