### PR TITLE
fix: build process used the wrong gradle task names for sonatype

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -357,7 +357,6 @@ jobs:
     needs: prepare-publish
     uses: ./.github/workflows/publish-jvm.yml
     with:
-        release: true
         staging_repository_id: ${{ needs.prepare-publish.outputs.jvm_staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -370,7 +369,6 @@ jobs:
     needs: prepare-publish
     uses: ./.github/workflows/publish-android.yml
     with:
-        release: true
         staging_repository_id: ${{ needs.prepare-publish.outputs.android_staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -358,6 +358,7 @@ jobs:
     uses: ./.github/workflows/publish-jvm.yml
     with:
         release: true
+        staging_repository_id: ${{ needs.prepare-publish.outputs.jvm_staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -370,6 +371,7 @@ jobs:
     uses: ./.github/workflows/publish-android.yml
     with:
         release: true
+        staging_repository_id: ${{ needs.prepare-publish.outputs.android_staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/prepare-publish-android.yml
+++ b/.github/workflows/prepare-publish-android.yml
@@ -1,0 +1,79 @@
+name: prepare to publish android packages
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}-prepare-publish-android"
+
+on:
+  workflow_call:
+    secrets:
+      SONATYPE_USERNAME:
+        required: true
+      SONATYPE_PASSWORD:
+        required: true
+      PGP_KEY_ID:
+        required: true
+      PGP_SIGNING_KEY:
+        required: true
+      PGP_PASSPHRASE:
+        required: true
+    outputs:
+      staging_repository_id:
+        description: "The Sonatype staging repository id created during the prepare phase."
+        value: ${{ jobs.android.outputs.staging_repository_id }}
+
+env:
+  RELEASE: 1
+
+jobs:
+  android:
+    if: github.repository == 'wireapp/core-crypto'
+    runs-on: ubuntu-latest
+    outputs:
+      staging_repository_id: ${{ steps.stage.outputs.staging_repository_id }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: set up jdk 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: adopt
+
+      - name: gradle setup
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: setup android sdk
+        uses: android-actions/setup-android@v4
+
+      - name: download android package
+        uses: ./.github/actions/make/android/package
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+
+      - name: stage artifact in sonatype
+        id: stage
+        run: |
+          cd crypto-ffi/bindings
+          ./gradlew :android:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache | tee gradle-stage.log
+
+          # grepping logs for this stuff isn't ideal, but technically should work, as long as the log string
+          # never changes. But we should keep an eye on it. Currently:
+          # https://github.com/gradle-nexus/publish-plugin/blob/c550fe9a15d177bad06b7902af9e497f837b6579/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt#L47
+          repo_id=$(grep -oP "Created staging repository '\K[^']+" gradle-stage.log | head -n1)
+          if [[ -z "$repo_id" ]]; then
+            echo "::error ::Could not determine the staging repository id from the Gradle output"
+            exit 1
+          fi
+          echo "::notice title=Android staging repository::Created and closed staging repository ${repo_id}"
+          echo "staging_repository_id=${repo_id}" >> "$GITHUB_OUTPUT"
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/prepare-publish-jvm.yml
+++ b/.github/workflows/prepare-publish-jvm.yml
@@ -1,0 +1,93 @@
+name: prepare to publish jvm packages
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}-prepare-publish-jvm"
+
+on:
+  workflow_call:
+    secrets:
+      SONATYPE_USERNAME:
+        required: true
+      SONATYPE_PASSWORD:
+        required: true
+      PGP_KEY_ID:
+        required: true
+      PGP_SIGNING_KEY:
+        required: true
+      PGP_PASSPHRASE:
+        required: true
+    outputs:
+      staging_repository_id:
+        description: "The Sonatype staging repository id created during the prepare phase."
+        value: ${{ jobs.jvm.outputs.staging_repository_id }}
+
+env:
+  RELEASE: 1
+
+jobs:
+  jvm:
+    if: github.repository == 'wireapp/core-crypto'
+    runs-on: ubuntu-latest
+    outputs:
+      staging_repository_id: ${{ steps.stage.outputs.staging_repository_id }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: set up jdk 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: 25
+          distribution: adopt
+
+      - name: gradle setup
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
+      - name: validate gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: download jvm bindings
+        uses: ./.github/actions/make/bindings-kotlin-jvm
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+
+      - name: download x86_64 linux artifact
+        uses: ./.github/actions/make/jvm
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+
+      # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
+      # Because this workflow runs on ubuntu, we're using the generic action
+      - name: download aarch64 apple darwin artifact
+        uses: ./.github/actions/make
+        with:
+          key: jvm-darwin
+          make-rule: jvm-darwin
+          target-path: target/aarch64-apple-darwin/release/libcore_crypto_ffi.dylib
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+
+      - name: stage artifact in sonatype
+        id: stage
+        run: |
+          cd crypto-ffi/bindings
+          ./gradlew :jvm:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache | tee gradle-stage.log
+
+          # grepping logs for this stuff isn't ideal, but technically should work, as long as the log string
+          # never changes. But we should keep an eye on it. Currently:
+          # https://github.com/gradle-nexus/publish-plugin/blob/c550fe9a15d177bad06b7902af9e497f837b6579/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt#L47
+          repo_id=$(grep -oP "Created staging repository '\K[^']+" gradle-stage.log | head -n1)
+          if [[ -z "$repo_id" ]]; then
+            echo "::error ::Could not determine the staging repository id from the Gradle output"
+            exit 1
+          fi
+          echo "::notice title=JVM staging repository::Created and closed staging repository ${repo_id}"
+          echo "staging_repository_id=${repo_id}" >> "$GITHUB_OUTPUT"
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -2,6 +2,13 @@ name: prepare publish
 
 on:
   workflow_call:
+    outputs:
+      jvm_staging_repository_id:
+        description: "Sonatype staging repository id staged for the jvm packages."
+        value: ${{ jobs.jvm.outputs.staging_repository_id }}
+      android_staging_repository_id:
+        description: "Sonatype staging repository id staged for the android packages."
+        value: ${{ jobs.android.outputs.staging_repository_id }}
     secrets:
       SONATYPE_USERNAME:
         required: true

--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -49,9 +49,7 @@ jobs:
 
   jvm:
     needs: verify-tag
-    uses: ./.github/workflows/publish-jvm.yml
-    with:
-      prepare: true
+    uses: ./.github/workflows/prepare-publish-jvm.yml
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -61,9 +59,7 @@ jobs:
 
   android:
     needs: verify-tag
-    uses: ./.github/workflows/publish-android.yml
-    with:
-      prepare: true
+    uses: ./.github/workflows/prepare-publish-android.yml
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -27,6 +27,15 @@ on:
           required: false
           type: boolean
           default: false
+        staging_repository_id:
+          description: "Sonatype staging repository id to release, as emitted by the prepare phase. If empty, the release falls back to discovery by description."
+          required: false
+          type: string
+          default: ""
+    outputs:
+      staging_repository_id:
+        description: "The Sonatype staging repository id created during the prepare phase."
+        value: ${{ jobs.android.outputs.staging_repository_id }}
 
 env:
   RELEASE: 1
@@ -35,6 +44,8 @@ jobs:
   android:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
+    outputs:
+      staging_repository_id: ${{ steps.stage.outputs.staging_repository_id }}
     steps:
       - uses: actions/checkout@v6.0.2
       - name: set up jdk 25
@@ -58,9 +69,21 @@ jobs:
 
       - name: stage artifact
         if: ${{ inputs.prepare == true }}
+        id: stage
         run: |
           cd crypto-ffi/bindings
-          ./gradlew :android:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache
+          ./gradlew :android:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache | tee gradle-stage.log
+
+          # grepping logs for this stuff isn't ideal, but technically should work, as long as the log string
+          # never changes. But we should keep an eye on it. Currently:
+          # https://github.com/gradle-nexus/publish-plugin/blob/c550fe9a15d177bad06b7902af9e497f837b6579/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt#L47
+          repo_id=$(grep -oP "Created staging repository '\K[^']+" gradle-stage.log | head -n1)
+          if [[ -z "$repo_id" ]]; then
+            echo "::error ::Could not determine the staging repository id from the Gradle output"
+            exit 1
+          fi
+          echo "::notice title=Android staging repository::Created and closed staging repository ${repo_id}"
+          echo "staging_repository_id=${repo_id}" >> "$GITHUB_OUTPUT"
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -72,8 +95,14 @@ jobs:
         if: ${{ inputs.release == true }}
         run: |
           cd crypto-ffi/bindings
-          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
+          if [[ -n "$STAGING_REPOSITORY_ID" ]]; then
+            ./gradlew releaseSonatypeStagingRepository --staging-repository-id="$STAGING_REPOSITORY_ID" --no-configuration-cache
+          else
+            echo "::warning ::No staging repository id supplied; discovering the staging repository by description"
+            ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
+          fi
         env:
+          STAGING_REPOSITORY_ID: ${{ inputs.staging_repository_id }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -17,25 +17,10 @@ on:
       PGP_PASSPHRASE:
         required: true
     inputs:
-        prepare:
-          description: "If true, stage and validate artifacts."
-          required: false
-          type: boolean
-          default: false
-        release:
-          description: "If true, release staged artifacts."
-          required: false
-          type: boolean
-          default: false
         staging_repository_id:
-          description: "Sonatype staging repository id to release, as emitted by the prepare phase. If empty, the release falls back to discovery by description."
-          required: false
+          description: "Sonatype staging repository id to release, as emitted by the prepare phase."
+          required: true
           type: string
-          default: ""
-    outputs:
-      staging_repository_id:
-        description: "The Sonatype staging repository id created during the prepare phase."
-        value: ${{ jobs.android.outputs.staging_repository_id }}
 
 env:
   RELEASE: 1
@@ -44,8 +29,6 @@ jobs:
   android:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
-    outputs:
-      staging_repository_id: ${{ steps.stage.outputs.staging_repository_id }}
     steps:
       - uses: actions/checkout@v6.0.2
       - name: set up jdk 25
@@ -61,46 +44,10 @@ jobs:
         uses: gradle/actions/wrapper-validation@v6
       - name: setup android sdk
         uses: android-actions/setup-android@v4
-      - uses: ./.github/actions/make/android/package
-        if: ${{ inputs.prepare == true }}
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
-
-      - name: stage artifact
-        if: ${{ inputs.prepare == true }}
-        id: stage
-        run: |
-          cd crypto-ffi/bindings
-          ./gradlew :android:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache | tee gradle-stage.log
-
-          # grepping logs for this stuff isn't ideal, but technically should work, as long as the log string
-          # never changes. But we should keep an eye on it. Currently:
-          # https://github.com/gradle-nexus/publish-plugin/blob/c550fe9a15d177bad06b7902af9e497f837b6579/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt#L47
-          repo_id=$(grep -oP "Created staging repository '\K[^']+" gradle-stage.log | head -n1)
-          if [[ -z "$repo_id" ]]; then
-            echo "::error ::Could not determine the staging repository id from the Gradle output"
-            exit 1
-          fi
-          echo "::notice title=Android staging repository::Created and closed staging repository ${repo_id}"
-          echo "staging_repository_id=${repo_id}" >> "$GITHUB_OUTPUT"
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}
-
       - name: release artifact
-        if: ${{ inputs.release == true }}
         run: |
           cd crypto-ffi/bindings
-          if [[ -n "$STAGING_REPOSITORY_ID" ]]; then
-            ./gradlew releaseSonatypeStagingRepository --staging-repository-id="$STAGING_REPOSITORY_ID" --no-configuration-cache
-          else
-            echo "::warning ::No staging repository id supplied; discovering the staging repository by description"
-            ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
-          fi
+          ./gradlew releaseSonatypeStagingRepository --staging-repository-id="$STAGING_REPOSITORY_ID" --no-configuration-cache
         env:
           STAGING_REPOSITORY_ID: ${{ inputs.staging_repository_id }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -60,7 +60,7 @@ jobs:
         if: ${{ inputs.prepare == true }}
         run: |
           cd crypto-ffi/bindings
-          ./gradlew :android:publishToSonatype :android:closeSonatypeStagingRepository --no-configuration-cache
+          ./gradlew :android:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -72,7 +72,7 @@ jobs:
         if: ${{ inputs.release == true }}
         run: |
           cd crypto-ffi/bindings
-          ./gradlew :android:findSonatypeStagingRepository :android:releaseSonatypeStagingRepository --no-configuration-cache
+          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -27,6 +27,15 @@ on:
           required: false
           type: boolean
           default: false
+        staging_repository_id:
+          description: "Sonatype staging repository id to release, as emitted by the prepare phase. If empty, the release falls back to discovery by description."
+          required: false
+          type: string
+          default: ""
+    outputs:
+      staging_repository_id:
+        description: "The Sonatype staging repository id created during the prepare phase."
+        value: ${{ jobs.jvm.outputs.staging_repository_id }}
 
 env:
   RELEASE: 1
@@ -35,6 +44,8 @@ jobs:
   jvm:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
+    outputs:
+      staging_repository_id: ${{ steps.stage.outputs.staging_repository_id }}
     steps:
       - uses: actions/checkout@v6.0.2
       - name: set up jdk 25
@@ -86,9 +97,21 @@ jobs:
 
       - name: stage artifact
         if: ${{ inputs.prepare == true }}
+        id: stage
         run: |
           cd crypto-ffi/bindings
-          ./gradlew :jvm:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache
+          ./gradlew :jvm:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache | tee gradle-stage.log
+
+          # grepping logs for this stuff isn't ideal, but technically should work, as long as the log string
+          # never changes. But we should keep an eye on it. Currently:
+          # https://github.com/gradle-nexus/publish-plugin/blob/c550fe9a15d177bad06b7902af9e497f837b6579/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt#L47
+          repo_id=$(grep -oP "Created staging repository '\K[^']+" gradle-stage.log | head -n1)
+          if [[ -z "$repo_id" ]]; then
+            echo "::error ::Could not determine the staging repository id from the Gradle output"
+            exit 1
+          fi
+          echo "::notice title=JVM staging repository::Created and closed staging repository ${repo_id}"
+          echo "staging_repository_id=${repo_id}" >> "$GITHUB_OUTPUT"
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -100,8 +123,14 @@ jobs:
         if: ${{ inputs.release == true }}
         run: |
           cd crypto-ffi/bindings
-          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
+          if [[ -n "$STAGING_REPOSITORY_ID" ]]; then
+            ./gradlew releaseSonatypeStagingRepository --staging-repository-id="$STAGING_REPOSITORY_ID" --no-configuration-cache
+          else
+            echo "::warning ::No staging repository id supplied; discovering the staging repository by description"
+            ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
+          fi
         env:
+          STAGING_REPOSITORY_ID: ${{ inputs.staging_repository_id }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ inputs.prepare == true }}
         run: |
           cd crypto-ffi/bindings
-          ./gradlew :jvm:publishToSonatype jvm:closeSonatypeStagingRepository --no-configuration-cache
+          ./gradlew :jvm:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -100,7 +100,7 @@ jobs:
         if: ${{ inputs.release == true }}
         run: |
           cd crypto-ffi/bindings
-          ./gradlew :jvm:findSonatypeStagingRepository :jvm:releaseSonatypeStagingRepository --no-configuration-cache
+          ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -17,25 +17,10 @@ on:
       PGP_PASSPHRASE:
         required: true
     inputs:
-        prepare:
-          description: "If true, stage and validate artifacts."
-          required: false
-          type: boolean
-          default: false
-        release:
-          description: "If true, release staged artifacts."
-          required: false
-          type: boolean
-          default: false
         staging_repository_id:
-          description: "Sonatype staging repository id to release, as emitted by the prepare phase. If empty, the release falls back to discovery by description."
-          required: false
+          description: "Sonatype staging repository id to release, as emitted by the prepare phase."
+          required: true
           type: string
-          default: ""
-    outputs:
-      staging_repository_id:
-        description: "The Sonatype staging repository id created during the prepare phase."
-        value: ${{ jobs.jvm.outputs.staging_repository_id }}
 
 env:
   RELEASE: 1
@@ -44,8 +29,6 @@ jobs:
   jvm:
     if: github.repository == 'wireapp/core-crypto'
     runs-on: ubuntu-latest
-    outputs:
-      staging_repository_id: ${{ steps.stage.outputs.staging_repository_id }}
     steps:
       - uses: actions/checkout@v6.0.2
       - name: set up jdk 25
@@ -53,13 +36,6 @@ jobs:
         with:
           java-version: 25
           distribution: adopt
-
-      - name: download bindings artifact
-        if: ${{ inputs.prepare == true }}
-        uses: ./.github/actions/make/bindings-kotlin-jvm
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
 
       - name: gradle setup
         uses: gradle/actions/setup-gradle@v6
@@ -69,66 +45,10 @@ jobs:
       - name: validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v6
 
-      - name: download jvm bindings
-        if: ${{ inputs.prepare == true }}
-        uses: ./.github/actions/make/bindings-kotlin-jvm
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
-
-      - name: download x86_64 linux artifact
-        if: ${{ inputs.prepare == true }}
-        uses: ./.github/actions/make/jvm
-        with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
-
-      # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
-      # Because this workflow runs on ubuntu, we're using the generic action
-      - name: download aarch64 apple darwin artifact
-        if: ${{ inputs.prepare == true }}
-        uses: ./.github/actions/make
-        with:
-          key: jvm-darwin
-          make-rule: jvm-darwin
-          target-path: target/aarch64-apple-darwin/release/libcore_crypto_ffi.dylib
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
-
-      - name: stage artifact
-        if: ${{ inputs.prepare == true }}
-        id: stage
-        run: |
-          cd crypto-ffi/bindings
-          ./gradlew :jvm:publishAllPublicationsToSonatypeRepository closeSonatypeStagingRepository --no-configuration-cache | tee gradle-stage.log
-
-          # grepping logs for this stuff isn't ideal, but technically should work, as long as the log string
-          # never changes. But we should keep an eye on it. Currently:
-          # https://github.com/gradle-nexus/publish-plugin/blob/c550fe9a15d177bad06b7902af9e497f837b6579/src/main/kotlin/io/github/gradlenexus/publishplugin/InitializeNexusStagingRepository.kt#L47
-          repo_id=$(grep -oP "Created staging repository '\K[^']+" gradle-stage.log | head -n1)
-          if [[ -z "$repo_id" ]]; then
-            echo "::error ::Could not determine the staging repository id from the Gradle output"
-            exit 1
-          fi
-          echo "::notice title=JVM staging repository::Created and closed staging repository ${repo_id}"
-          echo "staging_repository_id=${repo_id}" >> "$GITHUB_OUTPUT"
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PGP_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PGP_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PGP_PASSPHRASE }}
-
       - name: release artifact
-        if: ${{ inputs.release == true }}
         run: |
           cd crypto-ffi/bindings
-          if [[ -n "$STAGING_REPOSITORY_ID" ]]; then
-            ./gradlew releaseSonatypeStagingRepository --staging-repository-id="$STAGING_REPOSITORY_ID" --no-configuration-cache
-          else
-            echo "::warning ::No staging repository id supplied; discovering the staging repository by description"
-            ./gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository --no-configuration-cache
-          fi
+          ./gradlew releaseSonatypeStagingRepository --staging-repository-id="$STAGING_REPOSITORY_ID" --no-configuration-cache
         env:
           STAGING_REPOSITORY_ID: ${{ inputs.staging_repository_id }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,9 @@ jobs:
     uses: ./.github/workflows/publish-jvm.yml
     with:
       release: true
+      # Empty when prepare-jvm was skipped (sonatype-action == 'release'); the
+      # release then discovers the staging repository by description instead.
+      staging_repository_id: ${{ needs.prepare-jvm.outputs.staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -93,6 +96,9 @@ jobs:
     uses: ./.github/workflows/publish-android.yml
     with:
       release: true
+      # Empty when prepare-android was skipped (sonatype-action == 'release'); the
+      # release then discovers the staging repository by description instead.
+      staging_repository_id: ${{ needs.prepare-android.outputs.staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,20 @@ on:
         options:
           - release
           - prepare-and-release
+      jvm-staging-repository-id:
+        description: >
+          Required when 'sonatype-action' is 'release'.
+          In that case, you must manually specify the sonatype repository id which will be promoted.
+        required: false
+        type: string
+        default: ""
+      android-staging-repository-id:
+        description: >
+          Required when 'sonatype-action' is 'release'.
+          In that case, you must manually specify the sonatype repository id which will be promoted.
+        required: false
+        type: string
+        default: ""
 
 env:
   RELEASE: 1
@@ -42,9 +56,7 @@ jobs:
     if: >
       (inputs.registry == 'all' || inputs.registry == 'jvm') &&
       inputs.sonatype-action == 'prepare-and-release'
-    uses: ./.github/workflows/publish-jvm.yml
-    with:
-      prepare: true
+    uses: ./.github/workflows/prepare-publish-jvm.yml
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -52,7 +64,8 @@ jobs:
       PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
       PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
-  release-jvm:
+  jvm-staging-repository-id:
+    runs-on: ubuntu-latest
     needs: prepare-jvm
     # always() lets this run even when prepare-jvm was skipped (sonatype-action == 'release').
     # The result check ensures we don't run if prepare-jvm actually failed.
@@ -60,12 +73,39 @@ jobs:
       always() &&
       (inputs.registry == 'all' || inputs.registry == 'jvm') &&
       (needs.prepare-jvm.result == 'success' || needs.prepare-jvm.result == 'skipped')
+    env:
+      COMPUTED_ID: ${{ needs.prepare-jvm.outputs.staging_repository_id }}
+      PROVIDED_ID: ${{ inputs.jvm-staging-repository-id }}
+    steps:
+      - name: ensure the jvm staging repository id
+        id: ensure-staging-repo
+        run: |
+          if [ -n "$COMPUTED_ID" ]; then
+            staging_repository_id="$COMPUTED_ID"
+          elif [ -n "$PROVIDED_ID" ]; then
+            staging_repository_id="$PROVIDED_ID"
+          else
+            echo "::error ::When 'sonatype-action' is 'release' you must manually specify the 'jvm-staging-repository-id' input"
+            exit 1
+          fi
+          echo "staging_repository_id=$staging_repository_id" >> "$GITHUB_OUTPUT"
+    outputs:
+      staging_repository_id: ${{ steps.ensure-staging-repo.outputs.staging_repository_id }}
+
+  release-jvm:
+    needs:
+      - prepare-jvm
+      - jvm-staging-repository-id
+    # always() lets this run even when prepare-jvm was skipped (sonatype-action == 'release').
+    # The result check ensures we don't run if prepare-jvm actually failed.
+    if: >
+      always() &&
+      (inputs.registry == 'all' || inputs.registry == 'jvm') &&
+      (needs.prepare-jvm.result == 'success' || needs.prepare-jvm.result == 'skipped') &&
+      needs.jvm-staging-repository-id.result == 'success'
     uses: ./.github/workflows/publish-jvm.yml
     with:
-      release: true
-      # Empty when prepare-jvm was skipped (sonatype-action == 'release'); the
-      # release then discovers the staging repository by description instead.
-      staging_repository_id: ${{ needs.prepare-jvm.outputs.staging_repository_id }}
+      staging_repository_id: ${{ needs.jvm-staging-repository-id.outputs.staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -77,9 +117,7 @@ jobs:
     if: >
       (inputs.registry == 'all' || inputs.registry == 'android') &&
       inputs.sonatype-action == 'prepare-and-release'
-    uses: ./.github/workflows/publish-android.yml
-    with:
-      prepare: true
+    uses: ./.github/workflows/prepare-publish-android.yml
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -87,18 +125,48 @@ jobs:
       PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
       PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
-  release-android:
+
+  android-staging-repository-id:
+    runs-on: ubuntu-latest
     needs: prepare-android
+    # always() lets this run even when prepare-android was skipped (sonatype-action == 'release').
+    # The result check ensures we don't run if prepare-android actually failed.
     if: >
       always() &&
       (inputs.registry == 'all' || inputs.registry == 'android') &&
       (needs.prepare-android.result == 'success' || needs.prepare-android.result == 'skipped')
+    env:
+      COMPUTED_ID: ${{ needs.prepare-android.outputs.staging_repository_id }}
+      PROVIDED_ID: ${{ inputs.android-staging-repository-id }}
+    steps:
+      - name: ensure the android staging repository id
+        id: ensure-staging-repo
+        run: |
+          if [ -n "$COMPUTED_ID" ]; then
+            staging_repository_id="$COMPUTED_ID"
+          elif [ -n "$PROVIDED_ID" ]; then
+            staging_repository_id="$PROVIDED_ID"
+          else
+            echo "::error ::When 'sonatype-action' is 'release' you must manually specify the 'android-staging-repository-id' input"
+            exit 1
+          fi
+          echo "staging_repository_id=$staging_repository_id" >> "$GITHUB_OUTPUT"
+    outputs:
+      staging_repository_id: ${{ steps.ensure-staging-repo.outputs.staging_repository_id }}
+
+
+  release-android:
+    needs:
+      - prepare-android
+      - android-staging-repository-id
+    if: >
+      always() &&
+      (inputs.registry == 'all' || inputs.registry == 'android') &&
+      (needs.prepare-android.result == 'success' || needs.prepare-android.result == 'skipped') &&
+      needs.android-staging-repository-id.result == 'success'
     uses: ./.github/workflows/publish-android.yml
     with:
-      release: true
-      # Empty when prepare-android was skipped (sonatype-action == 'release'); the
-      # release then discovers the staging repository by description instead.
-      staging_repository_id: ${{ needs.prepare-android.outputs.staging_repository_id }}
+      staging_repository_id: ${{ needs.android-staging-repository-id.outputs.staging_repository_id }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
Turns out that we haven't actually tried this yet. That's the point of a prerelease!

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
