### PR TITLE
fix: remove ExternalSenderKey from the ffi which has been replaced by ExternalSender

### DIFF
--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -47,14 +47,6 @@ bytes_wrapper!(
     SecretKey
 );
 
-bytes_wrapper!(
-    /// The raw public key of an external sender.
-    ///
-    /// This can be used to initialize a subconversation.
-    #[derive(Clone)]
-    ExternalSenderKey
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
# What's new in this PR

Remove ExternalSenderKey from the ffi which has been replaced by ExternalSender

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
