### PR TITLE
Fix markdown link formatting in release notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ The versioning scheme used is [SemVer AKA Semantic Versioning](https://semver.or
 
 #### Consider when making a release from a release branch<a name="consider-when-making-a-release-from-a-release-branch"></a>
 
-1. Isolate the changes to [index.md](docs/index.md) and `[release notes](cc-book/src/release_notes.md)` from the release
+1. Isolate the changes to [index.md](docs/index.md) and [release notes](cc-book/src/release_notes.md) from the release
    commit itself
 1. After the release is finished, cherry-pick the changes to [index.md](docs/index.md) and
-   `[release notes](cc-book/src/release_notes.md)` and get them into `main`
+   [release notes](cc-book/src/release_notes.md) and get them into `main`


### PR DESCRIPTION
The link didn't work as the backticks wrapped entire link instead of just the displayed content.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
