### PR TITLE
refactor(test utils): there is just one format for client ids

### DIFF
--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -213,10 +213,10 @@ mod tests {
         async fn should_read_revoked_device() {
             let case = TestContext::default_x509();
 
-            let [alice_client_id, bob_client_id] = case.x509_client_ids();
+            let [alice_client_id, bob_client_id] = case.client_ids();
 
-            let rupert_user_id = uuid::Uuid::new_v4();
-            let [rupert_client_id] = case.x509_client_ids_for_user(rupert_user_id);
+            let [rupert_client_id] = case.client_ids();
+            let rupert_user_id = rupert_client_id.as_user_id();
 
             let sessions = case
                 .sessions_x509_with_client_ids_and_revocation(
@@ -289,8 +289,8 @@ mod tests {
         #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_read_users() {
             let case = TestContext::default_x509();
-            let [alice_android, alice_ios] = case.x509_client_ids_for_user(uuid::Uuid::new_v4());
-            let [bob_android] = case.x509_client_ids();
+            let [alice_android, alice_ios] = case.client_ids_for_user(uuid::Uuid::new_v4());
+            let [bob_android] = case.client_ids();
 
             let sessions = case
                 .sessions_x509_with_client_ids([alice_android, alice_ios, bob_android])

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -286,7 +286,7 @@ mod tests {
         };
 
         let x509_test_chain = case.set_test_chain(&[], &[], None).await;
-        let [bob_id] = case.x509_client_ids();
+        let [bob_id] = case.client_ids();
         let x509_intermediate = x509_test_chain.find_local_intermediate_ca();
         let certificate = CertificateBundle::rand(&bob_id, x509_intermediate);
         let credential = Credential::x509(other_cipher_suite, certificate).unwrap();
@@ -401,7 +401,7 @@ mod tests {
             let name = "alice";
             let common_name = format!("{name} Smith");
             let handle = format!("{}_wire", name.to_lowercase());
-            let client_id = crate::test_utils::x509::qualified_e2ei_cid_with_domain("wire.com");
+            let [client_id] = case.client_ids();
             local_ca.create_and_sign_end_identity(CertificateParams {
                 common_name: Some(common_name.clone()),
                 handle: Some(handle.clone()),

--- a/crypto/src/test_utils/test_context.rs
+++ b/crypto/src/test_utils/test_context.rs
@@ -7,7 +7,7 @@ pub use rstest_reuse::{self, *};
 
 use super::{
     CoreCryptoTransportSuccessProvider, MlsTransportTestExt, TestConversation, init_x509_test_chain, tmp_db_file,
-    x509::{CertificateParams, X509TestChain, qualified_e2ei_cid, qualified_e2ei_cid_from_user_id},
+    x509::{CertificateParams, X509TestChain},
 };
 use crate::{
     CertificateBundle, ClientId, ConnectionType, Credential, CredentialRef, Database, DatabaseKey, ExternalSender,
@@ -81,6 +81,8 @@ pub struct TestContext {
 }
 
 impl TestContext {
+    const DOMAIN: &str = "wire.com";
+
     pub fn new(credential_type: CredentialType, cs: openmls::prelude::Ciphersuite) -> Self {
         Self {
             credential_type,
@@ -152,28 +154,25 @@ impl TestContext {
         out
     }
 
+    /// Generate muliple client ids with unique user ids and unique device ids.
     pub fn client_ids<const N: usize>(&self) -> [ClientId; N] {
-        match self.credential_type {
-            CredentialType::Basic => self.basic_client_ids(),
-            CredentialType::X509 => self.x509_client_ids(),
-        }
-    }
-
-    pub fn x509_client_ids<const N: usize>(&self) -> [ClientId; N] {
-        std::array::from_fn(|_| qualified_e2ei_cid())
-    }
-
-    pub fn basic_client_ids<const N: usize>(&self) -> [ClientId; N] {
-        fn generate() -> ClientId {
+        let generate = |_| {
             let user_id = uuid::Uuid::new_v4();
             let device_id = rand::random::<u64>();
-            ClientId::new(user_id, device_id, "wire.com")
-        }
-        std::array::from_fn(|_| generate())
+            ClientId::new(user_id, device_id, Self::DOMAIN)
+        };
+
+        std::array::from_fn(generate)
     }
 
-    pub fn x509_client_ids_for_user<const N: usize>(&self, user: uuid::Uuid) -> [ClientId; N] {
-        std::array::from_fn(|_| qualified_e2ei_cid_from_user_id(user))
+    /// Generate muliple client ids with identical user id and unique device ids.
+    pub fn client_ids_for_user<const N: usize>(&self, user_id: uuid::Uuid) -> [ClientId; N] {
+        let generate = |_| {
+            let device_id = rand::random::<u64>();
+            ClientId::new(user_id, device_id, Self::DOMAIN)
+        };
+
+        std::array::from_fn(generate)
     }
 
     pub(crate) async fn set_test_chain(
@@ -253,7 +252,7 @@ impl TestContext {
     }
 
     pub async fn sessions_basic<const N: usize>(&self) -> [SessionContext; N] {
-        let client_ids = self.basic_client_ids::<N>();
+        let client_ids = self.client_ids::<N>();
         return self
             .sessions_with_credential_type(client_ids, CredentialType::Basic)
             .await;
@@ -288,7 +287,7 @@ impl TestContext {
     }
 
     pub async fn sessions_x509<const N: usize>(&self) -> [SessionContext; N] {
-        let client_ids = self.x509_client_ids();
+        let client_ids = self.client_ids();
         self.sessions_x509_with_client_ids(client_ids).await
     }
 

--- a/crypto/src/test_utils/test_context.rs
+++ b/crypto/src/test_utils/test_context.rs
@@ -197,7 +197,7 @@ impl TestContext {
         chain
     }
 
-    pub async fn x509_credentials<const N: usize>(&self, client_ids: [ClientId; N]) -> [Credential; N] {
+    async fn x509_credentials<const N: usize>(&self, client_ids: [ClientId; N]) -> [Credential; N] {
         if self.chain.read().await.is_none() {
             self.set_test_chain(&client_ids, &[], None).await;
         }
@@ -219,7 +219,7 @@ impl TestContext {
         credentials.try_into().expect("Vector should be of length N.")
     }
 
-    pub(crate) fn basic_credentials<const N: usize>(&self, client_ids: [ClientId; N]) -> [Credential; N] {
+    fn basic_credentials<const N: usize>(&self, client_ids: [ClientId; N]) -> [Credential; N] {
         client_ids
             .into_iter()
             .map(|id| Credential::basic(self.cipher_suite(), id).unwrap())
@@ -233,10 +233,6 @@ impl TestContext {
     /// This operation is _not_ idempotent; it generates a new credential each time.
     pub(crate) async fn generate_credential(&self) -> Credential {
         let [client_id] = self.client_ids();
-        self.generate_credential_wtih_client_id(client_id).await
-    }
-
-    pub(crate) async fn generate_credential_wtih_client_id(&self, client_id: ClientId) -> Credential {
         let [credential] = match self.credential_type {
             CredentialType::Basic => self.basic_credentials([client_id]),
             CredentialType::X509 => self.x509_credentials([client_id]).await,

--- a/crypto/src/test_utils/x509.rs
+++ b/crypto/src/test_utils/x509.rs
@@ -9,25 +9,7 @@ use crate::{
     transaction_context::TransactionContext,
 };
 
-const DOMAIN: &str = "wire.com";
 const DEFAULT_CRL_DOMAIN: &str = "localhost";
-
-pub(crate) fn qualified_e2ei_cid() -> ClientId {
-    qualified_e2ei_cid_from_user_id(uuid::Uuid::new_v4())
-}
-
-pub(crate) fn qualified_e2ei_cid_with_domain(domain: &str) -> ClientId {
-    qualified_e2ei_cid_from_user_id_and_domain(uuid::Uuid::new_v4(), domain)
-}
-
-pub(crate) fn qualified_e2ei_cid_from_user_id(user_id: uuid::Uuid) -> ClientId {
-    qualified_e2ei_cid_from_user_id_and_domain(user_id, DOMAIN)
-}
-
-pub(crate) fn qualified_e2ei_cid_from_user_id_and_domain(user_id: uuid::Uuid, domain: &str) -> ClientId {
-    let device_id = rand::random::<u64>();
-    ClientId::new(user_id, device_id, domain)
-}
 
 /// Params for generating the Certificate chain
 #[derive(Debug, Clone)]
@@ -301,7 +283,9 @@ impl X509TestChain {
 
         let common_name = format!("{name} Smith");
         let handle = format!("{}_wire", name.to_lowercase());
-        let client_id = qualified_e2ei_cid_with_domain("world.com");
+        let user_id = uuid::Uuid::new_v4();
+        let device_id = rand::random::<u64>();
+        let client_id = ClientId::new(user_id, device_id, "world.com");
         let mut cert_params = CertificateParams {
             common_name: Some(common_name.clone()),
             handle: Some(handle.clone()),


### PR DESCRIPTION
# What's new in this PR
See above

----
##### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
