### PR TITLE
test: e2e-identity: use the correct JSON field name

### DIFF
--- a/e2e-identity/tests/utils/stepca.rs
+++ b/e2e-identity/tests/utils/stepca.rs
@@ -75,7 +75,7 @@ fn generate_authority_config(cfg: &CaCfg) -> serde_json::Value {
                         "provider": {
                             "issuerUrl": issuer,
                             "discoveryBaseUrl": discovery_base_url,
-                            "id_token_signing_alg_values_supported": [
+                            "signatureAlgorithms": [
                                 "RS256",
                                 "ES256",
                                 "ES384",


### PR DESCRIPTION
The field name was changed back in 2024 as part of https://github.com/smallstep/certificates/commit/745017cf9ab0290384aed4c5f60b5701237d54ea but we never updated our test.
