### PR TITLE
fix: re-write the swift wrapper to be based on composition again.

### DIFF
--- a/.github/actions/make/bindings-swift/action.yml
+++ b/.github/actions/make/bindings-swift/action.yml
@@ -29,3 +29,12 @@ runs:
           gh-token: ${{ inputs.gh-token }}
           uses-rust: true
           artifact-generation: ${{ inputs.artifact-generation }}
+
+      - uses: ./.github/actions/make
+        with:
+          key: swift-generate-wrapper
+          make-rule: swift-generate-wrapper
+          target-path: crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto
+          gh-token: ${{ inputs.gh-token }}
+          uses-rust: false
+          artifact-generation: ${{ inputs.artifact-generation }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ DerivedData/
 *.dSYM.zip
 *.dSYM
 .DS_Store
+*.generated.swift
 
 # neovim
 .nvim.lua

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ make android
 
 Install Xcode & its command-line tools: [https://developer.apple.com/xcode/](https://developer.apple.com/xcode/).
 
+Install [Sourcery](https://github.com/krzysztofzablocki/sourcery)
+
+```sh
+brew install sourcery
+```
+
 Install iOS rust targets:
 
 ```sh

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/.sourcery.yml
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/.sourcery.yml
@@ -1,0 +1,5 @@
+sources:
+  - ../../WireCoreCryptoUniffi/WireCoreCryptoUniffi/core_crypto_ffi.swift
+templates:
+  - Sourcery/Templates
+output: .

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -26,16 +26,13 @@ public protocol CoreCryptoProtocol: CoreCryptoFfiProtocol {
 
 /// CoreCrypto client which manages one cryptographic client for proteus and MLS.
 ///
-public final class CoreCrypto: CoreCryptoFfi, CoreCryptoProtocol, @unchecked Sendable {
+public final class CoreCrypto: CoreCryptoProtocol, @unchecked Sendable {
+    let coreCryptoFfi: CoreCryptoFfi
     let database: Database?
 
-    /// Initialize CoreCrypto with an Ffi instance
-    private init(_ coreCrypto: WireCoreCryptoUniffi.CoreCryptoFfi, database: Database? = nil) {
+    private init(_ coreCrypto: CoreCryptoFfi, database: Database? = nil) {
+        self.coreCryptoFfi = coreCrypto
         self.database = database
-        // Due to Swift limitations, we can't use the `super` convenience intializer inside a child initializer, we
-        // have to call the default `super` initializer. Luckily, we can do this meaningfully by cloning the pointer of
-        // the instance that is passed in here.
-        super.init(unsafeFromRawPointer: coreCrypto.uniffiClonePointer())
     }
 
     ///
@@ -47,13 +44,6 @@ public final class CoreCrypto: CoreCryptoFfi, CoreCryptoProtocol, @unchecked Sen
     public convenience init(database: Database) throws {
         let coreCrypto = try coreCryptoNew(database: database)
         self.init(coreCrypto, database: database)
-    }
-
-    @_documentation(visibility: private) required init(
-        unsafeFromRawPointer pointer: UnsafeMutableRawPointer
-    ) {
-        self.database = nil
-        super.init(unsafeFromRawPointer: pointer)
     }
 
     /// Instantiate a history client.
@@ -74,29 +64,24 @@ public final class CoreCrypto: CoreCryptoFfi, CoreCryptoProtocol, @unchecked Sen
         let transactionExecutor = try TransactionExecutor<Result>(
             keystorePath: filePath, block)
         do {
-            try await super.transactionFfi(command: transactionExecutor)
+            try await coreCryptoFfi.transactionFfi(command: transactionExecutor)
         } catch {
             throw await transactionExecutor.innerError ?? error
         }
         return await transactionExecutor.result!
     }
 
-    @available(*, unavailable, message: "Use transaction(_:) instead.")
-    public override func transactionFfi(command: CoreCryptoCommand) async throws {
-        try await super.transactionFfi(command: command)
-    }
-
-    public func registerEpochObserver(_ epochObserver: EpochObserver) async throws {
+    public func registerEpochObserver(epochObserver: EpochObserver) async throws {
         // we want to wrap the observer here to provide async indirection, so that no matter what
         // the observer that makes its way to the Rust side of things doesn't end up blocking
-        try await self.registerEpochObserver(
+        try await coreCryptoFfi.registerEpochObserver(
             epochObserver: EpochObserverIndirector(epochObserver))
     }
 
-    public func registerHistoryObserver(_ historyObserver: HistoryObserver) async throws {
+    public func registerHistoryObserver(historyObserver: HistoryObserver) async throws {
         // we want to wrap the observer here to provide async indirection, so that no matter what
         // the observer that makes its way to the Rust side of things doesn't end up blocking
-        try await self.registerHistoryObserver(
+        try await coreCryptoFfi.registerHistoryObserver(
             historyObserver: HistoryObserverIndirector(historyObserver))
     }
 

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/Sourcery/Templates/CoreCrypto.stencil
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/Sourcery/Templates/CoreCrypto.stencil
@@ -1,0 +1,38 @@
+// Delegates all CoreCryptoFfiProtocol methods to the internal `coreCryptoFfi` reference.
+// Methods with manual implementations in CoreCrypto.swift are excluded via the `where` filter below.
+
+import WireCoreCryptoUniffi
+
+extension CoreCrypto {
+{% for protocol in types.protocols where protocol.name == "CoreCryptoFfiProtocol" %}{% for method in protocol.methods where method.callName != "registerEpochObserver" and method.callName != "registerHistoryObserver" %}
+    public func {{ method.callName }}(
+        {%- for param in method.parameters -%}
+            {%- if not param.argumentLabel -%}
+                _ {{ param.name }}: {{ param.typeName }}
+            {%- elif param.argumentLabel != param.name -%}
+                {{ param.argumentLabel }} {{ param.name }}: {{ param.typeName }}
+            {%- else -%}
+                {{ param.name }}: {{ param.typeName }}
+            {%- endif -%}
+            {%- if param.defaultValue %} = {{ param.defaultValue }}
+            {%- elif param.typeName.isOptional %} = nil
+            {%- endif -%}
+            {%- if not forloop.last %}, {% endif -%}
+        {%- endfor -%}
+    )
+    {%- if method.isAsync %} async{% endif -%}
+    {%- if method.throws %} throws{% endif -%}
+    {%- if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+        {% if not method.returnTypeName.isVoid %}return {% endif -%}
+        {%- if method.throws %}try {% endif -%}
+        {%- if method.isAsync %}await {% endif -%}
+        coreCryptoFfi.{{ method.callName }}(
+            {%- for param in method.parameters -%}
+                {%- if param.argumentLabel %}{{ param.argumentLabel }}: {% endif -%}
+                {{ param.name }}
+                {%- if not forloop.last %}, {% endif -%}
+            {%- endfor -%}
+        )
+    }
+{% endfor %}{% endfor %}
+}

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -512,7 +512,7 @@ final class WireCoreCryptoTests: XCTestCase {
 
         // register the observer
         let epochRecorder = EpochRecorder()
-        try await coreCrypto.registerEpochObserver(epochRecorder)
+        try await coreCrypto.registerEpochObserver(epochObserver: epochRecorder)
 
         // in another transaction, change the epoch
         try await coreCrypto.transaction { context in
@@ -546,7 +546,7 @@ final class WireCoreCryptoTests: XCTestCase {
 
         // register the observer
         let historyRecorder = HistoryRecorder()
-        try await coreCrypto.registerHistoryObserver(historyRecorder)
+        try await coreCrypto.registerHistoryObserver(historyObserver: historyRecorder)
 
         // in another transaction, enable history sharing
         try await coreCrypto.transaction { ctx in

--- a/make/ios.mk
+++ b/make/ios.mk
@@ -36,9 +36,24 @@ ios-simulator-arm: $(IOS_SIMULATOR_ARM) ## Build for aarch64-apple-ios-sim, iOS 
 .PHONY: ios
 ios: ios-device ios-simulator-arm
 
+# Generate swift wrapper extensions
+
+SWIFT_WRAPPER_DIR := crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto
+SOURCERY_CONFIG := $(SWIFT_WRAPPER_DIR)/.sourcery.yml
+SOURCERY_TEMPLATE := $(SWIFT_WRAPPER_DIR)/Sourcery/Templates/CoreCrypto.stencil
+SWIFT_WRAPPER_GENERATED := $(SWIFT_WRAPPER_DIR)/CoreCrypto.generated.swift
+
+.PHONY: swift-generate-wrapper
+swift-generate-wrapper: $(SWIFT_WRAPPER_GENERATED) $(SOURCERY_TEMPLATE)
+
+swift-generate-wrapper-deps := $(UNIFFI_SWIFT_OUTPUT) $(SOURCERY_CONFIG)
+
+$(SWIFT_WRAPPER_GENERATED): $(swift-generate-wrapper-deps)
+	sourcery --config $(SOURCERY_CONFIG)
+
 # Build XCFramework (macOS only)
 
-ios-create-xcframework-deps := $(IOS_DEVICE) $(IOS_SIMULATOR_ARM) $(UNIFFI_SWIFT_OUTPUT)
+ios-create-xcframework-deps := $(IOS_DEVICE) $(IOS_SIMULATOR_ARM) $(UNIFFI_SWIFT_OUTPUT) $(SWIFT_WRAPPER_GENERATED)
 $(STAMPS)/ios-create-xcframework: $(ios-create-xcframework-deps)
 	$(SHELL) scripts/build-xcframework.sh
 	$(TOUCH_STAMP)
@@ -46,7 +61,7 @@ $(STAMPS)/ios-create-xcframework: $(ios-create-xcframework-deps)
 .PHONY: ios-create-xcframework
 ios-create-xcframework: $(STAMPS)/ios-create-xcframework ## Build the XCode framework (macOS only)
 
-ios-test-deps := $(IOS_SIMULATOR_ARM) $(UNIFFI_SWIFT_OUTPUT) $(SWIFT_FILES)
+ios-test-deps := $(IOS_SIMULATOR_ARM) $(UNIFFI_SWIFT_OUTPUT) $(SWIFT_FILES) $(SWIFT_WRAPPER_GENERATED)
 
 $(STAMPS)/ios-test: $(ios-test-deps)
 	$(SHELL) scripts/run-ios-tests.sh $(XCODE_CONFIG)


### PR DESCRIPTION
# What's new in this PR

Inheriting from a uniffi class results in crashes when exposed as a protocol. Instead of going back to hand-writing the wrapper we are now generating wrapper with Sourcery.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
