### PR TITLE
chore: e2e-identity: use the IdP URL provided by the ACME server in the OIDC challenge (WPB-25833)

### DIFF
--- a/cc-book/src/cc10/migration-guide.md
+++ b/cc-book/src/cc10/migration-guide.md
@@ -88,7 +88,7 @@ replaces every one of those calls.
 
 1. **Build an `X509CredentialAcquisitionConfiguration`** describing the certificate you want:
 
-   - `acmeUrl`, `idpUrl`
+   - `acmeUrl` - the URL of the ACME server
    - `ciphersuite` — must be one of the four with a JWS-compatible signature scheme: Ed25519, P256, P384, or P521. Other
      ciphersuites will fail at construction.
    - `displayName`, `clientId`, `handle`, `domain`, optional `team`

--- a/crypto-ffi/bindings/js/packages/browser/test/e2ei.test.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/e2ei.test.ts
@@ -147,7 +147,6 @@ describe("end to end identity", () => {
             const config =
                 window.ccModule.X509CredentialAcquisitionConfiguration.new({
                     acmeUrl: "acme.example.com",
-                    idpUrl: "https://idp.example.com",
                     ciphersuite: window.defaultCipherSuite,
                     displayName: "Alice Smith",
                     clientId,

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
@@ -76,7 +76,6 @@ internal class E2EITest {
             pkiEnv,
             X509CredentialAcquisitionConfiguration(
                 acmeUrl = "acme.example.com",
-                idpUrl = "https://idp.example.com",
                 ciphersuite = CIPHERSUITE_DEFAULT,
                 displayName = "Alice Smith",
                 clientId = clientId,

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -925,7 +925,6 @@ final class WireCoreCryptoTests: XCTestCase {
             pkiEnvironment: pkiEnvironment,
             config: X509CredentialAcquisitionConfiguration(
                 acmeUrl: "acme.example.com",
-                idpUrl: "https://idp.example.com",
                 ciphersuite: ciphersuiteDefault(),
                 displayName: "Alice Smith",
                 clientId: clientId,

--- a/crypto-ffi/src/e2ei/mod.rs
+++ b/crypto-ffi/src/e2ei/mod.rs
@@ -66,8 +66,6 @@ impl From<JwsAlgorithm> for FfiCiphersuite {
 pub struct X509CredentialAcquisitionConfiguration {
     /// ACME server hostname.
     pub acme_url: String,
-    /// OIDC identity provider URL.
-    pub idp_url: String,
     /// Ciphersuite of the acquired credential.
     pub ciphersuite: FfiCiphersuite,
     /// User-visible display name.
@@ -93,7 +91,6 @@ impl X509CredentialAcquisitionConfiguration {
 
         Ok(wire_e2e_identity::acquisition::X509CredentialConfiguration {
             acme_url: self.acme_url,
-            idp_url: self.idp_url,
             sign_alg,
             hash_alg: HashAlgorithm::SHA256,
             display_name: self.display_name,

--- a/e2e-identity/src/acquisition/mod.rs
+++ b/e2e-identity/src/acquisition/mod.rs
@@ -28,7 +28,6 @@ pub use serialization::ClientIdDef;
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct X509CredentialConfiguration {
     pub acme_url: String,
-    pub idp_url: String,
     pub sign_alg: JwsAlgorithm,
     pub hash_alg: HashAlgorithm,
     pub display_name: String,

--- a/e2e-identity/src/acquisition/oidc_challenge.rs
+++ b/e2e-identity/src/acquisition/oidc_challenge.rs
@@ -23,9 +23,8 @@ impl X509CredentialAcquisition<states::DpopChallengeCompleted> {
         let snapshot = serde_json::to_vec(&self)?;
 
         let url = &self.data.oidc_challenge.url;
-        let id_token = hooks
-            .authenticate(self.config.idp_url.clone(), key_auth, url.to_string(), snapshot)
-            .await?;
+        let target = self.data.oidc_challenge.target.to_string();
+        let id_token = hooks.authenticate(target, key_auth, url.to_string(), snapshot).await?;
 
         let oidc_challenge_request = RustyAcme::oidc_chall_request(
             id_token,

--- a/e2e-identity/src/acquisition/serialization.rs
+++ b/e2e-identity/src/acquisition/serialization.rs
@@ -106,7 +106,6 @@ mod tests {
         let client_id = ClientId::try_new(Uuid::new_v4().to_string(), 1, "wire.example").unwrap();
         let config = X509CredentialConfiguration {
             acme_url: "acme.example".into(),
-            idp_url: "idp.example".into(),
             sign_alg: JwsAlgorithm::P256,
             hash_alg: HashAlgorithm::SHA256,
             display_name: "Alice".into(),

--- a/e2e-identity/tests/e2e.rs
+++ b/e2e-identity/tests/e2e.rs
@@ -195,7 +195,6 @@ async fn prepare_pki_env_and_config(
 
     let config = X509CredentialConfiguration {
         acme_url,
-        idp_url: test_env.idp_server.discovery_base_url.clone(),
         sign_alg,
         hash_alg: HashAlgorithm::SHA256,
         display_name: "Alice Smith".into(),


### PR DESCRIPTION
Right now the new X509 credential acquisition process requires the user to specify the IdP server
URL in the configuration. However, that is both unnecessary and risky because the ACME server provides
the IdP URL in the target field of the OIDC challenge. We should always consider the data coming from the
ACME server as authoritative.
