### PR TITLE
test(kotlin): wait until event was actually observed before asserting

### DIFF
--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -429,11 +429,16 @@ class MLSTest : HasMockDeliveryService() {
             data class ObserverEvent(val eventEpoch: ULong, val conversationEpoch: ULong)
 
             class Observer : EpochObserver {
-                val observedEvents = emptyList<ObserverEvent>().toMutableList()
+                val observedEvents = emptyList<CompletableDeferred<ObserverEvent>>().toMutableList()
+
+                fun expectEvent(): CompletableDeferred<ObserverEvent> =
+                    CompletableDeferred<ObserverEvent>().also { observedEvents.add(it) }
 
                 override suspend fun epochChanged(conversationId: ConversationId, epoch: ULong) {
+                    val deferredEvent = observedEvents.firstOrNull { !it.isCompleted } ?: expectEvent()
                     val conversationEpoch = alice.conversationEpoch(conversationId)
-                    observedEvents.add(ObserverEvent(epoch, conversationEpoch))
+                    val event = ObserverEvent(epoch, conversationEpoch)
+                    deferredEvent.complete(event)
                 }
             }
 
@@ -444,7 +449,9 @@ class MLSTest : HasMockDeliveryService() {
 
             alice.registerEpochObserver(scope, aliceObserver)
 
+            val expectedEvent = aliceObserver.expectEvent()
             alice.transaction { it.updateKeyingMaterial(id) }
+            val observedEvent = expectedEvent.await()
             val laterEpoch = alice.conversationEpoch(id)
 
             assertEquals(initialEpoch + 1U, laterEpoch)
@@ -454,9 +461,7 @@ class MLSTest : HasMockDeliveryService() {
                 "we triggered exactly 1 epoch change and must have observed that"
             )
             assertTrue(
-                aliceObserver.observedEvents.all {
-                    it.eventEpoch == it.conversationEpoch && it.eventEpoch == laterEpoch
-                },
+                observedEvent.eventEpoch == observedEvent.conversationEpoch && observedEvent.eventEpoch == laterEpoch,
                 "event epoch must equal the epoch read during the event"
             )
         }


### PR DESCRIPTION
We had assumed that 705e3df6aa2861c78fbf5b870e3aebeb24680160  would make 5eb7d8c08b64073835a09538fafb6483ec050577 unnecessary, but the test is still flaky. This re-implements waiting for the event observation.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
