### PR TITLE
ci: setup fd when make is used

### DIFF
--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -34,6 +34,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: setup fd
+      uses: taiki-e/install-action@v2
+      with:
+        tool: fd-find
     - name: Set MAKE
       uses: ./.github/actions/make/set-make-executable
 

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: wireapp/setup-fd@v0.1.0
+      - name: setup fd
+        uses: taiki-e/install-action@v2
+        with:
+          tool: fd-find
       - name: install mdformat
         run: |
           pip3 install mdformat mdformat-gfm mdformat-frontmatter mdformat-footnote mdformat-gfm-alerts mdformat-toc

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -12,5 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: uncenter/setup-taplo@v2
-      - uses: wireapp/setup-fd@v0.1.0
+      - name: setup fd
+        uses: taiki-e/install-action@v2
+        with:
+          tool: fd-find
       - run: fd --glob --hidden '*.toml' -X taplo fmt --check


### PR DESCRIPTION
# What's new in this PR
This PR installs fd in CI which we missed when adding it to the Makefile.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
