### PR TITLE
feat(keystore): add `Database::try_new_transaction`

### DIFF
--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -264,6 +264,21 @@ impl Database {
         Ok(())
     }
 
+    /// Start a new transaction if no other transaction is currently in progress.
+    ///
+    /// If a transaction is currently in progress, this will produce a `TransactionInProgress` error.
+    pub async fn try_new_immediate_transaction(&self) -> CryptoKeystoreResult<()> {
+        let semaphore =
+            self.transaction_semaphore
+                .try_acquire_arc()
+                .ok_or_else(|| CryptoKeystoreError::TransactionInProgress {
+                    attempted_operation: "create an immediate transaction".into(),
+                })?;
+        let mut transaction_guard = self.transaction.lock().await;
+        *transaction_guard = Some(KeystoreTransaction::new(semaphore).await?);
+        Ok(())
+    }
+
     pub async fn commit_transaction(&self) -> CryptoKeystoreResult<()> {
         let mut transaction_guard = self.transaction.lock().await;
         let Some(transaction) = transaction_guard.as_ref() else {

--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -268,12 +268,10 @@ impl Database {
     ///
     /// If a transaction is currently in progress, this will produce a `TransactionInProgress` error.
     pub async fn try_new_immediate_transaction(&self) -> CryptoKeystoreResult<()> {
-        let semaphore =
-            self.transaction_semaphore
-                .try_acquire_arc()
-                .ok_or_else(|| CryptoKeystoreError::TransactionInProgress {
-                    attempted_operation: "create an immediate transaction".into(),
-                })?;
+        let semaphore = self
+            .transaction_semaphore
+            .try_acquire_arc()
+            .ok_or(CryptoKeystoreError::TransactionInProgress)?;
         let mut transaction_guard = self.transaction.lock().await;
         *transaction_guard = Some(KeystoreTransaction::new(semaphore).await?);
         Ok(())

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -5,8 +5,8 @@ pub enum CryptoKeystoreError {
     KeyReprError(#[from] std::str::Utf8Error),
     #[error("A transaction must be in progress to perform this operation.")]
     MutatingOperationWithoutTransaction,
-    #[error("Cannot perform the operation \"{attempted_operation:?}\" while a transaction is in progress.")]
-    TransactionInProgress { attempted_operation: String },
+    #[error("cannot open a new transaction as there exists another transaction currently in progress")]
+    TransactionInProgress,
     #[error(transparent)]
     TryFromSliceError(#[from] std::array::TryFromSliceError),
     #[error("One of the Keystore locks has been poisoned")]


### PR DESCRIPTION
We have a use case for the PKI environment to get a new transaction without waiting: it's a programming error if they try to mutate the PKI environment during a CC transaction, because the PKI environment needs to open its own transaction.

Without this API that error produces a deadlock. With this API the PKI environment can just return an error.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
