### PR TITLE
feat(ffi): add `check_credentials` to ffi

### DIFF
--- a/cc-book/src/cc10/migration-guide.md
+++ b/cc-book/src/cc10/migration-guide.md
@@ -120,6 +120,11 @@ When the app resumes and is ready to complete acquisition, reconstruct the acqui
 There is no client-visible serialization method on `X509CredentialAcquisition` itself; the snapshot bytes are delivered
 to you exclusively through the `authenticate` hook's `acquisitionSnapshot` parameter.
 
+### Checking for expiration and revocation
+
+Call `checkCredentials` at least once every 24 hours to check all X509 credentials for expiration and revocation. It is
+recommended to do this during an idle period, because HTTP requests are done to fetch new certificate revocation lists.
+
 ## Key Packages
 
 1. We **removed** `CoreCryptoContext.clientKeypackages()`. To generate a desired amount of key packages, make repeated

--- a/crypto-ffi/bindings/js/packages/browser/shared/utils.ts
+++ b/crypto-ffi/bindings/js/packages/browser/shared/utils.ts
@@ -132,6 +132,7 @@ export async function sharedSetup() {
                 options: CcInitOptions = {
                     withBasicCredential: true,
                     cipherSuite: window.defaultCipherSuite,
+                    withPkiEnvironment: false,
                 }
             ): Promise<CoreCrypto> {
                 const clientId =
@@ -139,6 +140,15 @@ export async function sharedSetup() {
                 const db =
                     options.database ?? (await window.helpers.newDatabase());
                 const cc = window.ccModule.CoreCrypto.new(db);
+
+                if (options.withPkiEnvironment) {
+                    const pkiEnvironment =
+                        await window.ccModule.PkiEnvironment.create(
+                            window.pkiEnvironmentHooks,
+                            db
+                        );
+                    await cc.setPkiEnvironment(pkiEnvironment);
+                }
 
                 // this also sets the default if undefined
                 // ?? would break type narrowing of CcInitOptions
@@ -505,12 +515,14 @@ type CcInitOptions =
           withBasicCredential: false;
           clientId?: ClientId;
           database?: Database;
+          withPkiEnvironment?: boolean;
       }
     | {
           withBasicCredential?: true;
           cipherSuite?: CipherSuite;
           clientId?: ClientId;
           database?: Database;
+          withPkiEnvironment?: boolean;
       };
 
 export interface Helpers {

--- a/crypto-ffi/bindings/js/packages/browser/test/credential.test.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/credential.test.ts
@@ -1,0 +1,33 @@
+import { browser } from "@wdio/globals";
+import { setup, teardown } from "./utils";
+import { afterEach, beforeEach, describe } from "mocha";
+
+beforeEach(async () => {
+    await setup();
+});
+
+afterEach(async () => {
+    await teardown();
+});
+
+describe("credentials", () => {
+    it("can be checked", async () => {
+        const result = await browser.execute(async () => {
+            try {
+                const cc = await window.helpers.ccInit({
+                    withBasicCredential: true,
+                    cipherSuite: window.defaultCipherSuite,
+                    withPkiEnvironment: true,
+                });
+                await cc.transaction(async (ctx) => {
+                    await ctx.checkCredentials();
+                });
+                return { success: true };
+            } catch (err) {
+                console.log(JSON.stringify(err));
+                return { success: false };
+            }
+        });
+        expect(result.success).toBe(true);
+    });
+});

--- a/crypto-ffi/bindings/js/packages/browser/test/e2ei.test.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/e2ei.test.ts
@@ -167,12 +167,6 @@ describe("end to end identity", () => {
 
     it("should instantiate an x509 credential acquisition object from credential ref", async () => {
         const acquisitionCreated = await browser.execute(async () => {
-            const database = await window.helpers.newDatabase();
-            const pkiEnvironment = await window.ccModule.PkiEnvironment.create(
-                window.pkiEnvironmentHooks,
-                database
-            );
-
             const qualifiedClientId = window.helpers
                 .newClientId(
                     "LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com"
@@ -194,14 +188,16 @@ describe("end to end identity", () => {
             const cc = await window.helpers.ccInit({
                 withBasicCredential: true,
                 clientId,
-                database,
+                withPkiEnvironment: true,
             });
+
+            const pkiEnvironment = await cc.getPkiEnvironment();
 
             const [credentialRef] = await cc.findCredentials({ clientId });
 
             const acquisition =
                 await window.ccModule.X509CredentialAcquisition.newFromCredentialRef(
-                    pkiEnvironment,
+                    pkiEnvironment!,
                     config,
                     credentialRef!
                 );

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/AddUser.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/AddUser.kt
@@ -35,12 +35,13 @@ open class AddUser {
     @Setup(Level.Invocation)
     fun setup() {
         runBlocking {
-            aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            val options = CcInitOptions(CcInitOptions.Mode.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            aliceCc = ccInit(options)
             conversationId = createConversation(aliceCc)
 
             keyPackages = buildList {
                 repeat(userCount) {
-                    val bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+                    val bobCc = ccInit(options)
                     val kp = generateKeyPackage(bobCc)
                     this.add(kp)
                 }

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/CreateMessage.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/CreateMessage.kt
@@ -37,7 +37,7 @@ open class CreateMessage {
 
     @Setup(Level.Iteration)
     fun setup() = runBlocking {
-        cc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+        cc = ccInit(CcInitOptions(CcInitOptions.Mode.WithBasicCredential(CipherSuite.valueOf(cipherSuite))))
         conversationId = createConversation(cc)
         messages = List(messageCount) {
             ByteArray(messageSize) { 'A'.code.toByte() }

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/JoinGroup.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/JoinGroup.kt
@@ -33,14 +33,15 @@ open class JoinGroup {
     @Setup(Level.Invocation)
     fun setup() {
         runBlocking {
-            val aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            val options = CcInitOptions(CcInitOptions.Mode.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            val aliceCc = ccInit(options)
             conversationId = createConversation(aliceCc)
 
             val keyPackages = mutableListOf<KeyPackage>()
 
             if (userCount > 1) {
                 repeat(userCount) {
-                    val bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+                    val bobCc = ccInit(options)
                     val kp = generateKeyPackage(bobCc)
                     keyPackages.add(kp)
                 }
@@ -49,7 +50,7 @@ open class JoinGroup {
                 }
             }
 
-            charlieCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            charlieCc = ccInit(options)
             val kp = generateKeyPackage(charlieCc)
 
             aliceCc.transaction {

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/ProcessMessage.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/ProcessMessage.kt
@@ -39,10 +39,11 @@ open class ProcessMessage {
 
     @Setup(Level.Invocation)
     fun setup() = runBlocking {
-        val aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+        val options = CcInitOptions.Mode.WithBasicCredential(CipherSuite.valueOf(cipherSuite))
+        val aliceCc = ccInit(CcInitOptions(options))
         conversationId = createConversation(aliceCc)
 
-        bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+        bobCc = ccInit(CcInitOptions(options))
         invite(aliceCc, bobCc, conversationId)
 
         val messages = List(messageCount) {

--- a/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/RemoveUser.kt
+++ b/crypto-ffi/bindings/jvm/src/jmh/kotlin/com/wire/benchmark/RemoveUser.kt
@@ -35,14 +35,20 @@ open class RemoveUser {
     @Setup(Level.Invocation)
     fun setup() {
         runBlocking {
-            aliceCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite)))
+            aliceCc = ccInit(CcInitOptions(CcInitOptions.Mode.WithBasicCredential(CipherSuite.valueOf(cipherSuite))))
             conversationId = createConversation(aliceCc)
 
             val keyPackages = mutableListOf<KeyPackage>()
             clientIdsToRemove = buildList {
                 repeat(userCount) {
                     val bobId = genClientId()
-                    val bobCc = ccInit(CcInitOptions.WithBasicCredential(CipherSuite.valueOf(cipherSuite), bobId))
+                    val bobCc =
+                        ccInit(
+                            CcInitOptions(
+                                mode = CcInitOptions.Mode.WithBasicCredential(CipherSuite.valueOf(cipherSuite)),
+                                clientId = bobId
+                            )
+                        )
                     val kp = generateKeyPackage(bobCc)
                     keyPackages.add(kp)
                     this.add(bobId)

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/E2EITest.kt
@@ -111,7 +111,7 @@ internal class E2EITest {
             validityPeriodSecs = 3600uL
         )
 
-        val cc = ccInit(CcInitOptions.WithBasicCredential(clientId = clientId, database = db))
+        val cc = ccInit(CcInitOptions(clientId = clientId, database = db))
         val credentialRef = cc.findCredentials(clientId = clientId).first()
 
         val acquisition = X509CredentialAcquisition.newFromCredentialRef(pkiEnv, config, credentialRef)

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -563,6 +563,17 @@ class MLSTest {
     }
 
     @Test
+    fun canCheckCredentials(): TestResult {
+        val scope = TestScope()
+        return scope.runTest {
+            val cc = ccInit(CcInitOptions(withPkiEnvironment = true))
+            cc.transaction { ctx ->
+                ctx.checkCredentials()
+            }
+        }
+    }
+
+    @Test
     fun can_search_credentials_by_cipher_suite(): TestResult {
         val scope = TestScope()
         return scope.runTest {

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/MLSTest.kt
@@ -135,7 +135,7 @@ class MLSTest {
     @Test
     fun findCredentials_should_return_non_empty_result() = runTest {
         val clientId = genClientId()
-        val alice = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, clientId))
+        val alice = ccInit(CcInitOptions(clientId = clientId))
         assertThat(alice.findCredentials(clientId = clientId)).isNotEmpty()
     }
 
@@ -235,11 +235,11 @@ class MLSTest {
     @Test
     fun addClientsToConversation_should_add_members_to_the_MLS_group() = runTest {
         val aliceId = genClientId()
-        val alice = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, aliceId))
+        val alice = ccInit(CcInitOptions(clientId = aliceId))
         val bobId = genClientId()
-        val bob = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, bobId))
+        val bob = ccInit(CcInitOptions(clientId = bobId))
         val carolId = genClientId()
-        val carol = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, carolId))
+        val carol = ccInit(CcInitOptions(clientId = carolId))
 
         val conversationId = createConversation(bob)
         invite(bob, alice, conversationId)
@@ -270,7 +270,7 @@ class MLSTest {
         val alice = ccInit()
         val bob = ccInit()
         val carolId = genClientId()
-        val carol = ccInit(CcInitOptions.WithBasicCredential(CIPHERSUITE_DEFAULT, carolId))
+        val carol = ccInit(CcInitOptions(clientId = carolId))
         val conversationId = createConversation(bob)
         invite(bob, alice, conversationId)
         invite(bob, carol, conversationId)
@@ -297,7 +297,7 @@ class MLSTest {
 
     @Test
     fun givenTransactionRunsSuccessfully_thenShouldBeAbleToFinishOtherTransactions() = runTest {
-        val coreCrypto = ccInit(CcInitOptions.WithoutBasicCredential())
+        val coreCrypto = ccInit(CcInitOptions(mode = CcInitOptions.Mode.WithoutBasicCredential))
         val someWork = Job()
         val firstTransactionJob = launch {
             coreCrypto.transaction {
@@ -318,7 +318,7 @@ class MLSTest {
 
     @Test
     fun givenTransactionIsCancelled_thenShouldBeAbleToFinishOtherTransactions() = runTest {
-        val coreCrypto = ccInit(CcInitOptions.WithoutBasicCredential())
+        val coreCrypto = ccInit(CcInitOptions(CcInitOptions.Mode.WithoutBasicCredential))
 
         val firstTransactionJob = launch {
             coreCrypto.transaction {
@@ -574,7 +574,7 @@ class MLSTest {
                 CipherSuite.MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_ED25519
             val credential2 = Credential.basic(cipherSuite2, clientId)
 
-            val cc = ccInit(CcInitOptions.WithoutBasicCredential(clientId))
+            val cc = ccInit(CcInitOptions(CcInitOptions.Mode.WithoutBasicCredential, clientId))
             cc.transaction { ctx ->
                 ctx.addCredential(credential1)
                 ctx.addCredential(credential2)
@@ -678,7 +678,7 @@ class MLSTest {
                 clientId
             )
 
-            val cc = ccInit(CcInitOptions.WithoutBasicCredential(clientId))
+            val cc = ccInit(CcInitOptions(CcInitOptions.Mode.WithoutBasicCredential, clientId))
 
             cc.transaction { ctx ->
                 val cref1 = ctx.addCredential(credential1)

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/testutils/TestUtils.kt
@@ -102,48 +102,56 @@ class MockPkiEnvironmentHooks : PkiEnvironmentHooks {
     }
 }
 
-sealed interface CcInitOptions {
-    val clientId: ClientId?
-    val database: Database?
+data class CcInitOptions(
+    val mode: Mode = Mode.WithBasicCredential(),
+    val clientId: ClientId? = null,
+    val database: Database? = null,
+    val withPkiEnvironment: Boolean = false,
+) {
+    sealed interface Mode {
+        data object WithoutBasicCredential : Mode
 
-    data class WithoutBasicCredential(
-        override val clientId: ClientId? = null,
-        override val database: Database? = null,
-    ) : CcInitOptions
-
-    data class WithBasicCredential(
-        val cipherSuite: CipherSuite = CIPHERSUITE_DEFAULT,
-        override val clientId: ClientId? = null,
-        override val database: Database? = null,
-    ) : CcInitOptions
+        data class WithBasicCredential(
+            val cipherSuite: CipherSuite = CIPHERSUITE_DEFAULT
+        ) : Mode
+    }
 }
 
 suspend fun ccInit(
-    options: CcInitOptions = CcInitOptions.WithBasicCredential()
+    options: CcInitOptions = CcInitOptions()
 ): CoreCrypto {
     val db = options.database ?: newDatabase()
     val cc = CoreCrypto(db)
 
     val clientId = options.clientId ?: genClientId()
 
-    cc.transaction { ctx ->
-        ctx.mlsInit(clientId, MockMlsTransportSuccessProvider.getInstance())
+    if (options.withPkiEnvironment) {
+        val pkiEnvironment = PkiEnvironment.new(MockPkiEnvironmentHooks(), db)
+        cc.setPkiEnvironment(pkiEnvironment)
+    }
 
-        when (options) {
-            is CcInitOptions.WithBasicCredential -> {
+    cc.transaction { ctx ->
+        ctx.mlsInit(
+            clientId,
+            MockMlsTransportSuccessProvider.getInstance()
+        )
+
+        when (val mode = options.mode) {
+            is CcInitOptions.Mode.WithBasicCredential -> {
                 ctx.addCredential(
                     Credential.basic(
-                        options.cipherSuite,
+                        mode.cipherSuite,
                         clientId
                     )
                 )
             }
 
-            is CcInitOptions.WithoutBasicCredential -> {
+            CcInitOptions.Mode.WithoutBasicCredential -> {
                 // nothing
             }
         }
     }
+
     return cc
 }
 

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -785,6 +785,14 @@ final class WireCoreCryptoTests: XCTestCase {
         XCTAssertThrowsError(try ExternalSender.parseJwk(jwk: Data([0, 1, 2, 3])))
     }
 
+    func testCheckCredentials() async throws {
+        let coreCrypto = try await ccInit(
+            options: CcInitOptions(withPkiEnvironment: true))
+        try await coreCrypto.transaction { ctx in
+            try await ctx.checkCredentials()
+        }
+    }
+
     // MARK: - helpers
 
     final actor MockMlsTransport: MlsTransport {

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -405,8 +405,10 @@ final class WireCoreCryptoTests: XCTestCase {
 
         let cipherSuite1 = CipherSuite.mls128Dhkemp256Aes128gcmSha256P256
         let alice = try await ccInit(
-            options: CcInitOptions.withBasicCredential(
-                cipherSuite: cipherSuite1, clientId: clientId))
+            options: CcInitOptions(
+                mode: .withBasicCredential(cipherSuite: cipherSuite1),
+                clientId: clientId
+            ))
 
         let cipherSuite2 = CipherSuite.mls128Dhkemx25519Chacha20poly1305Sha256Ed25519
         let credential2 = try Credential.basic(cipherSuite: cipherSuite2, clientId: clientId)
@@ -626,7 +628,10 @@ final class WireCoreCryptoTests: XCTestCase {
         )
 
         let alice = try await ccInit(
-            options: CcInitOptions.withoutBasicCredential(clientId: clientId))
+            options: CcInitOptions(
+                mode: .withoutBasicCredential,
+                clientId: clientId
+            ))
 
         try await alice.transaction { ctx in
             let cref1 = try await ctx.addCredential(credential: credential1)
@@ -716,9 +721,6 @@ final class WireCoreCryptoTests: XCTestCase {
     }
 
     func testCanInstantiateX509CredentialAcquisitionFromCredentialRef() async throws {
-        let database = try await newDatabase()
-        let pkiEnvironment = try await PkiEnvironment(
-            hooks: MockPkiEnvironmentHooks(), database: database)
         let qualifiedClientId = try ClientId(
             bytes: Data("LcksJb74Tm6N12cDjFy7lQ:8e6424430d3b28be@world.com".utf8)
         ).parseQualified()
@@ -735,7 +737,10 @@ final class WireCoreCryptoTests: XCTestCase {
         )
 
         let coreCrypto = try await ccInit(
-            options: .withBasicCredential(clientId: clientId, database: database))
+            options: CcInitOptions(
+                clientId: clientId, withPkiEnvironment: true
+            ))
+        let pkiEnvironment = await coreCrypto.getPkiEnvironment()!
 
         let credentialRef = try await coreCrypto.findCredentials(clientId: clientId).first!
 

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -844,38 +844,8 @@ final class WireCoreCryptoTests: XCTestCase {
         return try await Database.open(location: keystore.path, key: genDatabaseKey())
     }
 
-    enum CcInitOptions {
-        case withoutBasicCredential(clientId: ClientId? = nil, database: Database? = nil)
-
-        case withBasicCredential(
-            cipherSuite: CipherSuite = cipherSuiteDefault(),
-            clientId: ClientId? = nil,
-            database: Database? = nil
-        )
-
-        var clientId: ClientId? {
-            switch self {
-            case .withoutBasicCredential(let clientId, _):
-                return clientId
-
-            case .withBasicCredential(_, let clientId, _):
-                return clientId
-            }
-        }
-
-        var database: Database? {
-            switch self {
-            case .withoutBasicCredential(_, let database):
-                return database
-
-            case .withBasicCredential(_, _, let database):
-                return database
-            }
-        }
-    }
-
     func ccInit(
-        options: CcInitOptions = .withBasicCredential()
+        options: CcInitOptions = CcInitOptions()
     ) async throws -> CoreCrypto {
 
         let database: Database
@@ -886,6 +856,14 @@ final class WireCoreCryptoTests: XCTestCase {
         }
         let coreCrypto = try CoreCrypto(database: database)
 
+        if options.withPkiEnvironment {
+            let pkiEnvironment = try await PkiEnvironment(
+                hooks: MockPkiEnvironmentHooks(),
+                database: database
+            )
+            await coreCrypto.setPkiEnvironment(pkiEnvironment: pkiEnvironment)
+        }
+
         let clientId = options.clientId ?? genClientId()
 
         try await coreCrypto.transaction { ctx in
@@ -894,14 +872,14 @@ final class WireCoreCryptoTests: XCTestCase {
                 transport: self.mockMlsTransport
             )
 
-            switch options {
-            case .withBasicCredential(let cipherSuite, _, _):
+            switch options.mode {
+
+            case .withBasicCredential(let cipherSuite):
                 _ = try await ctx.addCredential(
-                    credential:
-                        Credential.basic(
-                            cipherSuite: cipherSuite,
-                            clientId: clientId
-                        )
+                    credential: Credential.basic(
+                        cipherSuite: cipherSuite,
+                        clientId: clientId
+                    )
                 )
 
             case .withoutBasicCredential:
@@ -1075,5 +1053,29 @@ extension Data {
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+struct CcInitOptions {
+    enum Mode {
+        case withoutBasicCredential
+        case withBasicCredential(cipherSuite: CipherSuite = cipherSuiteDefault())
+    }
+
+    let mode: Mode
+    let clientId: ClientId?
+    let database: Database?
+    let withPkiEnvironment: Bool
+
+    init(
+        mode: Mode = .withBasicCredential(),
+        clientId: ClientId? = nil,
+        database: Database? = nil,
+        withPkiEnvironment: Bool = false
+    ) {
+        self.mode = mode
+        self.clientId = clientId
+        self.database = database
+        self.withPkiEnvironment = withPkiEnvironment
     }
 }

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -336,6 +336,14 @@ impl CoreCryptoContext {
         Ok(())
     }
 
+    /// Check all X509 credentials for expiration and revocation
+    ///
+    /// This function must be called at least once every 24 hours. It is recommended to do this during an idle period,
+    /// because in case x509 credentials are used, HTTP requests are done to fetch new certificate revocation lists.
+    pub async fn check_credentials(&self) -> CoreCryptoResult<()> {
+        self.inner.check_credentials().await.map_err(Into::into)
+    }
+
     /// Generate a `KeyPackage` from the referenced credential.
     ///
     /// Makes no attempt to look up or prune existing keypackages.

--- a/crypto/src/mls/credential/x509.rs
+++ b/crypto/src/mls/credential/x509.rs
@@ -18,7 +18,10 @@ use super::{Error, Result};
 use crate::mls_provider::PkiKeypair;
 #[cfg(test)]
 use crate::test_utils::x509::X509Certificate;
-use crate::{CipherSuite, ClientId, Credential, CredentialType, OpenMlsError, RecursiveError};
+use crate::{
+    CipherSuite, ClientId, Credential, CredentialType, OpenMlsError, RecursiveError,
+    mls::credential::ext::CredentialExt as _,
+};
 
 #[derive(core_crypto_macros::Debug, Clone, Zeroize, derive::Constructor)]
 #[zeroize(drop)]
@@ -134,6 +137,28 @@ impl Credential {
             earliest_validity,
         };
         Ok(cb)
+    }
+
+    /// Check an X509 Credential for expiration or revocation
+    ///
+    /// For now we only care about X509 credentials which require the pki_env as an external resource.
+    /// As soon as we have validation logic for other types the pki_env parameter becomes very smelly.
+    /// Other credential types will just return.
+    pub(crate) async fn check(&self, pki_env: &PkiEnvironment) -> Result<()> {
+        if self.credential_type == CredentialType::X509 {
+            let cert = self
+                .mls_credential()
+                .parse_leaf_cert()
+                .map_err(RecursiveError::mls_credential("parsing leaf certificate"))?
+                // This can actually never happen and points to a type issue with credentials
+                .expect("parse_leaf_cert to return a Certificate");
+
+            pki_env
+                .validate_cert(&cert)
+                .await
+                .map_err(RecursiveError::e2e_identity("validating credential certificate"))?;
+        }
+        Ok(())
     }
 }
 

--- a/crypto/src/transaction_context/credential/check.rs
+++ b/crypto/src/transaction_context/credential/check.rs
@@ -1,5 +1,5 @@
 use core_crypto_keystore::{entities::E2eiCrl, traits::FetchFromDatabase};
-use wire_e2e_identity::{pki_env::PkiEnvironment, x509_check::extract_crl_uris};
+use wire_e2e_identity::x509_check::extract_crl_uris;
 use x509_cert::Certificate;
 
 use super::{Error, Result};
@@ -7,15 +7,13 @@ use crate::{
     Credential, CredentialRef, CredentialType, KeystoreError, RecursiveError,
     mls::{
         conversation::Conversation,
-        credential::{
-            crl::{CrlUris, extract_crl_uris_from_credentials, extract_crl_uris_from_group},
-            ext::CredentialExt as _,
-        },
+        credential::crl::{CrlUris, extract_crl_uris_from_credentials, extract_crl_uris_from_group},
     },
     transaction_context::TransactionContext,
 };
 
 impl TransactionContext {
+    /// Check all X509 credentials for expiration and revocation
     /// This function must be called at least once every 24 hours. It is recommended to do this during an idle period,
     /// because in case x509 credentials are used, HTTP requests are done to fetch new certificate revocation lists.
     pub async fn check_credentials(&self) -> Result<()> {
@@ -52,9 +50,11 @@ impl TransactionContext {
 
         let mut invalid_credential_refs = Vec::new();
 
-        // check our own credentials for expiration or revocation
+        // Check our own x509 credentials for expiration or revocation
+        // Ideally, we can load credentials by type from db as we actually only care about X509 checks.
+        // Unfortunately, this is not supported yet.
         for credential in credentials {
-            if self.check_credential(&env, &credential).await.is_err() {
+            if credential.check(&env).await.is_err() {
                 invalid_credential_refs.push(CredentialRef::from_credential(&credential));
             }
         }
@@ -98,19 +98,6 @@ impl TransactionContext {
         }
 
         Ok(crl_uris)
-    }
-
-    async fn check_credential(&self, pki_env: &PkiEnvironment, credential: &Credential) -> Result<()> {
-        let cert = credential
-            .mls_credential()
-            .parse_leaf_cert()
-            .map_err(RecursiveError::mls_credential("parsing leaf certificate"))?
-            .ok_or(Error::InvalidCredential)?;
-        pki_env
-            .validate_cert(&cert)
-            .await
-            .map_err(RecursiveError::e2e_identity("validating credential certificate"))?;
-        Ok(())
     }
 
     async fn clean_up_irrelevant_crls(&self, relevant_crl_uris: &CrlUris) -> Result<()> {

--- a/crypto/src/transaction_context/error.rs
+++ b/crypto/src/transaction_context/error.rs
@@ -44,8 +44,6 @@ pub enum Error {
     CredentialStillInUse(ConversationId),
     #[error("The supplied credential does not match the id this CC instance was initialized with")]
     WrongCredential,
-    #[error("The supplied credential is invalid")]
-    InvalidCredential,
     #[error(
         "There are invalid CredentialRefs that should be removed. Hex encoded sha256 hashes: {}",
         format_invalid_credential_refs(.0)


### PR DESCRIPTION
# What's new in this PR

This adds `TransactionContext.check_credentials` to the FFI.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
