### PR TITLE
refactor: align external sender

### DIFF
--- a/crypto-ffi/bindings/js/packages/browser/test/externalSender.test.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/externalSender.test.ts
@@ -39,7 +39,7 @@ describe("external sender", () => {
                 });
 
                 return [
-                    Array.from(retrievedKey.copyBytes()),
+                    Array.from(retrievedKey.serialize()),
                     Array.from(externalSender.serialize()),
                 ];
             },

--- a/crypto-ffi/bindings/js/packages/native/test/externalSender.test.ts
+++ b/crypto-ffi/bindings/js/packages/native/test/externalSender.test.ts
@@ -34,7 +34,7 @@ describe("external sender", () => {
             return await ctx.getExternalSender(conversationId);
         });
 
-        expect(retrievedKey.copyBytes()).toEqual(externalSender.serialize());
+        expect(retrievedKey.serialize()).toEqual(externalSender.serialize());
     });
 
     test("parsePublicKey accepts the bytes produced by serialize", () => {

--- a/crypto-ffi/bindings/js/packages/shared/src/CoreCrypto.ts
+++ b/crypto-ffi/bindings/js/packages/shared/src/CoreCrypto.ts
@@ -54,7 +54,6 @@ export {
     type MlsTransportData,
     migrateDatabaseKeyTypeToBytes,
     ExternalSender,
-    ExternalSenderKey,
     GroupInfo,
     ConversationId,
     Welcome,

--- a/crypto-ffi/bindings/shared/src/commonMain/kotlin/com/wire/crypto/MlsModel.kt
+++ b/crypto-ffi/bindings/shared/src/commonMain/kotlin/com/wire/crypto/MlsModel.kt
@@ -12,9 +12,6 @@ val CREDENTIAL_TYPE_DEFAULT = CredentialType.BASIC
 /** Construct a client ID */
 fun String.toClientId() = ClientId(this.toByteArray())
 
-/** Construct an external sender ID */
-fun ByteArray.toExternalSenderKey() = ExternalSenderKey(this)
-
 /** Construct a Welcome */
 fun ByteArray.toWelcome() = Welcome(this)
 

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/ExternalSenderTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/ExternalSenderTest.kt
@@ -31,7 +31,7 @@ class ExternalSenderTest {
             ctx.getExternalSender(id)
         }
 
-        assertThat(retrievedKey.copyBytes()).isEqualTo(externalSender.serialize())
+        assertThat(retrievedKey).isEqualTo(externalSender)
     }
 
     @Test

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -760,7 +760,7 @@ final class WireCoreCryptoTests: XCTestCase {
         let conversationId = ConversationId(bytes: Data("ext-sender-jwk".utf8))
 
         let credentialRef = try await alice.getCredentials().first!
-        let retrievedKey = try await alice.transaction { ctx -> ExternalSenderKey in
+        let retrievedKey = try await alice.transaction { ctx -> ExternalSender in
             try await ctx.createConversation(
                 conversationId: conversationId,
                 credentialRef: credentialRef,
@@ -769,7 +769,7 @@ final class WireCoreCryptoTests: XCTestCase {
             return try await ctx.getExternalSender(conversationId: conversationId)
         }
 
-        XCTAssertEqual(retrievedKey.copyBytes(), externalSender.serialize())
+        XCTAssertEqual(retrievedKey, externalSender)
     }
 
     func testParsePublicKeyAcceptsBytesProducedBySerialize() throws {

--- a/crypto-ffi/src/core_crypto/conversation.rs
+++ b/crypto-ffi/src/core_crypto/conversation.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, sync::Arc};
 use core_crypto::{RecursiveError, mls::conversation::ConversationIdRef};
 
 use crate::{
-    CipherSuite, ClientId, CoreCryptoFfi, CoreCryptoResult, CredentialRef,
+    CipherSuite, ClientId, CoreCryptoFfi, CoreCryptoResult, CredentialRef, ExternalSender,
     bytes_wrapper::{bytes_wrapper, impl_display_via_hex},
     core_crypto_context::mls::SecretKey,
 };
@@ -108,8 +108,8 @@ impl CoreCryptoFfi {
             .collect())
     }
 
-    /// Returns the serialized public key of the external sender for the given conversation.
-    pub async fn get_external_sender(&self, conversation_id: &ConversationId) -> CoreCryptoResult<Vec<u8>> {
+    /// Returns the external sender for the given conversation.
+    pub async fn get_external_sender(&self, conversation_id: &ConversationId) -> CoreCryptoResult<ExternalSender> {
         let conversation = self
             .inner
             .mls_session()

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -5,8 +5,7 @@ use core_crypto::{ConversationConfiguration, transaction_context::Error as Trans
 use crate::{
     CipherSuite, ClientId, ConversationId, CoreCryptoContext, CoreCryptoError, CoreCryptoResult, Credential,
     CredentialRef, DecryptedMessage, ExternalSender, KeyPackage, KeyPackageRef, MlsTransport,
-    bytes_wrapper::{bytes_wrapper, impl_display_via_hex},
-    core_crypto::mls_transport::callback_shim,
+    bytes_wrapper::bytes_wrapper, core_crypto::mls_transport::callback_shim,
 };
 
 bytes_wrapper!(
@@ -27,16 +26,6 @@ impl fmt::Display for SecretKey {
         f.write_str(data)
     }
 }
-
-bytes_wrapper!(
-    /// The raw public key of an external sender.
-    ///
-    /// This can be used to initialize a subconversation.
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-    #[uniffi::export(Eq, Hash, Display)]
-    ExternalSenderKey infallibly wraps core_crypto::mls::conversation::ExternalSenderKey; copy_bytes
-);
-impl_display_via_hex!(ExternalSenderKey);
 
 /// MLS Group Information
 ///
@@ -175,7 +164,7 @@ impl CoreCryptoContext {
     }
 
     /// Returns the serialized public key of the external sender for the given conversation.
-    pub async fn get_external_sender(&self, conversation_id: &ConversationId) -> CoreCryptoResult<ExternalSenderKey> {
+    pub async fn get_external_sender(&self, conversation_id: &ConversationId) -> CoreCryptoResult<ExternalSender> {
         let conversation = self.inner.conversation(conversation_id.as_ref()).await?;
         conversation
             .get_external_sender()

--- a/crypto/src/mls/conversation/immutable/mod.rs
+++ b/crypto/src/mls/conversation/immutable/mod.rs
@@ -9,8 +9,10 @@ mod persistence;
 use async_lock::{RwLock, RwLockReadGuard};
 use openmls::group::MlsGroup;
 
-use super::{ConversationIdRef, Error, ExternalSenderKey, Result, SecretKey};
-use crate::{CipherSuite, ConversationConfiguration, ConversationId, CredentialRef, OpenMlsError, Session};
+use super::{ConversationIdRef, Error, Result, SecretKey};
+use crate::{
+    CipherSuite, ConversationConfiguration, ConversationId, CredentialRef, ExternalSender, OpenMlsError, Session,
+};
 
 /// A Conversation exposes the read-only interface of an MLS conversation.
 #[derive(Debug, derive_more::Constructor)]
@@ -80,18 +82,17 @@ impl Conversation {
             .map_err(Into::into)
     }
 
-    /// Returns the raw public key of the first external sender present in this group.
+    /// Returns the first external sender present in this group.
     ///
     /// This should be used to initialize a subconversation
-    pub async fn get_external_sender(&self) -> Result<ExternalSenderKey> {
+    pub async fn get_external_sender(&self) -> Result<ExternalSender> {
         let group = self.group().await;
         let ext_senders = group
             .group_context_extensions()
             .external_senders()
             .ok_or(Error::MissingExternalSenderExtension)?;
         let ext_sender = ext_senders.first().ok_or(Error::MissingExternalSenderExtension)?;
-        let ext_sender_public_key = ext_sender.signature_key().as_slice().to_vec().into();
-        Ok(ext_sender_public_key)
+        Ok(ext_sender.clone().into())
     }
 }
 

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -47,14 +47,6 @@ bytes_wrapper!(
     SecretKey
 );
 
-bytes_wrapper!(
-    /// The raw public key of an external sender.
-    ///
-    /// This can be used to initialize a subconversation.
-    #[derive(Clone)]
-    ExternalSenderKey
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -426,9 +418,10 @@ mod tests {
                     .await;
 
                 let alice_ext_sender = conversation.guard().await.get_external_sender().await.unwrap();
-                assert!(!alice_ext_sender.is_empty());
+                let signature_key: Vec<u8> = alice_ext_sender.signature_key().as_slice().to_vec();
+                assert!(!signature_key.is_empty());
                 assert_eq!(
-                    Sha256Hash::hash_from(alice_ext_sender),
+                    Sha256Hash::hash_from(&signature_key),
                     external_sender.initial_credential.public_key_hash()
                 );
             })


### PR DESCRIPTION
# What's new in this PR

Replace `ExternalSenderKey` with `ExternalSender`.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
