### PR TITLE
chore(ffi): add missing `to_string()` impls

### DIFF
--- a/crypto-ffi/bindings/js/packages/browser/test/clientIdentity.test.ts
+++ b/crypto-ffi/bindings/js/packages/browser/test/clientIdentity.test.ts
@@ -11,6 +11,16 @@ afterEach(async () => {
 });
 
 describe("client identity", () => {
+    it("Uuid.toString should work", async () => {
+        const result = await browser.execute(() => {
+            const rawUuid = window.crypto.randomUUID();
+            const uuid = new window.ccModule.Uuid(rawUuid);
+
+            return uuid.toString() === rawUuid;
+        });
+        expect(result).toBe(true);
+    });
+
     it("get client public key should work", async () => {
         const result = await browser.execute(async () => {
             const cc = await window.helpers.ccInit();

--- a/crypto-ffi/bindings/js/packages/native/test/clientIdentity.test.ts
+++ b/crypto-ffi/bindings/js/packages/native/test/clientIdentity.test.ts
@@ -1,3 +1,4 @@
+import { Uuid } from "@wireapp/core-crypto/native";
 import { ccInit, generateKeyPackage, setup, teardown } from "./utils";
 import { test, afterEach, beforeEach, describe, expect } from "bun:test";
 
@@ -10,6 +11,13 @@ afterEach(async () => {
 });
 
 describe("client identity", () => {
+    test("Uuid.toString should work", () => {
+        const rawUuid = crypto.randomUUID();
+        const uuid = new Uuid(rawUuid);
+
+        expect(uuid.toString()).toBe(rawUuid);
+    });
+
     test("get client public key should work", async () => {
         const cc = await ccInit();
         const result = (await cc.getCredentials())[0]!.publicKeyHash()

--- a/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/GeneralTest.kt
+++ b/crypto-ffi/bindings/shared/src/commonTest/kotlin/com/wire/crypto/GeneralTest.kt
@@ -8,10 +8,19 @@ import testutils.MockMlsTransportSuccessProvider
 import testutils.genClientId
 import testutils.genDatabaseKey
 import java.nio.file.Path
+import java.util.UUID
 import kotlin.io.path.*
 import kotlin.test.*
 
 class GeneralTest {
+    @Test
+    fun uuid_to_string() = runTest {
+        val rawUuid = UUID.randomUUID().toString()
+        val uuid = Uuid(rawUuid)
+
+        assertThat(uuid.toString()).isEqualTo(rawUuid)
+    }
+
     @Test
     fun get_version() = runTest {
         val version = version()

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -29,6 +29,14 @@ final class WireCoreCryptoTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    func testUuidToStringWorks() throws {
+        let rawUuid = UUID().uuidString
+        let uuid = try Uuid(uuid: rawUuid)
+
+        XCTAssertEqual(String(describing: uuid), rawUuid.lowercased())
+        XCTAssertEqual(uuid.description, rawUuid.lowercased())
+    }
+
     func testSetClientDataPersists() async throws {
         let database = try await newDatabase()
         let coreCrypto = try CoreCrypto(database: database)

--- a/crypto-ffi/src/client_id/serialize.rs
+++ b/crypto-ffi/src/client_id/serialize.rs
@@ -2,9 +2,17 @@ use std::sync::Arc;
 
 use crate::{ClientId, DeviceId, Uuid};
 
-/// This directly represents a `ClientId` of the `<userid>-<device-id>@<domain>` format.
+/// This directly represents a `ClientId` of the `<userid>:<device-id>@<domain>` format.
 /// Instantiate via [ClientId::deserialize].
-#[derive(Debug, uniffi::Record)]
+#[derive(Debug, uniffi::Record, derive_more::Display)]
+#[display(
+    "{user_id}{}{device_id_hex}{}{domain}",
+    core_crypto::ClientId::DELIMITER,
+    core_crypto::ClientId::DOMAIN_SEPERATOR,
+    device_id_hex = device_id.to_hex_string(),
+)]
+// only supported for records in uniffi >= 0.31. Remove condition after globally migrating to that version.
+#[cfg_attr(any(feature = "wasm", feature = "napi"), uniffi::export(Display))]
 pub struct DeserializedClientId {
     /// The client id this was deserialized from
     pub client_id: Arc<ClientId>,

--- a/crypto-ffi/src/client_id/user_id.rs
+++ b/crypto-ffi/src/client_id/user_id.rs
@@ -12,8 +12,9 @@ use crate::{CoreCryptoError, CoreCryptoResult};
     derive_more::Deref,
     derive_more::DerefMut,
     uniffi::Object,
+    derive_more::Display,
 )]
-#[uniffi::export(Eq, Hash)]
+#[uniffi::export(Eq, Hash, Display)]
 /// A Uuid.
 // It's currently just used as a user id. However, we're calling it `Uuid`, because it might potentially be used in
 // other places, too, e.g., conversation ids.


### PR DESCRIPTION
# What's new in this PR


----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
