### PR TITLE
chore: e2e-identity: fix typo in test name

### DIFF
--- a/e2e-identity/src/acquisition/identity.rs
+++ b/e2e-identity/src/acquisition/identity.rs
@@ -251,7 +251,7 @@ OfqfZA1YMtN5NLz/AA==
     #[rstest]
     #[tokio::test]
     #[wasm_bindgen_test]
-    async fn should_have_revoked_status(#[future] pki_env: PkiEnvironment) {
+    async fn should_have_expired_status(#[future] pki_env: PkiEnvironment) {
         let cert_der = pem::parse(CERT_EXPIRED).unwrap();
         let identity = cert_der
             .contents()


### PR DESCRIPTION
The test really checks expiration, not revocation.