### PR TITLE
test(ts-browser): fix benchmark name

### DIFF
--- a/crypto-ffi/bindings/js/packages/browser/benches/joinGroup.bench.ts
+++ b/crypto-ffi/bindings/js/packages/browser/benches/joinGroup.bench.ts
@@ -17,7 +17,7 @@ describe("benchmark", () => {
 
             void (async (parameters) => {
                 bench = new tinybench.Bench({
-                    name: "Adding a User",
+                    name: "Joining a Group",
                     time: 1000,
                     iterations: 5,
                     warmupIterations: 1,


### PR DESCRIPTION
Fixes a benchmark name.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
