### PR TITLE
fix(ci): download npm artifacts to the correct place in the filesystem

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,6 +75,7 @@ jobs:
         id: download
         if: ${{ inputs.prepare == false && inputs.release == true }}
         run: |
+          cd crypto-ffi/bindings/js/packages/core-crypto
           gh release download "${{ github.ref_name }}" --pattern "*.tgz" --dir . 2>/dev/null || true
           filename=$(ls *.tgz 2>/dev/null | head -n 1)
           if [[ -z "$filename" ]]; then


### PR DESCRIPTION
We are, after all, just trying to restore them to precisely where they were created from.

Should fix this kind of thing: https://github.com/wireapp/core-crypto/actions/runs/27347423684/job/80813690513


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
