### PR TITLE
test(ts): adjust "Remove User" benchmark [WPB-26123]

### DIFF
--- a/crypto-ffi/bindings/js/packages/browser/benches/removeUser.bench.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/removeUser.bench.ts
@@ -17,10 +17,12 @@ describe("benchmark", () => {
 
             void (async (parameters) => {
                 bench = new tinybench.Bench({
-                    name: "Adding a User",
-                    time: 1000,
-                    iterations: 5,
+                    name: "Removing a User",
+                    time: 0,
+                    iterations: 10,
+                    warmup: true,
                     warmupIterations: 1,
+                    warmupTime: 0,
                 });
                 for (const { userCount, cipherSuite } of parameters) {
                     bench.add(

--- a/crypto-ffi/bindings/js/packages/native/benches/removeUser.bench.ts
+++ b/crypto-ffi/bindings/js/packages/native/benches/removeUser.bench.ts
@@ -18,9 +18,11 @@ async function run() {
 
     const bench = new Bench({
         name: "Removing a User",
-        time: 1000,
-        iterations: 5,
+        time: 0,
+        iterations: 10,
+        warmup: true,
         warmupIterations: 1,
+        warmupTime: 0,
         setup: tinybenchSetup,
         teardown: teardown,
     });

--- a/crypto-ffi/bindings/js/shared/shared/utils.ts
+++ b/crypto-ffi/bindings/js/shared/shared/utils.ts
@@ -302,15 +302,9 @@ async function setHelpers() {
                 cipherSuite?: CipherSuite
             ): Promise<GroupInfoBundle> {
                 const kp = await helpers.generateKeyPackage(cc2, cipherSuite);
-                const clients = await cc1.getClientIds(conversationId);
-                console.log("clients");
-                console.log(clients);
-
-                console.log("inviting bob");
                 await cc1.transaction((ctx) =>
                     ctx.addClientsToConversation(conversationId, [kp])
                 );
-                console.log("processing welcome");
                 const commitBundle =
                     await deliveryService.getLatestCommitBundle();
                 await cc2.transaction((ctx) =>


### PR DESCRIPTION
This PR adjusts the benchmark options for the "Remove User" benchmark in ts as it took too long to finish.


<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
