### PR TITLE
feat: expose adding trust anchor / intermediate certificates on the FFI pki env

### DIFF
--- a/crypto-ffi/bindings/js/packages/browser/test/e2ei.test.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/e2ei.test.ts
@@ -3,6 +3,18 @@ import { setup, teardown } from "./utils";
 import { afterEach, beforeEach, describe } from "mocha";
 import { E2eiConversationState } from "@wireapp/core-crypto/browser";
 
+const TEST_CA_DER_BASE64 = `
+MIIBrTCCAVOgAwIBAgIUTZQSLl3eOORQ+adTBaACtDinzVIwCgYIKoZIzj0EAwIwIzEhMB8G
+A1UEAwwYQ29yZSBDcnlwdG8gVGVzdCBSb290IENBMCAXDTI2MDUxODExMzcxNFoYDzIxMjYw
+NDI0MTEzNzE0WjAjMSEwHwYDVQQDDBhDb3JlIENyeXB0byBUZXN0IFJvb3QgQ0EwWTATBgcq
+hkjOPQIBBggqhkjOPQMBBwNCAASepKWhYSdxi9vctOj+3iksMZqCYv94ijB7KkHwvaOhsByE
+tzGoCRVuw12fzZ7C5tDChISJDoDuLkMVF17n8IoYo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4G
+A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUcTTkAA9iiyLL9K7ZoQ/KowFwjZ8wHwYDVR0jBBgw
+FoAUcTTkAA9iiyLL9K7ZoQ/KowFwjZ8wCgYIKoZIzj0EAwIDSAAwRQIgGvcMi47MTKh6F4uz
+ppJsiJ+R0Mj4ato4FPg90nm0OtACIQCAIjV4mlXh8Gp2RRSlwuA894+NhyztLPU+vErHy/0I
+uA==
+`.replace(/\s/g, "");
+
 beforeEach(async () => {
     await setup();
 });
@@ -73,6 +85,50 @@ describe("PKI environment", () => {
             return (await cc.getPkiEnvironment()) != undefined;
         });
         await expect(success).toBe(true);
+    });
+
+    it("should add a trust anchor certificate", async () => {
+        const error = await browser.execute(async (certBase64) => {
+            const certDer = Uint8Array.from(atob(certBase64), (char) =>
+                char.charCodeAt(0)
+            );
+            const database = await window.helpers.newDatabase();
+            const pkiEnvironment = await window.ccModule.PkiEnvironment.create(
+                window.pkiEnvironmentHooks,
+                database
+            );
+
+            try {
+                await pkiEnvironment.addTrustAnchor(certDer);
+                return undefined;
+            } catch (error) {
+                return error instanceof Error ? error.message : String(error);
+            }
+        }, TEST_CA_DER_BASE64);
+
+        await expect(error).toBe(undefined);
+    });
+
+    it("should add an intermediate certificate", async () => {
+        const error = await browser.execute(async (certBase64) => {
+            const certDer = Uint8Array.from(atob(certBase64), (char) =>
+                char.charCodeAt(0)
+            );
+            const database = await window.helpers.newDatabase();
+            const pkiEnvironment = await window.ccModule.PkiEnvironment.create(
+                window.pkiEnvironmentHooks,
+                database
+            );
+
+            try {
+                await pkiEnvironment.addIntermediateCert(certDer);
+                return undefined;
+            } catch (error) {
+                return error instanceof Error ? error.message : String(error);
+            }
+        }, TEST_CA_DER_BASE64);
+
+        await expect(error).toBe(undefined);
     });
 });
 

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
@@ -5,12 +5,27 @@ package com.wire.crypto
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import testutils.*
-import java.nio.file.Files
-import kotlin.test.BeforeTest
-import kotlin.test.Ignore
+import java.util.Base64
 import kotlin.test.Test
+import kotlin.test.fail
 
 internal class E2EITest {
+    companion object {
+        private val testCaDer: ByteArray = Base64.getMimeDecoder().decode(
+            """
+            MIIBrTCCAVOgAwIBAgIUTZQSLl3eOORQ+adTBaACtDinzVIwCgYIKoZIzj0EAwIwIzEhMB8G
+            A1UEAwwYQ29yZSBDcnlwdG8gVGVzdCBSb290IENBMCAXDTI2MDUxODExMzcxNFoYDzIxMjYw
+            NDI0MTEzNzE0WjAjMSEwHwYDVQQDDBhDb3JlIENyeXB0byBUZXN0IFJvb3QgQ0EwWTATBgcq
+            hkjOPQIBBggqhkjOPQMBBwNCAASepKWhYSdxi9vctOj+3iksMZqCYv94ijB7KkHwvaOhsByE
+            tzGoCRVuw12fzZ7C5tDChISJDoDuLkMVF17n8IoYo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4G
+            A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUcTTkAA9iiyLL9K7ZoQ/KowFwjZ8wHwYDVR0jBBgw
+            FoAUcTTkAA9iiyLL9K7ZoQ/KowFwjZ8wCgYIKoZIzj0EAwIDSAAwRQIgGvcMi47MTKh6F4uz
+            ppJsiJ+R0Mj4ato4FPg90nm0OtACIQCAIjV4mlXh8Gp2RRSlwuA894+NhyztLPU+vErHy/0I
+            uA==
+            """.trimIndent()
+        )
+    }
+
     @Test
     fun testSetPkiEnvironment() = runTest {
         val hooks = MockPkiEnvironmentHooks()
@@ -21,6 +36,32 @@ internal class E2EITest {
         cc.setPkiEnvironment(pkiEnv)
         val pkiEnv2 = cc.getPkiEnvironment()
         assert(pkiEnv2 != null)
+    }
+
+    @Test
+    fun testAddTrustAnchor() = runTest {
+        val hooks = MockPkiEnvironmentHooks()
+        val db = newDatabase()
+        val pkiEnv = PkiEnvironment.new(hooks, db)
+
+        try {
+            pkiEnv.addTrustAnchor(testCaDer)
+        } catch (exception: Exception) {
+            fail("Expected addTrustAnchor not to throw, but it threw: ${exception.message}")
+        }
+    }
+
+    @Test
+    fun testAddIntermediateCert() = runTest {
+        val hooks = MockPkiEnvironmentHooks()
+        val db = newDatabase()
+        val pkiEnv = PkiEnvironment.new(hooks, db)
+
+        try {
+            pkiEnv.addIntermediateCert(testCaDer)
+        } catch (exception: Exception) {
+            fail("Expected addIntermediateCert not to throw, but it threw: ${exception.message}")
+        }
     }
 
     @Test

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -7,6 +7,20 @@ import XCTest
 // swiftlint:disable:next type_body_length
 final class WireCoreCryptoTests: XCTestCase {
     var mockMlsTransport: MockMlsTransport = .init()
+    private static let testCaDer = Data(
+        base64Encoded: """
+            MIIBrTCCAVOgAwIBAgIUTZQSLl3eOORQ+adTBaACtDinzVIwCgYIKoZIzj0EAwIwIzEhMB8G
+            A1UEAwwYQ29yZSBDcnlwdG8gVGVzdCBSb290IENBMCAXDTI2MDUxODExMzcxNFoYDzIxMjYw
+            NDI0MTEzNzE0WjAjMSEwHwYDVQQDDBhDb3JlIENyeXB0byBUZXN0IFJvb3QgQ0EwWTATBgcq
+            hkjOPQIBBggqhkjOPQMBBwNCAASepKWhYSdxi9vctOj+3iksMZqCYv94ijB7KkHwvaOhsByE
+            tzGoCRVuw12fzZ7C5tDChISJDoDuLkMVF17n8IoYo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4G
+            A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUcTTkAA9iiyLL9K7ZoQ/KowFwjZ8wHwYDVR0jBBgw
+            FoAUcTTkAA9iiyLL9K7ZoQ/KowFwjZ8wCgYIKoZIzj0EAwIDSAAwRQIgGvcMi47MTKh6F4uz
+            ppJsiJ+R0Mj4ato4FPg90nm0OtACIQCAIjV4mlXh8Gp2RRSlwuA894+NhyztLPU+vErHy/0I
+            uA==
+            """,
+        options: .ignoreUnknownCharacters
+    )!
 
     override func setUpWithError() throws {
         mockMlsTransport = MockMlsTransport()
@@ -862,6 +876,38 @@ final class WireCoreCryptoTests: XCTestCase {
         try await coreCrypto.setPkiEnvironment(pkiEnvironment: nil)
         let pkiEnvironment3 = await coreCrypto.getPkiEnvironment()
         XCTAssertNil(pkiEnvironment3)
+    }
+
+    func testCanAddTrustAnchor() async throws {
+        let root = FileManager.default.temporaryDirectory.appending(path: "mls")
+        let keystore = root.appending(path: "pki-trust-anchor-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let database = try await Database.open(location: keystore.path, key: genDatabaseKey())
+
+        let pkiEnvironment = try await PkiEnvironment(
+            hooks: MockPkiEnvironmentHooks(), database: database)
+
+        do {
+            try await pkiEnvironment.addTrustAnchor(certDer: Self.testCaDer)
+        } catch {
+            XCTFail("Expected addTrustAnchor not to throw, but it threw: \(error)")
+        }
+    }
+
+    func testCanAddIntermediateCert() async throws {
+        let root = FileManager.default.temporaryDirectory.appending(path: "mls")
+        let keystore = root.appending(path: "pki-intermediate-cert-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let database = try await Database.open(location: keystore.path, key: genDatabaseKey())
+
+        let pkiEnvironment = try await PkiEnvironment(
+            hooks: MockPkiEnvironmentHooks(), database: database)
+
+        do {
+            try await pkiEnvironment.addIntermediateCert(certDer: Self.testCaDer)
+        } catch {
+            XCTFail("Expected addIntermediateCert not to throw, but it threw: \(error)")
+        }
     }
 
     func testCanInstantiateX509CredentialAcquisition() async throws {

--- a/crypto-ffi/src/pki_env.rs
+++ b/crypto-ffi/src/pki_env.rs
@@ -1,8 +1,9 @@
 use std::{fmt, sync::Arc};
 
 use wire_e2e_identity::pki_env;
+use x509_cert::der::Decode as _;
 
-use crate::{CoreCryptoFfi, CoreCryptoResult, Database};
+use crate::{CoreCryptoError, CoreCryptoFfi, CoreCryptoResult, Database};
 
 /// HttpMethod used for PKI hooks.
 #[derive(uniffi::Enum)]
@@ -244,6 +245,26 @@ impl PkiEnvironment {
         let shim = Arc::new(PkiEnvironmentHooksShim::new(hooks));
         let pki_env = wire_e2e_identity::pki_env::PkiEnvironment::new(shim, database.as_ref().clone().into()).await?;
         Ok(Self(Arc::new(pki_env)))
+    }
+}
+
+#[uniffi::export]
+impl PkiEnvironment {
+    /// Add a DER-encoded certificate as a trust anchor.
+    ///
+    /// NOTE: currently we only support storing a single trust anchor, calling this method multiple
+    /// times will overwrite any previously added trust anchor.
+    pub async fn add_trust_anchor(&self, cert_der: &[u8]) -> CoreCryptoResult<()> {
+        let cert = x509_cert::Certificate::from_der(cert_der).map_err(CoreCryptoError::generic())?;
+        self.0.add_trust_anchor(cert).await?;
+        Ok(())
+    }
+
+    /// Add a DER-encoded certificate as an intermediate certificate.
+    pub async fn add_intermediate_cert(&self, cert_der: &[u8]) -> CoreCryptoResult<()> {
+        let cert = x509_cert::Certificate::from_der(cert_der).map_err(CoreCryptoError::generic())?;
+        self.0.add_intermediate_cert(cert).await?;
+        Ok(())
     }
 }
 

--- a/crypto/src/test_utils/x509.rs
+++ b/crypto/src/test_utils/x509.rs
@@ -275,12 +275,12 @@ impl X509TestChain {
 
         let env = context.pki_environment().await.unwrap();
 
-        env.add_trust_anchor("root", self.trust_anchor.certificate.clone())
+        env.add_trust_anchor(self.trust_anchor.certificate.clone())
             .await
             .expect("can add trust anchor");
 
-        for (idx, intermediate) in self.intermediates.iter().enumerate() {
-            env.add_intermediate_cert(&format!("intermediate {idx}"), intermediate.certificate.clone())
+        for intermediate in &self.intermediates {
+            env.add_intermediate_cert(intermediate.certificate.clone())
                 .await
                 .expect("can add intermediate cert");
         }

--- a/e2e-identity/src/pki_env/mod.rs
+++ b/e2e-identity/src/pki_env/mod.rs
@@ -189,7 +189,7 @@ impl PkiEnvironment {
     ///
     /// Adding a trust anchor will replace any existing trust anchor. This limitation
     /// will be relaxed in the future.
-    pub async fn add_trust_anchor(&self, name: &str, cert: Certificate) -> Result<()> {
+    pub async fn add_trust_anchor(&self, cert: Certificate) -> Result<()> {
         // Validate it (expiration & signature only)
         self.rjt_pki_env.lock().await.validate_trust_anchor_cert(&cert)?;
 
@@ -204,7 +204,7 @@ impl PkiEnvironment {
 
         let mut trust_anchors = TaSource::new();
         trust_anchors.push(certval::CertFile {
-            filename: name.to_owned(),
+            filename: "".to_string(),
             bytes: cert.to_der()?,
         });
         trust_anchors.initialize().map_err(Error::Certval)?;
@@ -222,7 +222,7 @@ impl PkiEnvironment {
     ///
     /// CRL (Certificate Revocation List) distribution points are extracted from the certificate and
     /// an attempt is made to fetch a CRL from each one.
-    pub async fn add_intermediate_cert(&self, name: &str, cert: Certificate) -> Result<()> {
+    pub async fn add_intermediate_cert(&self, cert: Certificate) -> Result<()> {
         // Save cert's DER representation to the database
         let (ski, aki) = RjtPkiEnvironment::extract_ski_aki_from_cert(&cert)?;
         let ski_aki_pair = format!("{ski}:{}", aki.unwrap_or_default());
@@ -251,7 +251,7 @@ impl PkiEnvironment {
         let cps = CertificationPathSettings::new();
         let mut cert_source = CertSource::new();
         cert_source.push(certval::CertFile {
-            filename: name.to_owned(),
+            filename: "".to_string(),
             bytes: cert.to_der()?,
         });
 

--- a/e2e-identity/tests/e2e.rs
+++ b/e2e-identity/tests/e2e.rs
@@ -230,7 +230,7 @@ async fn prepare_pki_env_and_config(
         .unwrap();
 
     let pki_env = PkiEnvironment::new(hooks, db).await.unwrap();
-    pki_env.add_trust_anchor("step-ca-root", acme_cert).await.unwrap();
+    pki_env.add_trust_anchor(acme_cert).await.unwrap();
     (pki_env, config)
 }
 


### PR DESCRIPTION
# What's new in this PR

Expose adding trust anchor / intermediate certificates on the FFI pki env

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
