### PR TITLE
feat: allow removing trust anchors

### DIFF
--- a/e2e-identity/src/pki_env/mod.rs
+++ b/e2e-identity/src/pki_env/mod.rs
@@ -16,7 +16,7 @@ use core_crypto_keystore::{
     CryptoKeystoreError,
     connection::Database,
     entities::{E2eiAcmeCA, E2eiCrl, E2eiIntermediateCert},
-    traits::FetchFromDatabase,
+    traits::{FetchFromDatabase, UnifiedUniqueEntity},
 };
 use openmls_traits::authentication_service::{CredentialAuthenticationStatus, CredentialRef};
 use x509_cert::{
@@ -212,6 +212,49 @@ impl PkiEnvironment {
             .lock()
             .await
             .add_trust_anchor_source(Box::new(trust_anchors));
+        Ok(())
+    }
+
+    /// Remove the trust anchor with serial number `serial_number` from the PKI environment.
+    ///
+    /// Note that any certificates relying on the removed trust anchor may no longer
+    /// validate.
+    pub async fn remove_trust_anchor(&self, serial_number: &[u8]) -> Result<()> {
+        let mut guard = self.rjt_pki_env.lock().await;
+
+        let certs: Vec<_> = guard
+            .get_trust_anchors()
+            .iter()
+            .filter_map(|choice| match choice.decoded_ta {
+                TrustAnchorChoice::Certificate(ref cert)
+                    if cert.tbs_certificate.serial_number.as_bytes() != serial_number =>
+                {
+                    Some(cert.clone())
+                }
+                _ => None,
+            })
+            .collect();
+
+        guard.clear_trust_anchor_sources();
+
+        let mut trust_anchors = TaSource::new();
+        for cert in certs {
+            trust_anchors.push(certval::CertFile {
+                filename: "".to_string(),
+                bytes: cert.to_der()?,
+            });
+        }
+        trust_anchors.initialize().map_err(Error::Certval)?;
+        guard.add_trust_anchor_source(Box::new(trust_anchors));
+
+        // TODO: make this work for multiple trust anchors, see WPB-25632
+        self.transactionally(async || {
+            self.database
+                .remove::<E2eiAcmeCA>(&<E2eiAcmeCA as UnifiedUniqueEntity>::KEY)
+                .await
+        })
+        .await?;
+
         Ok(())
     }
 

--- a/e2e-identity/src/pki_env/mod.rs
+++ b/e2e-identity/src/pki_env/mod.rs
@@ -392,6 +392,25 @@ LOVS/gxNk618+PKA2bYq67MZQXCYGgk=
     }
 
     #[tokio::test]
+    async fn can_remove_trust_anchor() {
+        let db = Database::open(ConnectionType::InMemory, &DatabaseKey::generate())
+            .await
+            .unwrap();
+        let pki_env = PkiEnvironment::with_dummy_hooks(db).await.unwrap();
+        let cert = x509_cert::Certificate::from_pem(EXAMPLE_CERT_PEM).unwrap();
+        pki_env.add_trust_anchor(cert.clone()).await.unwrap();
+
+        let certs = pki_env.get_trust_anchors().await;
+        assert_eq!(certs.len(), 1);
+
+        pki_env
+            .remove_trust_anchor(certs[0].tbs_certificate.serial_number.as_bytes())
+            .await
+            .unwrap();
+        assert_eq!(pki_env.get_trust_anchors().await.len(), 0);
+    }
+
+    #[tokio::test]
     async fn can_add_intermediate_cert() {
         let db = Database::open(ConnectionType::InMemory, &DatabaseKey::generate())
             .await

--- a/e2e-identity/tests/e2e.rs
+++ b/e2e-identity/tests/e2e.rs
@@ -308,12 +308,20 @@ async fn fetching_crls_works(test_env: TestEnvironment, #[case] sign_alg: JwsAlg
 }
 
 // @SF.PROVISIONING @TSFI.ACME
-// TODO: ignore this test for now, until the relevant PKI environment checks are in place
-#[ignore]
 #[rstest]
 #[tokio::test]
-async fn should_fail_when_certificate_path_doesnt_contain_trust_anchor(test_env: TestEnvironment) {
+async fn should_fail_without_trust_anchor(test_env: TestEnvironment) {
     let (pki_env, config) = prepare_pki_env_and_config(&test_env, JwsAlgorithm::P256).await;
+
+    let certs = pki_env.get_trust_anchors().await;
+    assert_eq!(certs.len(), 1);
+
+    pki_env
+        .remove_trust_anchor(certs[0].tbs_certificate.serial_number.as_bytes())
+        .await
+        .unwrap();
+    assert_eq!(pki_env.get_trust_anchors().await.len(), 0);
+
     let acq = X509CredentialAcquisition::try_new(Arc::new(pki_env), config).unwrap();
     let result = acq
         .complete_dpop_challenge()

--- a/keystore/src/transaction/dynamic_dispatch/entity_id.rs
+++ b/keystore/src/transaction/dynamic_dispatch/entity_id.rs
@@ -9,9 +9,9 @@ use crate::{
     CryptoKeystoreError, CryptoKeystoreResult,
     connection::TransactionWrapper,
     entities::{
-        ConsumerData, E2eiCrl, E2eiIntermediateCert, MlsPendingMessage, PersistedMlsGroup, PersistedMlsPendingGroup,
-        StoredBufferedCommit, StoredCredential, StoredE2eiEnrollment, StoredEncryptionKeyPair,
-        StoredEpochEncryptionKeypair, StoredHpkePrivateKey, StoredKeypackage, StoredPskBundle,
+        ConsumerData, E2eiAcmeCA, E2eiCrl, E2eiIntermediateCert, MlsPendingMessage, PersistedMlsGroup,
+        PersistedMlsPendingGroup, StoredBufferedCommit, StoredCredential, StoredE2eiEnrollment,
+        StoredEncryptionKeyPair, StoredEpochEncryptionKeypair, StoredHpkePrivateKey, StoredKeypackage, StoredPskBundle,
     },
     traits::{BorrowPrimaryKey, DeletableBySearchKey as _, Entity, EntityDatabaseMutation, KeyType, OwnedKeyType as _},
     transaction::dynamic_dispatch::EntityType,
@@ -108,7 +108,7 @@ impl EntityId {
             EntityType::E2eiRefreshToken => {
                 E2eiRefreshToken::delete(tx, &self.primary_key::<E2eiRefreshToken>()?).await
             }
-            EntityType::E2eiAcmeCA => Err(CryptoKeystoreError::NotImplemented),
+            EntityType::E2eiAcmeCA => E2eiAcmeCA::delete(tx, &self.primary_key::<E2eiAcmeCA>()?).await,
             EntityType::E2eiIntermediateCert => {
                 E2eiIntermediateCert::delete(tx, &self.primary_key::<E2eiIntermediateCert>()?).await
             }


### PR DESCRIPTION
This adds a way to remove a trust anchor, and makes use of that to re-enable one of our tests.