### PR TITLE
chore(crypto-ffi): creating a client id from the correct types is inf…

### DIFF
--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -966,9 +966,7 @@ final class WireCoreCryptoTests: XCTestCase {
         // swiftlint:disable:next force_try
         let userId = try! Uuid(uuid: UUID().uuidString)
         let deviceId = UInt64.random(in: 0...UInt64.max)
-        // constructor only fails if the generated parts do not satisfy the wire client-id format
-        // swiftlint:disable:next force_try
-        return try! ClientId(userId: userId, deviceId: DeviceId(id: deviceId), domain: "wire.com")
+        return ClientId(userId: userId, deviceId: DeviceId(id: deviceId), domain: "wire.com")
     }
 
     private func generateEd25519Jwk() -> Data {

--- a/crypto-ffi/src/client_id/mod.rs
+++ b/crypto-ffi/src/client_id/mod.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use wire_e2e_identity::E2eiClientId;
 
-use crate::CoreCryptoResult;
 pub use crate::client_id::{device_id::DeviceId, serialize::DeserializedClientId, user_id::Uuid};
 
 /// A unique identifier for an MLS client.
@@ -39,12 +38,12 @@ impl AsRef<core_crypto::ClientIdRef> for ClientId {
 impl ClientId {
     /// Create a new client id.
     #[uniffi::constructor]
-    pub fn new(user_id: Arc<crate::Uuid>, device_id: Arc<DeviceId>, domain: String) -> CoreCryptoResult<Self> {
-        let inner = core_crypto::ClientId::new(**user_id, (*device_id).into(), &domain);
-        Ok(Self(inner))
+    pub fn new(user_id: Arc<crate::Uuid>, device_id: Arc<DeviceId>, domain: String) -> Self {
+        let inner = core_crypto::ClientId::new(**user_id, **device_id, &domain);
+        Self(inner)
     }
 
-    /// Copy the wrapped data into a direct representation of the `<userid>-<device-id>@<domain>` format.
+    /// Copy the wrapped data into a direct representation of the `<user-id>:<device-id>@<domain>` format.
     pub fn deserialize(&self) -> DeserializedClientId {
         DeserializedClientId::new(self.clone())
     }


### PR DESCRIPTION
…allible

Therefore, the constructor must not return a `CoreCryptoResult`.

# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
