### PR TITLE
fix: fetch acme nonce using HEAD

### DIFF
--- a/e2e-identity/src/acquisition/dpop_challenge.rs
+++ b/e2e-identity/src/acquisition/dpop_challenge.rs
@@ -83,7 +83,7 @@ impl X509CredentialAcquisition<states::Initialized> {
         let directory = RustyAcme::acme_directory_response(body)?;
 
         let url = directory.new_nonce.to_string();
-        let resp = hooks.http_request(HttpMethod::Get, url, vec![], vec![]).await?;
+        let resp = hooks.http_request(HttpMethod::Head, url, vec![], vec![]).await?;
         let nonce = get_header(&resp, "replay-nonce")?;
         log::debug!(
             "acquisition({:?}): got the initial nonce",


### PR DESCRIPTION
# What's new in this PR

Acme protocol accepts both GET and HEAD, but we were using HEAD previously so let's keep it like that.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
