### PR TITLE
chore(e2e-identity): rm an unused function

### DIFF
--- a/e2e-identity/src/acme/order.rs
+++ b/e2e-identity/src/acme/order.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use rusty_jwt_tools::prelude::{ClientId, Handle, JwsAlgorithm, Pem};
 
 use crate::acme::{
-    AcmeAccount, AcmeAuthz, AcmeDirectory, AcmeIdentifier, AcmeJws, RustyAcme, RustyAcmeError, RustyAcmeResult,
+    AcmeAccount, AcmeDirectory, AcmeIdentifier, AcmeJws, RustyAcme, RustyAcmeError, RustyAcmeResult,
     identifier::CanonicalIdentifier,
 };
 
@@ -237,10 +237,6 @@ impl AcmeOrder {
             .transpose()?
             .ok_or(RustyAcmeError::OrderError(AcmeOrderError::WrongIdentifiers))?
             .try_into()
-    }
-
-    pub fn try_get_user_authorization(&self) -> RustyAcmeResult<AcmeAuthz> {
-        todo!()
     }
 }
 


### PR DESCRIPTION
This function was called nowhere and not implemented. However, it was part of the public interface of the module. We remove it here so that nobody accidentally calls it and produces a panic.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
