### PR TITLE
test(kotlin): simplify kotlin test helpers

### DIFF
--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/AddUser.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/AddUser.kt
@@ -35,34 +35,13 @@ open class AddUser {
     @Setup(Level.Invocation)
     fun setup() {
         runBlocking {
-            val mockTransportProvider = MockMlsTransportSuccessProvider()
-            val aliceId = genClientId()
-            conversationId = genConversationId()
-            aliceCc = initCc()
-            aliceCc.transaction { ctx ->
-                ctx.mlsInit(aliceId, mockTransportProvider)
-                val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), aliceId))
-                ctx.createConversation(conversationId, credentialRef, null)
-            }
+            aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            conversationId = createConversation(aliceCc)
 
             keyPackages = buildList {
                 repeat(userCount) {
-                    val bobId = genClientId()
-                    val bobCc = initCc()
-
-                    val kp = bobCc.transaction { ctx ->
-                        ctx.mlsInit(bobId, mockTransportProvider)
-
-                        val credentialRef = ctx.addCredential(
-                            Credential.basic(
-                                CipherSuite.valueOf(cipherSuite),
-                                bobId
-                            )
-                        )
-
-                        ctx.generateKeyPackage(credentialRef)
-                    }
-
+                    val bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+                    val kp = generateKeyPackage(bobCc)
                     this.add(kp)
                 }
             }

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/CreateMessage.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/CreateMessage.kt
@@ -37,14 +37,8 @@ open class CreateMessage {
 
     @Setup(Level.Iteration)
     fun setup() = runBlocking {
-        val aliceId = genClientId()
-        conversationId = genConversationId()
-        cc = initCc()
-        cc.transaction { ctx ->
-            ctx.mlsInit(aliceId, MockMlsTransportSuccessProvider())
-            val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), aliceId))
-            ctx.createConversation(conversationId, credentialRef, null)
-        }
+        cc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+        conversationId = createConversation(cc)
         messages = List(messageCount) {
             ByteArray(messageSize) { 'A'.code.toByte() }
         }

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/JoinGroup.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/JoinGroup.kt
@@ -33,27 +33,15 @@ open class JoinGroup {
     @Setup(Level.Invocation)
     fun setup() {
         runBlocking {
-            val mockTransportProvider = MockMlsTransportSuccessProvider()
-            val aliceId = genClientId()
-            conversationId = genConversationId()
-            val aliceCc = initCc()
-            aliceCc.transaction { ctx ->
-                ctx.mlsInit(aliceId, mockTransportProvider)
-                val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), aliceId))
-                ctx.createConversation(conversationId, credentialRef, null)
-            }
+            val aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            conversationId = createConversation(aliceCc)
 
             val keyPackages = mutableListOf<KeyPackage>()
 
             if (userCount > 1) {
                 repeat(userCount) {
-                    val bobId = genClientId()
-                    val bobCc = initCc()
-                    val kp = bobCc.transaction { ctx ->
-                        ctx.mlsInit(bobId, mockTransportProvider)
-                        val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), bobId))
-                        ctx.generateKeyPackage(credentialRef)
-                    }
+                    val bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+                    val kp = generateKeyPackage(bobCc)
                     keyPackages.add(kp)
                 }
                 aliceCc.transaction {
@@ -61,18 +49,13 @@ open class JoinGroup {
                 }
             }
 
-            val charlieId = genClientId()
-            charlieCc = initCc()
-            val kp = charlieCc.transaction { ctx ->
-                ctx.mlsInit(charlieId, mockTransportProvider)
-                val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), charlieId))
-                ctx.generateKeyPackage(credentialRef)
-            }
+            charlieCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            val kp = generateKeyPackage(charlieCc)
 
             aliceCc.transaction {
                 it.addClientsToConversation(conversationId, listOf(kp))
             }
-            welcome = mockTransportProvider.getLatestWelcome()
+            welcome = MockMlsTransportSuccessProvider.getInstance().getLatestWelcome()
         }
     }
 

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/ProcessMessage.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/ProcessMessage.kt
@@ -39,32 +39,11 @@ open class ProcessMessage {
 
     @Setup(Level.Invocation)
     fun setup() = runBlocking {
-        val aliceId = genClientId()
-        conversationId = genConversationId()
-        val aliceCc = initCc()
-        val mockTransportProvider = MockMlsTransportSuccessProvider()
-        aliceCc.transaction { ctx ->
-            ctx.mlsInit(aliceId, mockTransportProvider)
-            val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), aliceId))
-            ctx.createConversation(conversationId, credentialRef, null)
-        }
+        val aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+        conversationId = createConversation(aliceCc)
 
-        val bobId = genClientId()
-        bobCc = initCc()
-        val kp = bobCc.transaction { ctx ->
-            ctx.mlsInit(bobId, mockTransportProvider)
-            val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), bobId))
-            ctx.generateKeyPackage(credentialRef)
-        }
-
-        aliceCc.transaction {
-            it.addClientsToConversation(conversationId, keyPackages = listOf(kp))
-        }
-
-        val welcome = mockTransportProvider.getLatestWelcome()
-        bobCc.transaction {
-            it.processWelcomeMessage(welcome)
-        }
+        bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+        invite(aliceCc, bobCc, conversationId)
 
         val messages = List(messageCount) {
             ByteArray(messageSize) { 'A'.code.toByte() }

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/RemoveUser.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/RemoveUser.kt
@@ -35,26 +35,15 @@ open class RemoveUser {
     @Setup(Level.Invocation)
     fun setup() {
         runBlocking {
-            val mockTransportProvider = MockMlsTransportSuccessProvider()
-            val aliceId = genClientId()
-            conversationId = genConversationId()
-            aliceCc = initCc()
-            aliceCc.transaction { ctx ->
-                ctx.mlsInit(aliceId, mockTransportProvider)
-                val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), aliceId))
-                ctx.createConversation(conversationId, credentialRef, null)
-            }
+            aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            conversationId = createConversation(aliceCc)
 
             val keyPackages = mutableListOf<KeyPackage>()
             clientIdsToRemove = buildList {
                 repeat(userCount) {
                     val bobId = genClientId()
-                    val bobCc = initCc()
-                    val kp = bobCc.transaction { ctx ->
-                        ctx.mlsInit(bobId, mockTransportProvider)
-                        val credentialRef = ctx.addCredential(Credential.basic(CipherSuite.valueOf(cipherSuite), bobId))
-                        ctx.generateKeyPackage(credentialRef)
-                    }
+                    val bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite), bobId))
+                    val kp = generateKeyPackage(bobCc)
                     keyPackages.add(kp)
                     this.add(bobId)
                 }

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
@@ -10,24 +10,11 @@ import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 
-internal class E2EITest : HasMockDeliveryService() {
-    companion object {
-        private val id: ConversationId = genConversationId()
-    }
-
-    @BeforeTest
-    fun setup() {
-        setupMocks()
-    }
-
+internal class E2EITest {
     @Test
     fun testSetPkiEnvironment() = runTest {
-        val aliceId = genClientId()
-        val root = Files.createTempDirectory("mls").toFile()
-        val path = root.resolve("pki-$aliceId")
-        val key = genDatabaseKey()
         val hooks = MockPkiEnvironmentHooks()
-        val db = Database.open(path.absolutePath, key)
+        val db = newDatabase()
         val pkiEnv = PkiEnvironment.new(hooks, db)
 
         val cc = CoreCrypto(db)
@@ -38,11 +25,8 @@ internal class E2EITest : HasMockDeliveryService() {
 
     @Test
     fun testInstantiateX509CredentialAcquisition() = runTest {
-        val root = Files.createTempDirectory("mls").toFile()
-        val path = root.resolve("pki-acquisition")
-        val key = genDatabaseKey()
         val hooks = MockPkiEnvironmentHooks()
-        val db = Database.open(path.absolutePath, key)
+        val db = newDatabase()
         val pkiEnv = PkiEnvironment.new(hooks, db)
         val clientId =
             ClientId("LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com".encodeToByteArray())
@@ -68,24 +52,20 @@ internal class E2EITest : HasMockDeliveryService() {
     @Test
     fun conversation_should_be_not_verified_when_at_least_1_of_the_members_uses_a_Basic_credential() =
         runTest {
-            val (alice, bob) = newClients(genClientId(), genClientId())
+            val alice = ccInit()
+            val bob = ccInit()
 
-            bob.transaction { ctx -> ctx.createConversationShort(id) }
-
-            val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1u).first() }
-            bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-            val welcome = mockDeliveryService.getLatestWelcome()
-            val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
-
-            assertThat(alice.transaction { ctx -> ctx.e2eiConversationState(groupId) })
+            val conversationId = createConversation(bob)
+            invite(bob, alice, conversationId)
+            assertThat(alice.transaction { ctx -> ctx.e2eiConversationState(conversationId) })
                 .isEqualTo(E2eiConversationState.NOT_ENABLED)
-            assertThat(bob.transaction { ctx -> ctx.e2eiConversationState(groupId) })
+            assertThat(bob.transaction { ctx -> ctx.e2eiConversationState(conversationId) })
                 .isEqualTo(E2eiConversationState.NOT_ENABLED)
         }
 
     @Test
     fun e2ei_should_not_be_enabled_for_a_Basic_Credential() = runTest {
-        val (alice) = newClients(genClientId())
+        val alice = ccInit()
         assertThat(alice.transaction { ctx -> ctx.e2eiIsEnabled(CIPHERSUITE_DEFAULT) }).isFalse()
     }
 }

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/ExternalSenderTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/ExternalSenderTest.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import testutils.*
 import kotlin.test.*
 
-class ExternalSenderTest : HasMockDeliveryService() {
+class ExternalSenderTest {
     companion object {
         private val id: ConversationId = genConversationId()
 
@@ -17,15 +17,10 @@ class ExternalSenderTest : HasMockDeliveryService() {
             """{"kty":"OKP","crv":"Ed25519","x":"SN_PbU3M_gqC4ztSO0uagUZVabiXU1KVdRJF1ciRnnM"}""".toByteArray()
     }
 
-    @BeforeTest
-    fun setup() {
-        setupMocks()
-    }
-
     @Test
     fun parseJwk_produces_a_sender_usable_in_createConversation() = runTest {
         val externalSender = ExternalSender.parseJwk(FIXTURE_JWK)
-        val (alice) = newClients(genClientId())
+        val alice = ccInit()
 
         val retrievedKey = alice.transaction { ctx ->
             val credentials = ctx.findCredentials(

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -62,11 +62,12 @@ class MLSTest {
         val cc = ccInit()
 
         val expectedException = IllegalStateException("Expected Exception")
-
+        val conversationId = genConversationId()
         val actualException =
             assertFailsWith<RuntimeException> {
                 cc.transaction<Unit> { ctx ->
-                    ctx.createConversationShort(id)
+                    val credentialRef = ctx.getCredentials().last()
+                    ctx.createConversation(conversationId, credentialRef)
                     throw expectedException
                 }
             }
@@ -78,7 +79,10 @@ class MLSTest {
 
         // This would fail with a "Conversation already exists" exception, if the above
         // transaction hadn't been rolled back.
-        cc.transaction { ctx -> ctx.createConversationShort(id) }
+        cc.transaction { ctx ->
+            val credentialRef = ctx.getCredentials().last()
+                    ctx.createConversation(conversationId, credentialRef)
+        }
     }
 
     @Suppress("InjectDispatcher")
@@ -120,7 +124,10 @@ class MLSTest {
         val alice = ccInit()
         val conversationId = createConversation(alice)
         val expectedException = assertFailsWith<CoreCryptoException.Mls> {
-            alice.transaction { ctx -> ctx.createConversationShort(conversationId) }
+            alice.transaction { ctx ->
+                val credentialRef = ctx.`getCredentials`().last()
+                ctx.createConversation(conversationId, credentialRef)
+            }
         }
         assertIs<MlsException.ConversationAlreadyExists>(expectedException.mlsError)
     }
@@ -135,9 +142,13 @@ class MLSTest {
     @Test
     fun conversationExists_should_return_true() = runTest {
         val alice = ccInit()
-        assertThat(alice.transaction { ctx -> ctx.conversationExists(id) }).isFalse()
-        alice.transaction { ctx -> ctx.createConversationShort(id) }
-        assertThat(alice.transaction { ctx -> ctx.conversationExists(id) }).isTrue()
+        val conversationId = genConversationId()
+        assertThat(alice.transaction { ctx -> ctx.conversationExists(conversationId) }).isFalse()
+        alice.transaction { ctx ->
+            val credentialRef = ctx.getCredentials().last()
+            ctx.createConversation(conversationId, credentialRef)
+        }
+        assertThat(alice.transaction { ctx -> ctx.conversationExists(conversationId) }).isTrue()
     }
 
     @Test

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -13,19 +13,10 @@ import kotlin.collections.toList
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
-class MLSTest : HasMockDeliveryService() {
-    companion object {
-        private val id: ConversationId = genConversationId()
-    }
-
-    @BeforeTest
-    fun setup() {
-        setupMocks()
-    }
-
+class MLSTest {
     @Test
     fun set_client_data_persists() = runTest {
-        val cc = initCc()
+        val cc = CoreCrypto(newDatabase())
 
         val data = "my message processing checkpoint".toByteArray()
 
@@ -39,14 +30,14 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun interaction_with_invalid_context_throws_error() = runTest {
-        val cc = initCc()
+        val cc = CoreCrypto(newDatabase())
         var context: CoreCryptoContext? = null
 
         cc.transaction { ctx -> context = ctx }
 
         val expectedException =
             assertFailsWith<CoreCryptoException.Mls> {
-                context!!.mlsInitShort(genClientId())
+                context!!.mlsInit(genClientId(), MockMlsTransportSuccessProvider.getInstance())
             }
 
         assertIs<MlsException.Other>(expectedException.mlsError)
@@ -54,7 +45,7 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun error_is_propagated_by_transaction() = runTest {
-        val cc = initCc()
+        val cc = CoreCrypto(newDatabase())
         val expectedException = RuntimeException("Expected Exception")
 
         val actualException =
@@ -68,7 +59,7 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun transaction_rolls_back_on_error() = runTest {
-        val (cc) = newClients(genClientId())
+        val cc = ccInit()
 
         val expectedException = IllegalStateException("Expected Exception")
 
@@ -94,7 +85,7 @@ class MLSTest : HasMockDeliveryService() {
     @Test
     fun parallel_transactions_are_performed_serially() = runTest {
         withContext(Dispatchers.Default) {
-            val (alice) = newClients(genClientId())
+            val alice = ccInit()
             val jobs: MutableList<Job> = mutableListOf()
             val token = "t"
             val transactionCount = 3
@@ -126,10 +117,10 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun errorTypeMapping_should_work() = runTest {
-        val (alice) = newClients(genClientId())
-        alice.transaction { ctx -> ctx.createConversationShort(id) }
+        val alice = ccInit()
+        val conversationId = createConversation(alice)
         val expectedException = assertFailsWith<CoreCryptoException.Mls> {
-            alice.transaction { ctx -> ctx.createConversationShort(id) }
+            alice.transaction { ctx -> ctx.createConversationShort(conversationId) }
         }
         assertIs<MlsException.ConversationAlreadyExists>(expectedException.mlsError)
     }
@@ -137,13 +128,13 @@ class MLSTest : HasMockDeliveryService() {
     @Test
     fun findCredentials_should_return_non_empty_result() = runTest {
         val clientId = genClientId()
-        val (alice) = newClients(clientId)
+        val alice = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, clientId))
         assertThat(alice.transaction { it.findCredentials(clientId, null, null, null, null) }).isNotEmpty()
     }
 
     @Test
     fun conversationExists_should_return_true() = runTest {
-        val (alice) = newClients(genClientId())
+        val alice = ccInit()
         assertThat(alice.transaction { ctx -> ctx.conversationExists(id) }).isFalse()
         alice.transaction { ctx -> ctx.createConversationShort(id) }
         assertThat(alice.transaction { ctx -> ctx.conversationExists(id) }).isTrue()
@@ -151,7 +142,7 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun calling_generateKeyPackages_should_return_expected_number() = runTest {
-        val (alice) = newClients(genClientId())
+        val alice = ccInit()
 
         // by default, no key packages are generated
         assertThat(
@@ -169,23 +160,20 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun given_new_conversation_when_calling_conversationEpoch_should_return_epoch_0() = runTest {
-        val (alice) = newClients(genClientId())
-        alice.transaction { ctx -> ctx.createConversationShort(id) }
+        val alice = ccInit()
+        val id = createConversation(alice)
         assertThat(alice.transaction { ctx -> ctx.conversationEpoch(id) }).isEqualTo(0UL)
     }
 
     @Test
     fun updateKeyingMaterial_should_process_the_commit_message() = runTest {
-        val (alice, bob) = newClients(genClientId(), genClientId())
+        val alice = ccInit()
+        val bob = ccInit()
+        val conversationId = createConversation(bob)
 
-        bob.transaction { ctx -> ctx.createConversationShort(id) }
-
-        val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-        val welcome = mockDeliveryService.getLatestWelcome()
-        val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
-        bob.transaction { ctx -> ctx.updateKeyingMaterial(id) }
-        val commit = mockDeliveryService.getLatestCommit()
+        val groupId = invite(bob, alice, conversationId)
+        bob.transaction { ctx -> ctx.updateKeyingMaterial(groupId) }
+        val commit = MockMlsTransportSuccessProvider.getInstance().getLatestCommit()
 
         val decrypted = alice.transaction { ctx -> ctx.decryptMessage(groupId, commit) }
         assertThat(decrypted.message).isNull()
@@ -195,28 +183,22 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun addClientsToConversation_should_allow_joining_a_conversation_with_a_Welcome() = runTest {
-        val (alice, bob) = newClients(genClientId(), genClientId())
+        val alice = ccInit()
+        val bob = ccInit()
 
-        bob.transaction { ctx -> ctx.createConversationShort(id) }
+        val conversationId = createConversation(bob)
+        val groupId = invite(bob, alice, conversationId)
 
-        val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-        val welcome = mockDeliveryService.getLatestWelcome()
-        val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
-
-        assertThat(groupId).isEqualTo(id)
+        assertThat(groupId).isEqualTo(conversationId)
     }
 
     @Test
     fun encryptMessage_should_encrypt_then_receiver_should_decrypt() = runTest {
-        val (alice, bob) = newClients(genClientId(), genClientId())
+        val alice = ccInit()
+        val bob = ccInit()
 
-        bob.transaction { ctx -> ctx.createConversationShort(id) }
-
-        val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-        val welcome = mockDeliveryService.getLatestWelcome()
-        val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+        val conversationId = createConversation(bob)
+        val groupId = invite(bob, alice, conversationId)
 
         val msg = "Hello World !".toByteArray()
         val ciphertextMsg = alice.transaction { ctx -> ctx.encryptMessage(groupId, msg) }
@@ -235,58 +217,52 @@ class MLSTest : HasMockDeliveryService() {
     @Test
     fun addClientsToConversation_should_add_members_to_the_MLS_group() = runTest {
         val aliceId = genClientId()
+        val alice = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, aliceId))
         val bobId = genClientId()
+        val bob = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, bobId))
         val carolId = genClientId()
-        val (alice, bob, carol) = newClients(aliceId, bobId, carolId)
+        val carol = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, carolId))
 
-        bob.transaction { ctx -> ctx.createConversationShort(id) }
-        val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-        val welcome = mockDeliveryService.getLatestWelcome()
+        val conversationId = createConversation(bob)
+        invite(bob, alice, conversationId)
 
-        alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+        invite(bob, carol, conversationId)
+        val commit = MockMlsTransportSuccessProvider.getInstance().getLatestCommit()
 
-        val carolKp = carol.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(carolKp)) }
-        val commit = mockDeliveryService.getLatestCommit()
-
-        val decrypted = alice.transaction { ctx -> ctx.decryptMessage(id, commit) }
+        val decrypted = alice.transaction { ctx -> ctx.decryptMessage(conversationId, commit) }
         assertThat(decrypted.message).isNull()
 
-        val members = alice.transaction { ctx -> ctx.getClientIds(id) }
+        val members = alice.transaction { ctx -> ctx.getClientIds(conversationId) }
         assertThat(members).containsAll(listOf(aliceId, bobId, carolId))
     }
 
     @Test
     fun addClientsToConversation_should_return_a_valid_Welcome_message() = runTest {
-        val (alice, bob) = newClients(genClientId(), genClientId())
+        val alice = ccInit()
+        val bob = ccInit()
 
-        bob.transaction { ctx -> ctx.createConversationShort(id) }
+        val id = createConversation(bob)
 
-        val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-        val welcome = mockDeliveryService.getLatestWelcome()
-
-        val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+        val groupId = invite(bob, alice, id)
         assertThat(groupId).isEqualTo(id)
     }
 
     @Test
     fun removeMember_should_remove_members_from_the_MLS_group() = runTest {
+        val alice = ccInit()
+        val bob = ccInit()
         val carolId = genClientId()
-        val (alice, bob, carol) = newClients(genClientId(), genClientId(), carolId)
-
-        bob.transaction { ctx -> ctx.createConversationShort(id) }
-
-        val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        val carolKp = carol.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-        bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp, carolKp)) }
-        val welcome = mockDeliveryService.getLatestWelcome()
-        val conversationId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+        val carol = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, carolId))
+        val conversationId = createConversation(bob)
+        invite(bob, alice, conversationId)
+        invite(bob, carol, conversationId)
+        alice.transaction { ctx ->
+            ctx.decryptMessage(conversationId, MockMlsTransportSuccessProvider.getInstance().getLatestCommit())
+        }
 
         val carolMember = listOf(carolId)
         bob.transaction { ctx -> ctx.removeClientsFromConversation(conversationId, carolMember) }
-        val commit = mockDeliveryService.getLatestCommit()
+        val commit = MockMlsTransportSuccessProvider.getInstance().getLatestCommit()
 
         val decrypted = alice.transaction { ctx -> ctx.decryptMessage(conversationId, commit) }
         assertThat(decrypted.message).isNull()
@@ -294,16 +270,16 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun wipeConversation_should_delete_the_conversation_from_the_keystore() = runTest {
-        val (alice) = newClients(genClientId())
-        alice.transaction { ctx -> ctx.createConversationShort(id) }
+        val alice = ccInit()
+        val conversationId = createConversation(alice)
         assertThatNoException().isThrownBy {
-            runBlocking { alice.transaction { ctx -> ctx.wipeConversation(id) } }
+            runBlocking { alice.transaction { ctx -> ctx.wipeConversation(conversationId) } }
         }
     }
 
     @Test
     fun givenTransactionRunsSuccessfully_thenShouldBeAbleToFinishOtherTransactions() = runTest {
-        val coreCrypto = initCc()
+        val coreCrypto = ccInit(CcInitOptions.WithoutBasicCredential())
         val someWork = Job()
         val firstTransactionJob = launch {
             coreCrypto.transaction {
@@ -324,7 +300,7 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun givenTransactionIsCancelled_thenShouldBeAbleToFinishOtherTransactions() = runTest {
-        val coreCrypto = initCc()
+        val coreCrypto = ccInit(CcInitOptions.WithoutBasicCredential())
 
         val firstTransactionJob = launch {
             coreCrypto.transaction {
@@ -345,11 +321,11 @@ class MLSTest : HasMockDeliveryService() {
 
     @Test
     fun exportSecretKey_should_generate_a_secret_with_the_right_length() = runTest {
-        val (alice) = newClients(genClientId())
-        alice.transaction { ctx -> ctx.createConversationShort(id) }
+        val alice = ccInit()
+        val conversationId = createConversation(alice)
         val n = 50
         val secrets = (0 until n).map {
-            val secret = alice.transaction { ctx -> ctx.exportSecretKey(id, 32U) }.copyBytes()
+            val secret = alice.transaction { ctx -> ctx.exportSecretKey(conversationId, 32U) }.copyBytes()
             assertThat(secret).hasSize(32)
             secret
         }.toSet()
@@ -374,26 +350,24 @@ class MLSTest : HasMockDeliveryService() {
             val aliceObserver = Observer()
 
             // Set up the conversation in one transaction
-            val (alice, bob) = newClients(genClientId(), genClientId())
-            bob.transaction { ctx -> ctx.createConversationShort(id) }
+            val alice = ccInit()
+            val bob = ccInit()
+            val conversationId = createConversation(bob)
 
             // Register observers
             bob.registerEpochObserver(scope, bobObserver)
             alice.registerEpochObserver(scope, aliceObserver)
 
             // In another transaction, change the epoch
-            bob.transaction { ctx -> ctx.updateKeyingMaterial(id) }
+            bob.transaction { ctx -> ctx.updateKeyingMaterial(conversationId) }
 
             // Alice joins the group
-            val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-            bob.transaction { ctx -> ctx.addClientsToConversation(id, listOf(aliceKp)) }
-            val welcome = mockDeliveryService.getLatestWelcome()
-            val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+            invite(bob, alice, conversationId)
 
             // Change the epoch again, this should be seen by both observers
-            bob.transaction { ctx -> ctx.updateKeyingMaterial(id) }
-            val commit = mockDeliveryService.getLatestCommit()
-            alice.transaction { ctx -> ctx.decryptMessage(groupId, commit) }
+            bob.transaction { ctx -> ctx.updateKeyingMaterial(conversationId) }
+            val commit = MockMlsTransportSuccessProvider.getInstance().getLatestCommit()
+            alice.transaction { ctx -> ctx.decryptMessage(conversationId, commit) }
 
             // Bob's observer must have observed all epoch change events, Alice's observer saw only the
             // last one
@@ -409,11 +383,11 @@ class MLSTest : HasMockDeliveryService() {
             )
 
             assertTrue(
-                bobObserver.observedEvents.all { ctx -> ctx.conversationId == id },
+                bobObserver.observedEvents.all { ctx -> ctx.conversationId == conversationId },
                 "the events observed by bob must be for this conversation"
             )
             assertTrue(
-                aliceObserver.observedEvents.all { ctx -> ctx.conversationId == id },
+                aliceObserver.observedEvents.all { ctx -> ctx.conversationId == conversationId },
                 "the event observed by alice must be for this conversation"
             )
         }
@@ -423,7 +397,7 @@ class MLSTest : HasMockDeliveryService() {
     fun epochObserverEvent_shouldAllowReadingData(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val (alice) = newClients(genClientId())
+            val alice = ccInit()
 
             data class ObserverEvent(val eventEpoch: ULong, val conversationEpoch: ULong)
 
@@ -443,15 +417,15 @@ class MLSTest : HasMockDeliveryService() {
 
             val aliceObserver = Observer()
 
-            alice.transaction { it.createConversationShort(id) }
-            val initialEpoch = alice.conversationEpoch(id)
+            val conversationId = createConversation(alice)
+            val initialEpoch = alice.conversationEpoch(conversationId)
 
             alice.registerEpochObserver(scope, aliceObserver)
 
             val expectedEvent = aliceObserver.expectEvent()
-            alice.transaction { it.updateKeyingMaterial(id) }
+            alice.transaction { it.updateKeyingMaterial(conversationId) }
             val observedEvent = expectedEvent.await()
-            val laterEpoch = alice.conversationEpoch(id)
+            val laterEpoch = alice.conversationEpoch(conversationId)
 
             assertEquals(initialEpoch + 1U, laterEpoch)
             assertEquals(
@@ -487,34 +461,29 @@ class MLSTest : HasMockDeliveryService() {
             val aliceObserver = Observer()
 
             // Set up the conversation in one transaction
-            val (alice, bob) = newClients(genClientId(), genClientId())
-            val aliceKp = alice.transaction { ctx -> ctx.clientKeypackagesShort(1U).first() }
-            bob.transaction { ctx ->
-                ctx.createConversationShort(id)
-                ctx.addClientsToConversation(id, listOf(aliceKp))
-            }
+            val alice = ccInit()
+            val bob = ccInit()
+            val conversationId = createConversation(bob)
 
-            // Alice joins the group
-            val welcome = mockDeliveryService.getLatestWelcome()
-            val groupId = alice.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+            invite(bob, alice, conversationId)
 
             // Register observers
             bob.registerHistoryObserver(scope, bobObserver)
             alice.registerHistoryObserver(scope, aliceObserver)
 
             // History sharing is disabled by default
-            assertFalse(bob.isHistorySharingEnabled(id))
+            assertFalse(bob.isHistorySharingEnabled(conversationId))
 
             // In another transaction, enable history sharing
-            bob.transaction { ctx -> ctx.enableHistorySharing(id) }
+            bob.transaction { ctx -> ctx.enableHistorySharing(conversationId) }
 
             // Before Alice received the commit, history sharing is only enabled for Bob
-            assertTrue(bob.isHistorySharingEnabled(id))
-            assertFalse(alice.isHistorySharingEnabled(id))
+            assertTrue(bob.isHistorySharingEnabled(conversationId))
+            assertFalse(alice.isHistorySharingEnabled(conversationId))
 
-            val commit = mockDeliveryService.getLatestCommit()
-            alice.transaction { ctx: CoreCryptoContext -> ctx.decryptMessage(groupId, commit) }
-            assertTrue(alice.isHistorySharingEnabled(id))
+            val commit = MockMlsTransportSuccessProvider.getInstance().getLatestCommit()
+            alice.transaction { ctx: CoreCryptoContext -> ctx.decryptMessage(conversationId, commit) }
+            assertTrue(alice.isHistorySharingEnabled(conversationId))
 
             // Bob's observer must have observed the history secret changes, Alice's should not
             // have observed anything
@@ -528,7 +497,7 @@ class MLSTest : HasMockDeliveryService() {
                 aliceObserver.observedEvents.size,
                 "alice did not trigger any history secret changes and must not have observed that"
             )
-            val expected = id
+            val expected = conversationId
             assertTrue(
                 bobObserver.observedEvents.all { ctx -> ctx.conversationId == expected },
                 "the events observed by bob must be for this conversation"
@@ -550,19 +519,11 @@ class MLSTest : HasMockDeliveryService() {
     fun can_add_basic_credential(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val clientId = genClientId()
-            val credential = Credential.basic(CIPHERSUITE_DEFAULT, clientId)
-
-            val cc = initCc()
-            val ref = cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
-                ctx.addCredential(credential)
-            }
-
+            val cc = ccInit()
+            val allCredentials = cc.transaction { ctx -> ctx.getCredentials() }
+            val ref = allCredentials.last()
             assertEquals(ref.type(), CredentialType.BASIC)
             assertNotEquals(ref.earliestValidity(), 0uL)
-
-            val allCredentials = cc.transaction { ctx -> ctx.getCredentials() }
             assertThat(allCredentials).hasSize(1)
         }
     }
@@ -571,13 +532,9 @@ class MLSTest : HasMockDeliveryService() {
     fun can_remove_basic_credential(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val clientId = genClientId()
-            val credential = Credential.basic(CIPHERSUITE_DEFAULT, clientId)
-
-            val cc = initCc()
+            val cc = ccInit()
             val ref = cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
-                ctx.addCredential(credential)
+                ctx.`getCredentials`().last()
             }
 
             cc.transaction { ctx ->
@@ -601,9 +558,8 @@ class MLSTest : HasMockDeliveryService() {
                 CipherSuite.MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_ED25519
             val credential2 = Credential.basic(ciphersuite2, clientId)
 
-            val cc = initCc()
+            val cc = ccInit(CcInitOptions.WithoutBasicCredential(clientId))
             cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
                 ctx.addCredential(credential1)
                 ctx.addCredential(credential2)
             }
@@ -637,13 +593,9 @@ class MLSTest : HasMockDeliveryService() {
     fun can_create_keypackage(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val clientId = genClientId()
-            val credential = Credential.basic(CIPHERSUITE_DEFAULT, clientId)
-
-            val cc = initCc()
+            val cc = ccInit()
             val credentialRef = cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
-                ctx.addCredential(credential)
+                ctx.`getCredentials`().last()
             }
 
             val keyPackage = cc.transaction { ctx ->
@@ -658,18 +610,9 @@ class MLSTest : HasMockDeliveryService() {
     fun can_serialize_keypackage(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val clientId = genClientId()
-            val credential = Credential.basic(CIPHERSUITE_DEFAULT, clientId)
+            val cc = ccInit()
 
-            val cc = initCc()
-            val credentialRef = cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
-                ctx.addCredential(credential)
-            }
-
-            val keyPackage = cc.transaction { ctx ->
-                ctx.generateKeyPackage(credentialRef)
-            }
+            val keyPackage = generateKeyPackage(cc)
 
             val bytes = keyPackage.serialize()
             assertNotNull(bytes)
@@ -687,19 +630,8 @@ class MLSTest : HasMockDeliveryService() {
     fun can_retrieve_keypackages_in_bulk(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val clientId = genClientId()
-            val credential = Credential.basic(CIPHERSUITE_DEFAULT, clientId)
-
-            val cc = initCc()
-            val credentialRef = cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
-                ctx.addCredential(credential)
-            }
-
-            cc.transaction { ctx ->
-                ctx.generateKeyPackage(credentialRef)
-            }
-
+            val cc = ccInit()
+            generateKeyPackage(cc)
             val keyPackages = cc.transaction { ctx ->
                 ctx.getKeyPackages()
             }
@@ -714,24 +646,11 @@ class MLSTest : HasMockDeliveryService() {
     fun can_remove_keypackage(): TestResult {
         val scope = TestScope()
         return scope.runTest {
-            val clientId = genClientId()
-            val credential = Credential.basic(CIPHERSUITE_DEFAULT, clientId)
-
-            val cc = initCc()
-            val credentialRef = cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
-                ctx.addCredential(credential)
-            }
-
-            // add a kp which will not be removed
-            cc.transaction { ctx ->
-                ctx.generateKeyPackage(credentialRef)
-            }
+            val cc = ccInit()
+            generateKeyPackage(cc)
 
             // add a kp which will be removed
-            val keyPackage = cc.transaction { ctx ->
-                ctx.generateKeyPackage(credentialRef)
-            }
+            val keyPackage = generateKeyPackage(cc)
 
             // remove the keypackage
             cc.transaction { ctx ->
@@ -761,10 +680,9 @@ class MLSTest : HasMockDeliveryService() {
                 clientId
             )
 
-            val cc = initCc()
+            val cc = ccInit(CcInitOptions.WithoutBasicCredential(clientId))
 
             cc.transaction { ctx ->
-                ctx.mlsInitShort(clientId)
                 val cref1 = ctx.addCredential(credential1)
                 val cref2 = ctx.addCredential(credential2)
 

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -81,7 +81,7 @@ class MLSTest {
         // transaction hadn't been rolled back.
         cc.transaction { ctx ->
             val credentialRef = ctx.getCredentials().last()
-                    ctx.createConversation(conversationId, credentialRef)
+            ctx.createConversation(conversationId, credentialRef)
         }
     }
 
@@ -161,7 +161,14 @@ class MLSTest {
                 ctx.getKeyPackages().size
             }
         ).isEqualTo(0)
-        assertThat(alice.transaction { ctx -> ctx.clientKeypackagesShort(200U) }).isNotEmpty().hasSize(200)
+        assertThat(
+            alice.transaction { ctx ->
+
+                val credentialRef = ctx.getCredentials().last()
+
+                List(200U.toInt()) { _ -> ctx.generateKeyPackage(credentialRef) }
+            }
+        ).isNotEmpty().hasSize(200)
         assertThat(
             alice.transaction { ctx ->
                 ctx.getKeyPackages().size

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
@@ -183,22 +183,6 @@ fun randomIdentifier(n: Int = 12): String {
         .joinToString("")
 }
 
-
-/** Shorthand for creating a conversation with defaults */
-suspend fun CoreCryptoContext.createConversationShort(
-    id: ConversationId
-) {
-    val credentials = findCredentials(
-        clientId = null,
-        publicKey = null,
-        ciphersuite = CIPHERSUITE_DEFAULT,
-        credentialType = CREDENTIAL_TYPE_DEFAULT,
-        earliestValidity = null
-    )
-    val credential = credentials.last()
-    createConversation(id, credential, null)
-}
-
 /** Shorthand for generating keypackages with defaults */
 suspend fun CoreCryptoContext.clientKeypackagesShort(amount: UInt): List<KeyPackage> {
     val credentials = findCredentials(

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
@@ -183,10 +183,6 @@ fun randomIdentifier(n: Int = 12): String {
         .joinToString("")
 }
 
-/** Shorthand for initializing MLS with only a client id */
-suspend fun CoreCryptoContext.mlsInitShort(
-    clientId: ClientId
-) = mlsInit(clientId, HasMockDeliveryService.mockDeliveryService)
 
 /** Shorthand for creating a conversation with defaults */
 suspend fun CoreCryptoContext.createConversationShort(

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
@@ -39,7 +39,18 @@ interface MockDeliveryService : MlsTransport {
     suspend fun getLatestCommit(): ByteArray
 }
 
+// We use a singleton to easily access the mocked provider
 class MockMlsTransportSuccessProvider : MockDeliveryService {
+    companion object {
+        @Volatile
+        private var instance: MockMlsTransportSuccessProvider? = null
+
+        fun getInstance() =
+            instance ?: synchronized(this) {
+                instance ?: MockMlsTransportSuccessProvider().also { instance = it }
+            }
+    }
+
     private var latestCommitBundle: CommitBundle? = null
 
     override suspend fun sendCommitBundle(commitBundle: CommitBundle) {
@@ -91,34 +102,78 @@ class MockPkiEnvironmentHooks : PkiEnvironmentHooks {
     }
 }
 
-open class HasMockDeliveryService {
-    companion object {
-        internal lateinit var mockDeliveryService: MockDeliveryService
-    }
+sealed interface CcInitOptions {
+    val clientId: ClientId?
 
-    fun setupMocks() {
-        mockDeliveryService = MockMlsTransportSuccessProvider()
-    }
+    data class WithoutBasicCredential(
+        override val clientId: ClientId? = null
+    ) : CcInitOptions
+
+    data class WithBasicCredential(
+        val cipherSuite: CipherSuite = CIPHERSUITE_DEFAULT,
+        override val clientId: ClientId? = null
+    ) : CcInitOptions
 }
 
-fun newClients(vararg clientIds: ClientId) = runBlocking {
-    clientIds.map { clientID ->
-        val cc = initCc()
-        cc.transaction { ctx ->
-            ctx.mlsInitShort(clientID)
-            ctx.addCredential(Credential.basic(CIPHERSUITE_DEFAULT, clientID))
+suspend fun ccInit(
+    options: CcInitOptions = CcInitOptions.WithBasicCredential()
+): CoreCrypto {
+    val db = newDatabase()
+    val cc = CoreCrypto(db)
+
+    val clientId = options.clientId ?: genClientId()
+
+    cc.transaction { ctx ->
+        ctx.mlsInit(clientId, MockMlsTransportSuccessProvider.getInstance())
+
+        when (options) {
+            is CcInitOptions.WithBasicCredential -> {
+                ctx.addCredential(
+                    Credential.basic(
+                        options.cipherSuite,
+                        clientId
+                    )
+                )
+            }
+
+            is CcInitOptions.WithoutBasicCredential -> {
+                // nothing
+            }
         }
-        cc
     }
+    return cc
 }
 
-fun initCc(): CoreCrypto = runBlocking {
+suspend fun newDatabase(): Database {
     val root = Files.createTempDirectory("mls").toFile()
     val path = root.resolve("keystore-${randomIdentifier()}")
     val key = genDatabaseKey()
-    val db = openDatabase(path.absolutePath, key)
-    val cc = CoreCrypto(db)
-    cc
+    return openDatabase(path.absolutePath, key)
+}
+
+suspend fun createConversation(cc: CoreCrypto): ConversationId {
+    val conversationId = genConversationId()
+    cc.transaction { ctx ->
+        val credentialRef = ctx.`getCredentials`().last()
+        ctx.createConversation(conversationId, credentialRef)
+    }
+    return conversationId
+}
+
+suspend fun invite(cc1: CoreCrypto, cc2: CoreCrypto, conversationId: ConversationId): ConversationId {
+    val kp = generateKeyPackage(cc2)
+    cc1.transaction {
+        it.addClientsToConversation(conversationId, listOf(kp))
+    }
+    val welcome = MockMlsTransportSuccessProvider.getInstance().getLatestWelcome()
+    return cc2.transaction { ctx -> ctx.processWelcomeMessage(welcome) }
+}
+
+suspend fun generateKeyPackage(cc: CoreCrypto): KeyPackage {
+    return cc.transaction { ctx ->
+        val credentialRef = ctx.getCredentials().last()
+        ctx.generateKeyPackage(credentialRef)
+    }
 }
 
 fun randomIdentifier(n: Int = 12): String {

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
@@ -182,20 +182,3 @@ fun randomIdentifier(n: Int = 12): String {
         .map { Random.nextInt(0, charPool.size).let { index -> charPool[index] } }
         .joinToString("")
 }
-
-/** Shorthand for generating keypackages with defaults */
-suspend fun CoreCryptoContext.clientKeypackagesShort(amount: UInt): List<KeyPackage> {
-    val credentials = findCredentials(
-        clientId = null,
-        publicKey = null,
-        ciphersuite = CIPHERSUITE_DEFAULT,
-        credentialType = CREDENTIAL_TYPE_DEFAULT,
-        earliestValidity = null
-    )
-    val credential = credentials.last()
-
-    return List(amount.toInt()) { _ ->
-        // cycle through credentials if amount > credentials.size
-        generateKeyPackage(credential)
-    }
-}


### PR DESCRIPTION
# What's new in this PR

This PR simplifies kotlin test helpers and aligns them to what we do in ts tests.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
