### PR TITLE
ci: use XCode 26.3

### DIFF
--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -41,7 +41,7 @@ jobs:
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.6.0'
+          xcode-version: '26.3.0'
       - name: Set up Ruby environment
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION

Github is trolling us today.

It serves us different images for macos-latest, this is the latest common version.

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
