### PR TITLE
feat(ts-native):  add `PkiEnvironment` constructor

### DIFF
--- a/cc-book/src/cc10/whats-new.md
+++ b/cc-book/src/cc10/whats-new.md
@@ -22,7 +22,10 @@ With CC10 we introduce multiple new types that provide their own new API.
 
 ### PKI Environment API
 
-- Added `PkiEnvironment` constructed via `createPkiEnvironment(database: Database, hooks: PkiEnvironmentHooks)`
+- Added `PkiEnvironment`constructed via
+  - `PkiEnvironment(database: Database, hooks: PkiEnvironmentHooks)` (swift)
+  - `PkiEnvironment.new(database: Database, hooks: PkiEnvironmentHooks)` (kotlin)
+  - `PkiEnvironment.create(database: Database, hooks: PkiEnvironmentHooks)` (ts)
 - Added `PkiEnvironmentHooks` interface which has to be implemented by a client and will be used by CoreCrypto during
   e2ei flow
 - Added `CoreCrypto.setPkiEnvironment()` to set a PkiEnvironment on a `CoreCrypto` instance

--- a/crypto-ffi/src/lib.rs
+++ b/crypto-ffi/src/lib.rs
@@ -75,7 +75,7 @@ pub use identity::{
 };
 pub use key_package::{KeyPackage, KeyPackageRef};
 pub use metadata::{BuildMetadata, build_metadata, version};
-#[cfg(not(any(feature = "wasm", target_os = "unknown")))]
+#[cfg(not(any(feature = "wasm", feature = "napi", target_os = "unknown")))]
 pub use pki_env::create_pki_environment;
 pub use pki_env::{HttpHeader, HttpMethod, HttpResponse, PkiEnvironment, PkiEnvironmentHooks};
 pub use signature_scheme::SignatureScheme;

--- a/crypto-ffi/src/pki_env.rs
+++ b/crypto-ffi/src/pki_env.rs
@@ -241,10 +241,10 @@ impl PkiEnvironment {
     }
 }
 
-#[cfg_attr(feature = "wasm", uniffi::export)]
+#[cfg_attr(any(feature = "wasm", feature = "napi"), uniffi::export)]
 impl PkiEnvironment {
     /// Create a new PKI environment.
-    #[cfg_attr(feature = "wasm", uniffi::constructor)]
+    #[cfg_attr(any(feature = "wasm", feature = "napi"), uniffi::constructor)]
     pub async fn new(hooks: Arc<dyn PkiEnvironmentHooks>, database: Arc<Database>) -> CoreCryptoResult<Self> {
         let shim = Arc::new(PkiEnvironmentHooksShim::new(hooks));
         let pki_env = wire_e2e_identity::pki_env::PkiEnvironment::new(shim, database.as_ref().clone().into()).await?;
@@ -273,7 +273,7 @@ impl PkiEnvironment {
 }
 
 /// Create a new PKI environment.
-#[cfg(not(any(feature = "wasm", target_os = "unknown")))]
+#[cfg(not(any(feature = "wasm", feature = "napi", target_os = "unknown")))]
 #[uniffi::export]
 pub async fn create_pki_environment(
     hooks: Arc<dyn PkiEnvironmentHooks>,


### PR DESCRIPTION
# What's new in this PR

This PR adds the missing `PkiEnvironment` constructor to ts-native bindings.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
