### PR TITLE
refactor(ffi): emit `GroupInfo` as bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
   Affected platforms: android, ios, web
 
+- `GroupInfoBundle.payload` now contains a byte array instead of a class instance.
+
 - Added `Welcome::serialize()`
 
   We had test functions which required the serialized bytes given a `Welcome` instance. So we added the ability to

--- a/cc-book/src/cc10/migration-guide.md
+++ b/cc-book/src/cc10/migration-guide.md
@@ -79,3 +79,5 @@ operations is delegated to the consumer.
 
 1. removed `CoreCryptoContext.proteusReloadSessions()`. Proteus sessions are now loaded on demand by the new per-session
    cache, so explicit reloads are no longer needed. Delete any call sites.
+
+1. `GroupInfoBundle.payload` now contains a byte array instead of a class instance.

--- a/crypto-ffi/src/bundles/commit.rs
+++ b/crypto-ffi/src/bundles/commit.rs
@@ -24,7 +24,7 @@ impl TryFrom<MlsCommitBundle> for CommitBundle {
         let encrypted_message = msg.encrypted_message.clone();
         let (welcome, commit, group_info) = msg.to_bytes_triple()?;
         let welcome = welcome.map(Into::into).map(Arc::new);
-        let group_info = group_info.try_into()?;
+        let group_info = group_info.into();
         Ok(Self {
             welcome,
             commit,

--- a/crypto-ffi/src/bundles/group_info.rs
+++ b/crypto-ffi/src/bundles/group_info.rs
@@ -1,9 +1,4 @@
-use std::sync::Arc;
-
-use core_crypto::{MlsGroupInfoBundle, MlsMessageIn, MlsMessageInBody};
-use tls_codec::Deserialize;
-
-use crate::{CoreCryptoError, CoreCryptoResult, core_crypto_context::mls::GroupInfo};
+use core_crypto::MlsGroupInfoBundle;
 
 /// How a `GroupInfo` is encrypted in a commit bundle.
 #[derive(Debug, Clone, Copy, uniffi::Enum)]
@@ -76,29 +71,17 @@ pub struct GroupInfoBundle {
     /// What kind of ratchet tree is used.
     pub ratchet_tree_type: MlsRatchetTreeType,
     /// The group info payload.
-    pub payload: Arc<GroupInfo>,
+    pub payload: Vec<u8>,
 }
 
-impl TryFrom<MlsGroupInfoBundle> for GroupInfoBundle {
-    type Error = CoreCryptoError;
-
-    fn try_from(group_info_bundle: MlsGroupInfoBundle) -> CoreCryptoResult<Self> {
+impl From<MlsGroupInfoBundle> for GroupInfoBundle {
+    fn from(group_info_bundle: MlsGroupInfoBundle) -> Self {
         // single variant => no match stmt necessary
         let core_crypto::GroupInfoPayload::Plaintext(payload) = group_info_bundle.payload;
-        let message_in = MlsMessageIn::tls_deserialize_exact(payload)
-            .map_err(CoreCryptoError::generic())?
-            .extract();
-        let MlsMessageInBody::GroupInfo(group_info) = message_in else {
-            return Err(CoreCryptoError::ad_hoc(
-                "group info bundle contained a non-GroupInfo body",
-            ));
-        };
-        let payload = Arc::new(group_info.into());
-
-        Ok(Self {
+        Self {
             encryption_type: group_info_bundle.encryption_type.into(),
             ratchet_tree_type: group_info_bundle.ratchet_tree_type.into(),
             payload,
-        })
+        }
     }
 }


### PR DESCRIPTION
We'd previously been emitting the typed struct we use for inbound data, but that had two problems:

1. we were using it in an outbound context and clients only care about the bytes
2. the inbound typed struct didn't implement `Serialize`

It's simpler if we just emit bytes in the outbound direction.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
