### PR TITLE
fix: nightly benchmark timeouts [WPB-26123]

### DIFF
--- a/.github/workflows/benchmark-ts-browser.yml
+++ b/.github/workflows/benchmark-ts-browser.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Run benchmark
         run: make ts-browser-bench
+        timeout-minutes: 180
 
       # Merge all benchmark results into one file
       - name: Process results

--- a/.github/workflows/benchmark-ts-native.yml
+++ b/.github/workflows/benchmark-ts-native.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Run benchmark
         run: make ts-native-bench
+        timeout-minutes: 180
 
       # Merge all benchmark results into one file
       - name: Process results

--- a/crypto-ffi/bindings/js/packages/browser/benches/wdio.bench.conf.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/wdio.bench.conf.ts
@@ -33,9 +33,9 @@ export const config: WebdriverIO.Config = {
     capabilities,
     mochaOpts: {
         ...baseConfig.mochaOpts,
-        timeout: 3_600_000, // 1 hr
+        timeout: 3_600_000 * 3, // 3 hr
     },
-    waitforTimeout: 3_600_000, // 1 hr
+    waitforTimeout: 3_600_000 * 3, // 3 hr
     services: [
         [
             "static-server",


### PR DESCRIPTION
TS native and browser nightly benchmarks are reliably failing in just over 1h. This feels like a timeout.

This sets the timeout to 3h.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
