### PR TITLE
ci: use `wasm-pack` to run wasm keystore tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,4 +35,3 @@ rustdoc = ".cargo/rustdoc-wrapper.sh"
 
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", 'getrandom_backend="wasm_js"']
-runner = "wasm-bindgen-test-runner"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,14 +81,8 @@ jobs:
       - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: wasm32-unknown-unknown
-      - uses: wireapp/setup-chrome@master
-        id: setup-chrome
-        with:
-          chrome-version: stable
-      - run: echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-      - name: Install wasm-bindgen-cli
-        uses: ./.github/actions/setup-wasm-bindgen
-      - run: cargo test --locked --target wasm32-unknown-unknown -p core-crypto-keystore
+      - uses: taiki-e/install-action@wasm-pack
+      - run: wasm-pack test --headless --chrome -- ./keystore --locked
 
   keystore-proteus-wasm-test:
     runs-on: ubuntu-latest
@@ -99,14 +93,8 @@ jobs:
       - uses: ./.github/actions/setup-and-cache-rust
         with:
           target: wasm32-unknown-unknown
-      - uses: wireapp/setup-chrome@master
-        id: setup-chrome
-        with:
-          chrome-version: stable
-      - run: echo "CHROME_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
-      - name: Install wasm-bindgen-cli
-        uses: ./.github/actions/setup-wasm-bindgen
-      - run: cargo test --locked --target wasm32-unknown-unknown -p core-crypto-keystore --features proteus-keystore -- proteus
+      - uses: taiki-e/install-action@wasm-pack
+      - run: wasm-pack test --headless --chrome -- ./keystore --locked --features proteus-keystore -- proteus
 
   hack:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -249,11 +249,18 @@ cargo nextest run --features test-all-cipher
 Sometimes for the Keystore it is valuable to run Rust unit/integration tests on the WASM target.
 
 - Ensure you are set up to [build wasm](#wasm)
+- Install `wasm-pack`: `cargo install wasm-pack`.
 
-Then, just use `cargo test`:
+Then, just use `wasm-pack` to run the tests:
 
 ```sh
-cargo test --target wasm32-unknown-unknown -p core-crypto-keystore
+wasm-pack test --headless --chrome -- ./keystore --locked
+```
+
+Run tests containing the word _proteus_, additionally enabling the feature `proteus-keystore`:
+
+```sh
+wasm-pack test --headless --chrome -- ./keystore --locked --features proteus-keystore -- proteus
 ```
 
 Unfortunately it appears that nextest doesn't work well with the wasm runner, so we're stuck with the basic test runner.


### PR DESCRIPTION
# What's new in this PR
`wasm-pack` seems to be actively maintained again and it solves the
problem for us to setup chrome and chromedriver separately.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
