### PR TITLE
chore(make/ios): use `release` profile when building for `ios-sim`

### DIFF
--- a/crypto-ffi/bindings/swift/WireCoreCryptoUniffi/WireCoreCryptoUniffi.xcodeproj/project.pbxproj
+++ b/crypto-ffi/bindings/swift/WireCoreCryptoUniffi/WireCoreCryptoUniffi.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=arm64]" = "../../../../target/aarch64-apple-ios/debug/libcore_crypto_ffi.a";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*][arch=arm64]" = "../../../../target/aarch64-apple-ios-sim/debug/libcore_crypto_ffi.a";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*][arch=arm64]" = "../../../../target/aarch64-apple-ios-sim/release/libcore_crypto_ffi.a";
 				"OTHER_LDFLAGS[sdk=iphonesimulator*][arch=x86_64]" = "../../../../target/x86_64-apple-ios/debug/libcore_crypto_ffi.a";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireCoreCryptoUniffi;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/make/ios.mk
+++ b/make/ios.mk
@@ -16,7 +16,7 @@ $(IOS_DEVICE): $(ios-device-deps)
 .PHONY: ios-device
 ios-device: $(IOS_DEVICE) ## Build core-crypto-ffi for aarch64-apple-ios for iOS 16.4 (macOS only)
 
-IOS_SIMULATOR_ARM := target/aarch64-apple-ios-sim/$(RELEASE_MODE)/libcore_crypto_ffi.$(LIBRARY_EXTENSION)
+IOS_SIMULATOR_ARM := target/aarch64-apple-ios-sim/release/libcore_crypto_ffi.$(LIBRARY_EXTENSION)
 ios-simulator-arm-deps := $(RUST_SOURCES)
 $(IOS_SIMULATOR_ARM): $(ios-simulator-arm-deps)
 	CRATE_CC_NO_DEFAULTS=1 \
@@ -28,10 +28,10 @@ $(IOS_SIMULATOR_ARM): $(ios-simulator-arm-deps)
 	  --crate-type=cdylib \
 	  --crate-type=staticlib \
 	  --package core-crypto-ffi \
-	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
+	  --release -- $(RUST_STRIP_FLAGS)
 
 .PHONY: ios-simulator-arm
-ios-simulator-arm: $(IOS_SIMULATOR_ARM) ## Build core-crypto-ffi for aarch64-apple-ios-sim, iOS 16.4 (macOS only)
+ios-simulator-arm: $(IOS_SIMULATOR_ARM) ## Build for aarch64-apple-ios-sim, iOS 16.4 (macOS only). Always builds in release mode (see WPB-25954).
 
 .PHONY: ios
 ios: ios-device ios-simulator-arm


### PR DESCRIPTION
Currently, the ios test suite fails with a stack overflow when run in debug mode. This is due to deep stack and correspodning futures in openmls. The goes away when compiling the rust binaries in release mode.

The item to revert this is WPB-25954.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
