### PR TITLE
feat(swift): transactions run `withTaskCancellationHandler` [WPB-27117]

### DIFF
--- a/.github/actions/make/bindings-swift/action.yml
+++ b/.github/actions/make/bindings-swift/action.yml
@@ -15,10 +15,14 @@ runs:
           gh-token: ${{ inputs.gh-token }}
           artifact-generation: ${{ inputs.artifact-generation }}
 
-      - name: fetch ffi library
-        uses: ./.github/actions/make/ffi-library
+      - name: fetch or make Swift FFI library
+        uses: ./.github/actions/make
         with:
+          key: swift-ffi-library
+          make-rule: swift-ffi-library
+          target-path: target/swift-bindgen/release/libcore_crypto_ffi.dylib
           gh-token: ${{ inputs.gh-token }}
+          uses-rust: true
           artifact-generation: ${{ inputs.artifact-generation }}
 
       - uses: ./.github/actions/make

--- a/.github/actions/make/ffi-library/action.yml
+++ b/.github/actions/make/ffi-library/action.yml
@@ -1,4 +1,4 @@
-name: Fetch or make ffi library
+name: Fetch or make ffi library for linux
 
 inputs:
   gh-token:
@@ -10,23 +10,11 @@ runs:
   using: composite
 
   steps:
-    - name: ffi library extension
-      run: |
-        os="$(uname -s)"
-        echo "ARTIFACT_NAME=uniffi-${os}" >> $GITHUB_ENV
-        if [ "$os" = "Linux" ]; then
-          library_extension="so"
-        elif [ "$os" = "Darwin" ]; then
-          library_extension="dylib"
-        fi
-        echo "LIBRARY_EXTENSION=${library_extension}" >> $GITHUB_ENV
-      shell: bash -euo pipefail {0}
-
     - uses: ./.github/actions/make
       with:
-        key: libcore_crypto_ffi.${{ env.LIBRARY_EXTENSION }}
+        key: libcore_crypto_ffi.so
         make-rule: ffi-library
-        target-path: target/release/libcore_crypto_ffi.${{ env.LIBRARY_EXTENSION }}
+        target-path: target/release/libcore_crypto_ffi.so
         gh-token: ${{ inputs.gh-token }}
         uses-rust: true
         rust-target: x86_64-unknown-linux-gnu

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 
 [features]
 default = ["proteus"]
+cancellable-transactions = []
 proteus = ["core-crypto/proteus", "dep:proteus-wasm"]
 wasm = ["dep:uniffi_ubrn"]
 napi = ["dep:uniffi_ubrn"]

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -63,8 +63,19 @@ public final class CoreCrypto: CoreCryptoProtocol, @unchecked Sendable {
         let filePath = dbLocation.map { FilePath(stringLiteral: $0) }
         let transactionExecutor = try TransactionExecutor<Result>(
             keystorePath: filePath, block)
+        let token = CoreCryptoCancellationToken()
+
         do {
-            try await coreCryptoFfi.transactionFfi(command: transactionExecutor)
+            try await withTaskCancellationHandler {
+                try await coreCryptoFfi.transactionFfiCancellable(
+                    command: transactionExecutor,
+                    cancellation: token
+                )
+            } onCancel: {
+                token.cancel()
+            }
+        } catch CoreCryptoError.TransactionCanceled {
+            throw CancellationError()
         } catch {
             throw await transactionExecutor.innerError ?? error
         }

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCryptoTests/WireCoreCryptoTests.swift
@@ -294,6 +294,96 @@ final class WireCoreCryptoTests: XCTestCase {
         )
     }
 
+    // swiftlint:disable:next function_body_length
+    func testCancellingTransactionStopsWaitingForLongRunningCallbacks() async throws {
+        // Verifies that cancellation stops waiting for PKI and MLS transport callbacks.
+        let database = try await newDatabase()
+
+        // This struct implements send commit bundle and x509 credential finalization by just waiting.
+        // Also, we're passing in expectations that are used as checkpoints.
+        let sendCommitStarted = expectation(description: "send commit started")
+        let sendCommitExited = expectation(description: "send commit exited")
+        let httpRequestStarted = expectation(description: "http request started")
+        let httpRequestExited = expectation(description: "http request exited")
+        let longRunningCallbacks = LongRunningCallbacks(
+            sencCommitStarted: sendCommitStarted,
+            sencCommitExited: sendCommitExited,
+            httpRequestStarted: httpRequestStarted,
+            httpRequestExited: httpRequestExited
+        )
+
+        let clientId = genClientId()
+        let coreCrypto = try CoreCrypto(database: database)
+
+        let pkiEnvironment = try await PkiEnvironment(
+            hooks: longRunningCallbacks, database: database)
+        await coreCrypto.setPkiEnvironment(pkiEnvironment: pkiEnvironment)
+        let acquisition = try X509CredentialAcquisition(
+            pkiEnvironment: pkiEnvironment,
+            config: X509CredentialAcquisitionConfiguration(
+                acmeDirectoryUrl: "https://acme.example.com/directory",
+                cipherSuite: cipherSuiteDefault(),
+                displayName: "Alice Smith",
+                clientId: clientId,
+                handle: "alice_wire",
+                domain: "world.com",
+                team: nil,
+                validityPeriodSecs: 3600
+            )
+        )
+
+        let conversationId = genConversationId()
+        let credential = try Credential.basic(
+            cipherSuite: cipherSuiteDefault(),
+            clientId: clientId
+        )
+
+        try await coreCrypto.transaction { context in
+            try await context.mlsInit(clientId: clientId, transport: longRunningCallbacks)
+            let credentialRef = try await context.addCredential(credential: credential)
+            try await context.createConversation(
+                conversationId: conversationId,
+                credentialRef: credentialRef,
+                externalSender: nil
+            )
+        }
+
+        let transactionTask = Task {
+            try await coreCrypto.transaction { context in
+                try await context.setData(data: Data("This data should not be committed.".utf8))
+
+                // Start the long-running callbacks concurrently within the cancellable transaction.
+                async let update: () = context.updateKeyingMaterial(
+                    conversationId: conversationId
+                )
+                async let acquiredCredential = acquisition.finalize()
+                _ = try await (update, acquiredCredential)
+            }
+        }
+
+        // Wait until both long-running callbacks have started before cancelling.
+        await fulfillment(of: [sendCommitStarted, httpRequestStarted])
+        transactionTask.cancel()
+
+        // Assert that cancellation is triggered without waiting for either callback result.
+        do {
+            try await transactionTask.value
+            XCTFail("Expected the transaction to be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        await fulfillment(of: [sendCommitExited, httpRequestExited])
+
+        // Assert that work performed before the callbacks was rolled back.
+        let data = try await coreCrypto.transaction { context in
+            try await context.getData()
+        }
+        XCTAssertNil(data)
+    }
+
     func testParallelTransactionsArePerformedSeriallyAcrossMultipleCoreCryptoInstances()
         async throws
     {
@@ -850,6 +940,79 @@ final class WireCoreCryptoTests: XCTestCase {
             dpop: String
         ) async -> String {
             return "mock-backend-access-token"
+        }
+    }
+
+    private final actor LongRunningCallbacks: MlsTransport, PkiEnvironmentHooks {
+        private let sencCommitStarted: XCTestExpectation
+        private let sendCommitExited: XCTestExpectation
+        private let httpRequestStarted: XCTestExpectation
+        private let httpRequestExited: XCTestExpectation
+
+        init(
+            sencCommitStarted: XCTestExpectation,
+            sencCommitExited: XCTestExpectation,
+            httpRequestStarted: XCTestExpectation,
+            httpRequestExited: XCTestExpectation
+        ) {
+            self.sencCommitStarted = sencCommitStarted
+            self.sendCommitExited = sencCommitExited
+            self.httpRequestStarted = httpRequestStarted
+            self.httpRequestExited = httpRequestExited
+        }
+
+        func sendCommitBundle(commitBundle: CommitBundle) async {
+            sencCommitStarted.fulfill()
+            do {
+                try await Task.sleep(for: .milliseconds(9999))
+                XCTFail("Expected the Task.sleep() to be cancelled")
+            } catch is CancellationError {
+                sendCommitExited.fulfill()
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        func prepareForTransport(historySecret: WireCoreCryptoUniffi.HistorySecret) async
+            -> WireCoreCryptoUniffi.MlsTransportData
+        {
+            Data()
+        }
+
+        func httpRequest(
+            method: HttpMethod,
+            url: String,
+            headers: [HttpHeader],
+            body: Data
+        ) async -> HttpResponse {
+            httpRequestStarted.fulfill()
+            do {
+                try await Task.sleep(for: .milliseconds(9999))
+                XCTFail("Expected Task.sleep() to be cancelled")
+            } catch is CancellationError {
+                httpRequestExited.fulfill()
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+
+            return HttpResponse(status: 200, headers: [], body: Data())
+        }
+
+        func authenticate(
+            idp: String,
+            keyAuth: String,
+            acmeAud: String,
+            acquisitionSnapshot: Data
+        ) async -> String {
+            "mock-id-token"
+        }
+
+        func getBackendNonce() async -> String {
+            "mock-backend-nonce"
+        }
+
+        func fetchBackendAccessToken(dpop: String) async -> String {
+            "mock-backend-access-token"
         }
     }
 

--- a/crypto-ffi/src/cancellation/future.rs
+++ b/crypto-ffi/src/cancellation/future.rs
@@ -1,0 +1,43 @@
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use crate::CoreCryptoCancellationToken;
+
+pub(crate) struct Cancelled {
+    pub(crate) token: Arc<CoreCryptoCancellationToken>,
+    pub(crate) wakers_index: Option<usize>,
+}
+
+impl Future for Cancelled {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        if this.token.is_cancelled() {
+            return Poll::Ready(());
+        }
+
+        let mut wakers = this.token.wakers();
+        // Cancellation may have happened while waiting for the wakers lock.
+        if this.token.is_cancelled() {
+            return Poll::Ready(());
+        }
+
+        wakers.insert(&mut this.wakers_index, cx.waker());
+        Poll::Pending
+    }
+}
+
+impl Drop for Cancelled {
+    fn drop(&mut self) {
+        let Some(index) = self.wakers_index.take() else {
+            return;
+        };
+
+        self.token.wakers().remove(index);
+    }
+}

--- a/crypto-ffi/src/cancellation/mod.rs
+++ b/crypto-ffi/src/cancellation/mod.rs
@@ -1,0 +1,3 @@
+mod token;
+
+pub use token::CoreCryptoCancellationToken;

--- a/crypto-ffi/src/cancellation/mod.rs
+++ b/crypto-ffi/src/cancellation/mod.rs
@@ -1,5 +1,7 @@
+mod future;
 mod slot;
 mod token;
 
+pub(crate) use future::Cancelled;
 pub(crate) use slot::CancellationSlot;
 pub use token::CoreCryptoCancellationToken;

--- a/crypto-ffi/src/cancellation/mod.rs
+++ b/crypto-ffi/src/cancellation/mod.rs
@@ -1,3 +1,4 @@
+mod slot;
 mod token;
 
 pub use token::CoreCryptoCancellationToken;

--- a/crypto-ffi/src/cancellation/mod.rs
+++ b/crypto-ffi/src/cancellation/mod.rs
@@ -1,4 +1,5 @@
 mod slot;
 mod token;
 
+pub(crate) use slot::CancellationSlot;
 pub use token::CoreCryptoCancellationToken;

--- a/crypto-ffi/src/cancellation/slot.rs
+++ b/crypto-ffi/src/cancellation/slot.rs
@@ -1,0 +1,57 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{CoreCryptoCancellationToken, CoreCryptoError, CoreCryptoResult};
+
+/// Makes the current transaction's cancellation token available to foreign callbacks.
+///
+/// Cancelling the outer transaction does not automatically stop a nested Rust call that is
+/// waiting for a Swift callback. The transport uses this token to stop waiting, which
+/// lets the nested call return and the transaction unwind.
+#[derive(Debug, Default)]
+pub(crate) struct CancellationSlot {
+    current: Mutex<Option<Arc<CoreCryptoCancellationToken>>>,
+}
+
+/// Clears the active cancellation token from the slot when dropped.
+#[derive(Debug)]
+pub(crate) struct CancellationGuard {
+    slot: Arc<CancellationSlot>,
+}
+
+impl CancellationSlot {
+    /// Installs the token for the transaction currently holding the semaphore.
+    ///
+    /// Only one token may be installed at a time.
+    pub(crate) fn enter(
+        self: &Arc<Self>,
+        token: Arc<CoreCryptoCancellationToken>,
+    ) -> CoreCryptoResult<CancellationGuard> {
+        let mut current = self.current.lock().map_err(CoreCryptoError::ad_hoc)?;
+
+        assert!(
+            current.is_none(),
+            "only one transaction cancellation token may be in the slot; correct wrapper implementation never hits this"
+        );
+
+        *current = Some(token);
+        Ok(CancellationGuard { slot: self.clone() })
+    }
+
+    pub(crate) fn current(&self) -> CoreCryptoResult<Option<Arc<CoreCryptoCancellationToken>>> {
+        self.current
+            .lock()
+            .map_err(CoreCryptoError::ad_hoc)
+            .map(|guard| guard.clone())
+    }
+}
+
+impl Drop for CancellationGuard {
+    fn drop(&mut self) {
+        let mut current = self.slot.current.lock().unwrap_or_else(|poisoned| {
+            log::warn!("recovering poisoned cancellation slot");
+            poisoned.into_inner()
+        });
+
+        *current = None;
+    }
+}

--- a/crypto-ffi/src/cancellation/token/mod.rs
+++ b/crypto-ffi/src/cancellation/token/mod.rs
@@ -61,4 +61,12 @@ impl CoreCryptoCancellationToken {
             poisoned.into_inner()
         })
     }
+
+    /// Return a future that resolves when this token is cancelled.
+    pub(crate) fn cancelled(self: &Arc<Self>) -> Cancelled {
+        Cancelled {
+            token: self.clone(),
+            wakers_index: None,
+        }
+    }
 }

--- a/crypto-ffi/src/cancellation/token/mod.rs
+++ b/crypto-ffi/src/cancellation/token/mod.rs
@@ -1,0 +1,64 @@
+mod wakers;
+
+use std::sync::{
+    Arc, Mutex, MutexGuard,
+    atomic::{AtomicBool, Ordering},
+};
+
+use crate::cancellation::{Cancelled, token::wakers::CancellationWakers};
+
+/// Use this to cancel a `CoreCrypto` transaction and running foreign callbacks. Should be used in the Swift wrapper
+/// only.
+#[derive(Debug, uniffi::Object)]
+pub struct CoreCryptoCancellationToken {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    cancelled: AtomicBool,
+    /// We're using a non-async lock to avoid spawning another future to wait during
+    /// [CoreCryptoCancellationToken::cancel].
+    wakers: Mutex<CancellationWakers>,
+}
+
+#[uniffi::export]
+impl CoreCryptoCancellationToken {
+    /// Create a new `CoreCryptoCancellationToken`.
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Default::default(),
+        })
+    }
+
+    /// Cancel the token and wake all futures waiting for `cancelled()`.
+    pub fn cancel(&self) {
+        // Set the cancel atomic to true, clear wakers and wake them.
+        if !self.inner.cancelled.swap(true, Ordering::SeqCst) {
+            let wakers = self.wakers().take_all();
+
+            for waker in wakers.into_iter().flatten() {
+                waker.wake();
+            }
+        }
+    }
+
+    /// Whether `cancel` has been called.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::SeqCst)
+    }
+}
+
+impl CoreCryptoCancellationToken {
+    /// Locks the disposable waker registry, recovering poisoned state.
+    ///
+    /// The registry contains only transient notification state, so cancellation
+    /// remains usable after a waiter panics. Recovery is logged for visibility.
+    pub(crate) fn wakers(&self) -> MutexGuard<'_, CancellationWakers> {
+        self.inner.wakers.lock().unwrap_or_else(|poisoned| {
+            log::warn!("recovering poisoned cancellation waker registry");
+            poisoned.into_inner()
+        })
+    }
+}

--- a/crypto-ffi/src/cancellation/token/wakers.rs
+++ b/crypto-ffi/src/cancellation/token/wakers.rs
@@ -1,0 +1,48 @@
+use std::task::Waker;
+
+/// The collection of wakers where each future that's waiting for cancellation of this token will register when it's
+/// polled (which is a no op in case of repeated polling).
+#[derive(Debug, Default)]
+pub(crate) struct CancellationWakers {
+    wakers: Vec<Option<Waker>>,
+}
+
+impl CancellationWakers {
+    /// Called by the future to register its waker.
+    pub(crate) fn insert(&mut self, wakers_index: &mut Option<usize>, waker: &Waker) {
+        // If there is already a waker at the given index...
+        if let Some(entry) = wakers_index.and_then(|index| self.wakers.get_mut(index)) {
+            if entry
+                .as_ref()
+                .is_none_or(|existing_waker| !existing_waker.will_wake(waker))
+            {
+                // Only replace it if it doesn't awake the same task (i.e., not a repeated poll for the same
+                // future).
+                *entry = Some(waker.clone());
+            }
+            return;
+        }
+
+        // If we're still here, we need to add the given waker to the wakers list.
+        // To avoid the vector to grow for the lifetime of the future, reuse the first `None` position. If there
+        // isn't one, extend the vector.
+        let index = self.wakers.iter().position(Option::is_none).unwrap_or_else(|| {
+            self.wakers.push(None);
+            self.wakers.len() - 1
+        });
+
+        self.wakers[index] = Some(waker.clone());
+        *wakers_index = Some(index);
+    }
+
+    pub(crate) fn remove(&mut self, index: usize) {
+        // We need to keep the indices stable, so removal means just emptying the entry.
+        if let Some(entry) = self.wakers.get_mut(index) {
+            *entry = None;
+        }
+    }
+
+    pub(super) fn take_all(&mut self) -> Vec<Option<Waker>> {
+        std::mem::take(&mut self.wakers)
+    }
+}

--- a/crypto-ffi/src/core_crypto/command/mod.rs
+++ b/crypto-ffi/src/core_crypto/command/mod.rs
@@ -3,7 +3,9 @@ pub(crate) mod transaction_helper;
 
 use std::sync::Arc;
 
-use crate::{CoreCryptoContext, CoreCryptoFfi, CoreCryptoResult};
+use futures_util::FutureExt;
+
+use crate::{CoreCryptoCancellationToken, CoreCryptoContext, CoreCryptoError, CoreCryptoFfi, CoreCryptoResult};
 
 /// A `CoreCryptoCommand` has an `execute` method which accepts a `CoreCryptoContext` and returns nothing.
 ///
@@ -54,6 +56,7 @@ impl CoreCryptoFfi {
 
         let context = CoreCryptoContext {
             inner: inner_context.clone(),
+            cancellation_slot: self.cancellation_slot.clone(),
         };
 
         // We need one more layer of Arc-wrapping in uniffi. It's kind of silly, given the
@@ -63,6 +66,64 @@ impl CoreCryptoFfi {
 
         log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 3; "created context; executing command");
         let result = command.execute(context).await;
+        match result {
+            Ok(()) => {
+                log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 4, command_success = true; "command succeeded; committing transaction");
+                inner_context.finish().await?;
+                log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 5, command_success = true; "exiting successfully");
+                Ok(())
+            }
+            Err(err) => {
+                log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 4, command_success = false; "command failed; aborting transaction");
+                inner_context.abort().await?;
+                log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 5, command_success = false, err:err; "exiting propagating error");
+                Err(err)
+            }
+        }
+    }
+
+    /// Like `transaction_ffi`, but cancellable.
+    ///
+    /// Cancelling the token aborts the transaction and stops waiting for any
+    /// in-flight `MlsTransport` callback associated with it.
+    pub async fn transaction_ffi_cancellable(
+        &self,
+        command: Command,
+        cancellation: Arc<CoreCryptoCancellationToken>,
+    ) -> CoreCryptoResult<()> {
+        log::info!(
+            scope = "CoreCryptoFfi::transaction_ffi", stage = 1;
+            "racing cancellation token against acquisition of transaction semaphore"
+        );
+        // Prefer cancellation so a pre-cancelled token cannot start a transaction.
+        let inner_context = futures_util::select_biased! {
+            _ = cancellation.cancelled().fuse() => return Err(CoreCryptoError::TransactionCanceled),
+            inner_context_result = self.inner.new_transaction().fuse() => inner_context_result?,
+        };
+
+        log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 2; "acquired semaphore; creating context");
+        let inner_context = Arc::new(inner_context);
+
+        // Only the transaction owning the semaphore may publish its token. This guard
+        // is declared after the context so the slot is cleared before the semaphore is released.
+        let _cancellation_guard = self.cancellation_slot.enter(cancellation.clone())?;
+
+        let context = CoreCryptoContext {
+            inner: inner_context.clone(),
+            cancellation_slot: self.cancellation_slot.clone(),
+        };
+
+        let context = Arc::new(context);
+
+        log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 3; "created context; racing command against cancellation");
+
+        // Prefer cancellation when both futures become ready together. This also
+        // normalizes cancellation observed by an MLS transport callback.
+        let result = futures_util::select_biased! {
+            _ = cancellation.cancelled().fuse() => Err(CoreCryptoError::TransactionCanceled),
+            result = command.execute(context).fuse() => result,
+        };
+
         match result {
             Ok(()) => {
                 log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 4, command_success = true; "command succeeded; committing transaction");

--- a/crypto-ffi/src/core_crypto/command/mod.rs
+++ b/crypto-ffi/src/core_crypto/command/mod.rs
@@ -3,9 +3,12 @@ pub(crate) mod transaction_helper;
 
 use std::sync::Arc;
 
+#[cfg(feature = "cancellable-transactions")]
 use futures_util::FutureExt;
 
-use crate::{CoreCryptoCancellationToken, CoreCryptoContext, CoreCryptoError, CoreCryptoFfi, CoreCryptoResult};
+#[cfg(feature = "cancellable-transactions")]
+use crate::{CoreCryptoCancellationToken, CoreCryptoError};
+use crate::{CoreCryptoContext, CoreCryptoFfi, CoreCryptoResult};
 
 /// A `CoreCryptoCommand` has an `execute` method which accepts a `CoreCryptoContext` and returns nothing.
 ///
@@ -56,6 +59,7 @@ impl CoreCryptoFfi {
 
         let context = CoreCryptoContext {
             inner: inner_context.clone(),
+            #[cfg(feature = "cancellable-transactions")]
             cancellation_slot: self.cancellation_slot.clone(),
         };
 
@@ -81,7 +85,11 @@ impl CoreCryptoFfi {
             }
         }
     }
+}
 
+#[cfg(feature = "cancellable-transactions")]
+#[uniffi::export]
+impl CoreCryptoFfi {
     /// Like `transaction_ffi`, but cancellable.
     ///
     /// Cancelling the token aborts the transaction and stops waiting for any

--- a/crypto-ffi/src/core_crypto/command/mod.rs
+++ b/crypto-ffi/src/core_crypto/command/mod.rs
@@ -85,7 +85,7 @@ impl CoreCryptoFfi {
     /// Like `transaction_ffi`, but cancellable.
     ///
     /// Cancelling the token aborts the transaction and stops waiting for any
-    /// in-flight `MlsTransport` callback associated with it.
+    /// in-flight `MlsTransport` callback or `PkiEnvironment` hook associated with it.
     pub async fn transaction_ffi_cancellable(
         &self,
         command: Command,
@@ -104,9 +104,18 @@ impl CoreCryptoFfi {
         log::info!(scope = "CoreCryptoFfi::transaction_ffi", stage = 2; "acquired semaphore; creating context");
         let inner_context = Arc::new(inner_context);
 
-        // Only the transaction owning the semaphore may publish its token. This guard
-        // is declared after the context so the slot is cleared before the semaphore is released.
+        // Only the transaction owning the semaphore may publish its token. These guards
+        // are declared after the context so the slots are cleared before the semaphore is released.
         let _cancellation_guard = self.cancellation_slot.enter(cancellation.clone())?;
+        let pki_cancellation_slot = self
+            .pki_environment
+            .read()
+            .await
+            .as_ref()
+            .map(|environment| environment.cancellation_slot.clone());
+        let _pki_cancellation_guard = pki_cancellation_slot
+            .map(|slot| slot.enter(cancellation.clone()))
+            .transpose()?;
 
         let context = CoreCryptoContext {
             inner: inner_context.clone(),

--- a/crypto-ffi/src/core_crypto/mls_transport.rs
+++ b/crypto-ffi/src/core_crypto/mls_transport.rs
@@ -6,8 +6,12 @@
 use std::{fmt, sync::Arc};
 
 use core_crypto::{CommitBundle as CryptoCommitBundle, HistorySecret};
+use futures_util::{FutureExt as _, TryFutureExt as _};
 
-use crate::{ClientId, CommitBundle, HistorySecret as HistorySecretFfi, error::mls_transport::MlsTransportResult};
+use crate::{
+    ClientId, CommitBundle, HistorySecret as HistorySecretFfi, cancellation::CancellationSlot,
+    error::mls_transport::MlsTransportResult,
+};
 
 /// Application data packaged to be encrypted and transmitted in an MLS application message.
 //
@@ -37,12 +41,15 @@ pub trait MlsTransport: Send + Sync {
 }
 
 #[derive(derive_more::Constructor)]
-struct MlsTransportShim(Arc<dyn MlsTransport>);
+struct MlsTransportShim {
+    callbacks: Arc<dyn MlsTransport>,
+    cancellation_slot: Arc<CancellationSlot>,
+}
 
 impl std::fmt::Debug for MlsTransportShim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("MlsTransportShim")
-            .field(&fmt::from_fn(|f| write!(f, "{:p}", Arc::as_ptr(&self.0))))
+            .field(&fmt::from_fn(|f| write!(f, "{:p}", Arc::as_ptr(&self.callbacks))))
             .finish()
     }
 }
@@ -53,10 +60,19 @@ impl core_crypto::MlsTransport for MlsTransportShim {
     async fn send_commit_bundle(&self, commit_bundle: CryptoCommitBundle) -> core_crypto::Result<()> {
         let commit_bundle = CommitBundle::try_from(commit_bundle)
             .map_err(|e| core_crypto::Error::ErrorDuringMlsTransport(e.to_string()))?;
-        self.0.send_commit_bundle(commit_bundle).await.map_err(Into::into)
+
+        race_callback(
+            &self.cancellation_slot,
+            async { self.callbacks.send_commit_bundle(commit_bundle) }
+                .await
+                .map_err(Into::into),
+        )
+        .await
     }
 
     async fn prepare_for_transport(&self, secret: &HistorySecret) -> core_crypto::Result<core_crypto::TransportData> {
+        // This callback is expected to perform only short-running local preparation,
+        // so it is intentionally not raced against transaction cancellation.
         let client_id = ClientId::from(secret.client_id.clone()).into();
         let history_secret = rmp_serde::to_vec(&secret)
             .map(|secret| HistorySecretFfi {
@@ -64,11 +80,36 @@ impl core_crypto::MlsTransport for MlsTransportShim {
                 data: secret,
             })
             .map_err(|e| core_crypto::Error::ErrorDuringMlsTransport(e.to_string()))?;
-        Ok(self.0.prepare_for_transport(history_secret).await.into())
+        Ok(self.callbacks.prepare_for_transport(history_secret).await.into())
     }
 }
 
-/// In uniffi, `MlsTransport` is a trait which we need to wrap
-pub(crate) fn callback_shim(callbacks: Arc<dyn MlsTransport>) -> Arc<dyn core_crypto::MlsTransport> {
-    Arc::new(MlsTransportShim::new(callbacks))
+/// In uniffi, `MlsTransport` is a trait which we need to wrap, and we need to provide the transport shim with the
+/// cancellation slot of core crypto.
+pub(crate) fn callback_shim(
+    callbacks: Arc<dyn MlsTransport>,
+    cancellation_slot: Arc<CancellationSlot>,
+) -> Arc<dyn core_crypto::MlsTransport> {
+    Arc::new(MlsTransportShim::new(callbacks, cancellation_slot))
+}
+
+async fn race_callback<T>(
+    slot: &CancellationSlot,
+    callback: impl Future<Output = core_crypto::Result<T>>,
+) -> core_crypto::Result<T> {
+    let Some(token) = slot
+        .current()
+        .map_err(|e| core_crypto::Error::ErrorDuringMlsTransport(e.to_string()))?
+    else {
+        return callback.await;
+    };
+
+    // Futures used with select_biased!{} need to be `Fuse` instances. select_biased!{} prefers the first declared
+    // future in case both finish at the same time.
+    let result = futures_util::select_biased! {
+        result = callback.fuse() => result,
+        _ = token.cancelled().fuse() => Err(core_crypto::Error::ErrorDuringMlsTransport("cancelled via cancellation token".into())),
+    };
+
+    result
 }

--- a/crypto-ffi/src/core_crypto/mls_transport.rs
+++ b/crypto-ffi/src/core_crypto/mls_transport.rs
@@ -6,12 +6,12 @@
 use std::{fmt, sync::Arc};
 
 use core_crypto::{CommitBundle as CryptoCommitBundle, HistorySecret};
+#[cfg(feature = "cancellable-transactions")]
 use futures_util::{FutureExt as _, TryFutureExt as _};
 
-use crate::{
-    ClientId, CommitBundle, HistorySecret as HistorySecretFfi, cancellation::CancellationSlot,
-    error::mls_transport::MlsTransportResult,
-};
+#[cfg(feature = "cancellable-transactions")]
+use crate::cancellation::CancellationSlot;
+use crate::{ClientId, CommitBundle, HistorySecret as HistorySecretFfi, error::mls_transport::MlsTransportResult};
 
 /// Application data packaged to be encrypted and transmitted in an MLS application message.
 //
@@ -43,6 +43,7 @@ pub trait MlsTransport: Send + Sync {
 #[derive(derive_more::Constructor)]
 struct MlsTransportShim {
     callbacks: Arc<dyn MlsTransport>,
+    #[cfg(feature = "cancellable-transactions")]
     cancellation_slot: Arc<CancellationSlot>,
 }
 
@@ -61,13 +62,20 @@ impl core_crypto::MlsTransport for MlsTransportShim {
         let commit_bundle = CommitBundle::try_from(commit_bundle)
             .map_err(|e| core_crypto::Error::ErrorDuringMlsTransport(e.to_string()))?;
 
-        race_callback(
-            &self.cancellation_slot,
-            async { self.callbacks.send_commit_bundle(commit_bundle) }
-                .await
-                .map_err(Into::into),
-        )
-        .await
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            return race_callback(
+                &self.cancellation_slot,
+                self.callbacks.send_commit_bundle(commit_bundle).map_err(Into::into),
+            )
+            .await;
+        }
+
+        #[cfg(not(feature = "cancellable-transactions"))]
+        self.callbacks
+            .send_commit_bundle(commit_bundle)
+            .await
+            .map_err(Into::into)
     }
 
     async fn prepare_for_transport(&self, secret: &HistorySecret) -> core_crypto::Result<core_crypto::TransportData> {
@@ -86,6 +94,7 @@ impl core_crypto::MlsTransport for MlsTransportShim {
 
 /// In uniffi, `MlsTransport` is a trait which we need to wrap, and we need to provide the transport shim with the
 /// cancellation slot of core crypto.
+#[cfg(feature = "cancellable-transactions")]
 pub(crate) fn callback_shim(
     callbacks: Arc<dyn MlsTransport>,
     cancellation_slot: Arc<CancellationSlot>,
@@ -93,6 +102,12 @@ pub(crate) fn callback_shim(
     Arc::new(MlsTransportShim::new(callbacks, cancellation_slot))
 }
 
+#[cfg(not(feature = "cancellable-transactions"))]
+pub(crate) fn callback_shim(callbacks: Arc<dyn MlsTransport>) -> Arc<dyn core_crypto::MlsTransport> {
+    Arc::new(MlsTransportShim::new(callbacks))
+}
+
+#[cfg(feature = "cancellable-transactions")]
 async fn race_callback<T>(
     slot: &CancellationSlot,
     callback: impl Future<Output = core_crypto::Result<T>>,

--- a/crypto-ffi/src/core_crypto/mod.rs
+++ b/crypto-ffi/src/core_crypto/mod.rs
@@ -13,12 +13,13 @@ mod randomness;
 
 use std::sync::Arc;
 
-use crate::{CoreCryptoResult, Database};
+use crate::{CoreCryptoResult, Database, cancellation::CancellationSlot};
 
 /// CoreCrypto wraps around MLS and Proteus implementations and provides a transactional interface for each.
 #[derive(Debug, uniffi::Object)]
 pub struct CoreCryptoFfi {
     pub(crate) inner: Arc<core_crypto::CoreCrypto>,
+    pub(crate) cancellation_slot: Arc<CancellationSlot>,
 }
 
 /// Construct a new `CoreCryptoFfi` instance.
@@ -32,7 +33,10 @@ pub fn core_crypto_new(database: &Arc<Database>) -> CoreCryptoResult<CoreCryptoF
     let db = database.as_ref().clone().into();
     let inner = core_crypto::CoreCrypto::new(db);
 
-    Ok(CoreCryptoFfi { inner })
+    Ok(CoreCryptoFfi {
+        inner,
+        cancellation_slot: Default::default(),
+    })
 }
 
 #[cfg_attr(any(feature = "wasm", feature = "napi"), uniffi::export)]

--- a/crypto-ffi/src/core_crypto/mod.rs
+++ b/crypto-ffi/src/core_crypto/mod.rs
@@ -13,13 +13,16 @@ mod randomness;
 
 use std::sync::Arc;
 
-use crate::{CoreCryptoResult, Database, cancellation::CancellationSlot};
+use async_lock::RwLock;
+
+use crate::{CoreCryptoResult, Database, PkiEnvironment, cancellation::CancellationSlot};
 
 /// CoreCrypto wraps around MLS and Proteus implementations and provides a transactional interface for each.
 #[derive(Debug, uniffi::Object)]
 pub struct CoreCryptoFfi {
     pub(crate) inner: Arc<core_crypto::CoreCrypto>,
     pub(crate) cancellation_slot: Arc<CancellationSlot>,
+    pub(crate) pki_environment: RwLock<Option<Arc<PkiEnvironment>>>,
 }
 
 /// Construct a new `CoreCryptoFfi` instance.
@@ -36,6 +39,7 @@ pub fn core_crypto_new(database: &Arc<Database>) -> CoreCryptoResult<CoreCryptoF
     Ok(CoreCryptoFfi {
         inner,
         cancellation_slot: Default::default(),
+        pki_environment: Default::default(),
     })
 }
 

--- a/crypto-ffi/src/core_crypto/mod.rs
+++ b/crypto-ffi/src/core_crypto/mod.rs
@@ -13,15 +13,20 @@ mod randomness;
 
 use std::sync::Arc;
 
+#[cfg(feature = "cancellable-transactions")]
 use async_lock::RwLock;
 
-use crate::{CoreCryptoResult, Database, PkiEnvironment, cancellation::CancellationSlot};
+use crate::{CoreCryptoResult, Database};
+#[cfg(feature = "cancellable-transactions")]
+use crate::{PkiEnvironment, cancellation::CancellationSlot};
 
 /// CoreCrypto wraps around MLS and Proteus implementations and provides a transactional interface for each.
 #[derive(Debug, uniffi::Object)]
 pub struct CoreCryptoFfi {
     pub(crate) inner: Arc<core_crypto::CoreCrypto>,
+    #[cfg(feature = "cancellable-transactions")]
     pub(crate) cancellation_slot: Arc<CancellationSlot>,
+    #[cfg(feature = "cancellable-transactions")]
     pub(crate) pki_environment: RwLock<Option<Arc<PkiEnvironment>>>,
 }
 
@@ -38,7 +43,9 @@ pub fn core_crypto_new(database: &Arc<Database>) -> CoreCryptoResult<CoreCryptoF
 
     Ok(CoreCryptoFfi {
         inner,
+        #[cfg(feature = "cancellable-transactions")]
         cancellation_slot: Default::default(),
+        #[cfg(feature = "cancellable-transactions")]
         pki_environment: Default::default(),
     })
 }

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -80,7 +80,7 @@ impl CoreCryptoContext {
     /// Calling it multiple times with varying parameters might succeed, but this is not a supported or tested mode of
     /// operation.
     pub async fn mls_init(&self, client_id: &Arc<ClientId>, transport: Arc<dyn MlsTransport>) -> CoreCryptoResult<()> {
-        let transport = callback_shim(transport);
+        let transport = callback_shim(transport, self.cancellation_slot.clone());
         self.inner
             .mls_init(client_id.as_ref().as_ref().to_owned(), transport)
             .await?;

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -80,7 +80,10 @@ impl CoreCryptoContext {
     /// Calling it multiple times with varying parameters might succeed, but this is not a supported or tested mode of
     /// operation.
     pub async fn mls_init(&self, client_id: &Arc<ClientId>, transport: Arc<dyn MlsTransport>) -> CoreCryptoResult<()> {
+        #[cfg(feature = "cancellable-transactions")]
         let transport = callback_shim(transport, self.cancellation_slot.clone());
+        #[cfg(not(feature = "cancellable-transactions"))]
+        let transport = callback_shim(transport);
         self.inner
             .mls_init(client_id.as_ref().as_ref().to_owned(), transport)
             .await?;

--- a/crypto-ffi/src/core_crypto_context/mod.rs
+++ b/crypto-ffi/src/core_crypto_context/mod.rs
@@ -6,7 +6,9 @@ use std::{ops::Deref, sync::Arc};
 
 use core_crypto::transaction_context::TransactionContext;
 
-use crate::{CoreCryptoResult, cancellation::CancellationSlot};
+use crate::CoreCryptoResult;
+#[cfg(feature = "cancellable-transactions")]
+use crate::cancellation::CancellationSlot;
 
 /// The `CoreCryptoContext` holds the primary `CoreCrypto` APIs.
 ///
@@ -17,6 +19,7 @@ use crate::{CoreCryptoResult, cancellation::CancellationSlot};
 #[derive(Debug, uniffi::Object)]
 pub struct CoreCryptoContext {
     pub(crate) inner: Arc<TransactionContext>,
+    #[cfg(feature = "cancellable-transactions")]
     pub(crate) cancellation_slot: Arc<CancellationSlot>,
 }
 

--- a/crypto-ffi/src/core_crypto_context/mod.rs
+++ b/crypto-ffi/src/core_crypto_context/mod.rs
@@ -6,7 +6,7 @@ use std::{ops::Deref, sync::Arc};
 
 use core_crypto::transaction_context::TransactionContext;
 
-use crate::CoreCryptoResult;
+use crate::{CoreCryptoResult, cancellation::CancellationSlot};
 
 /// The `CoreCryptoContext` holds the primary `CoreCrypto` APIs.
 ///
@@ -17,6 +17,7 @@ use crate::CoreCryptoResult;
 #[derive(Debug, uniffi::Object)]
 pub struct CoreCryptoContext {
     pub(crate) inner: Arc<TransactionContext>,
+    pub(crate) cancellation_slot: Arc<CancellationSlot>,
 }
 
 impl Deref for CoreCryptoContext {

--- a/crypto-ffi/src/ephemeral.rs
+++ b/crypto-ffi/src/ephemeral.rs
@@ -33,7 +33,10 @@ async fn history_client_inner(history_secret: HistorySecret) -> CoreCryptoResult
         rmp_serde::from_slice::<CoreCryptoHistorySecret>(&history_secret.data).map_err(CoreCryptoError::generic())?;
     CoreCrypto::history_client(secret)
         .await
-        .map(|inner| CoreCryptoFfi { inner })
+        .map(|inner| CoreCryptoFfi {
+            inner,
+            cancellation_slot: Default::default(),
+        })
         .map_err(Into::into)
 }
 

--- a/crypto-ffi/src/ephemeral.rs
+++ b/crypto-ffi/src/ephemeral.rs
@@ -35,7 +35,9 @@ async fn history_client_inner(history_secret: HistorySecret) -> CoreCryptoResult
         .await
         .map(|inner| CoreCryptoFfi {
             inner,
+            #[cfg(feature = "cancellable-transactions")]
             cancellation_slot: Default::default(),
+            #[cfg(feature = "cancellable-transactions")]
             pki_environment: Default::default(),
         })
         .map_err(Into::into)

--- a/crypto-ffi/src/ephemeral.rs
+++ b/crypto-ffi/src/ephemeral.rs
@@ -36,6 +36,7 @@ async fn history_client_inner(history_secret: HistorySecret) -> CoreCryptoResult
         .map(|inner| CoreCryptoFfi {
             inner,
             cancellation_slot: Default::default(),
+            pki_environment: Default::default(),
         })
         .map_err(Into::into)
 }

--- a/crypto-ffi/src/error/core_crypto.rs
+++ b/crypto-ffi/src/error/core_crypto.rs
@@ -26,6 +26,9 @@ pub enum CoreCryptoError {
     /// A transaction was rolled back due to an unexpected callback error.
     #[error("Transaction rolled back due to unexpected uniffi error: {error:?}")]
     TransactionFailed { error: String },
+    /// The transaction was canceled via the cancellation token.
+    #[error("The transaction was canceled via the cancellation token.")]
+    TransactionCanceled,
     /// An unclassified error.
     #[error("{msg}")]
     Other { msg: String },

--- a/crypto-ffi/src/error/core_crypto.rs
+++ b/crypto-ffi/src/error/core_crypto.rs
@@ -27,6 +27,7 @@ pub enum CoreCryptoError {
     #[error("Transaction rolled back due to unexpected uniffi error: {error:?}")]
     TransactionFailed { error: String },
     /// The transaction was canceled via the cancellation token.
+    #[cfg(feature = "cancellable-transactions")]
     #[error("The transaction was canceled via the cancellation token.")]
     TransactionCanceled,
     /// An unclassified error.

--- a/crypto-ffi/src/lib.rs
+++ b/crypto-ffi/src/lib.rs
@@ -13,6 +13,7 @@ uniffi::setup_scaffolding!("core_crypto_ffi");
 
 mod bundles;
 mod bytes_wrapper;
+mod cancellation;
 mod cipher_suite;
 mod client_id;
 mod core_crypto;
@@ -35,6 +36,7 @@ mod signature_scheme;
 mod timestamp;
 
 pub use bundles::{commit::CommitBundle, group_info::GroupInfoBundle, proteus_auto_prekey::ProteusAutoPrekeyBundle};
+pub use cancellation::CoreCryptoCancellationToken;
 pub use cipher_suite::{CipherSuite, cipher_suite_default, cipher_suite_from_u16};
 pub use client_id::{ClientId, DeserializedClientId, DeviceId, Uuid};
 #[cfg(not(target_os = "unknown"))]

--- a/crypto-ffi/src/lib.rs
+++ b/crypto-ffi/src/lib.rs
@@ -13,6 +13,7 @@ uniffi::setup_scaffolding!("core_crypto_ffi");
 
 mod bundles;
 mod bytes_wrapper;
+#[cfg(feature = "cancellable-transactions")]
 mod cancellation;
 mod cipher_suite;
 mod client_id;
@@ -36,6 +37,7 @@ mod signature_scheme;
 mod timestamp;
 
 pub use bundles::{commit::CommitBundle, group_info::GroupInfoBundle, proteus_auto_prekey::ProteusAutoPrekeyBundle};
+#[cfg(feature = "cancellable-transactions")]
 pub use cancellation::CoreCryptoCancellationToken;
 pub use cipher_suite::{CipherSuite, cipher_suite_default, cipher_suite_from_u16};
 pub use client_id::{ClientId, DeserializedClientId, DeviceId, Uuid};

--- a/crypto-ffi/src/pki_env.rs
+++ b/crypto-ffi/src/pki_env.rs
@@ -1,9 +1,10 @@
 use std::{fmt, sync::Arc};
 
+use futures_util::{FutureExt as _, TryFutureExt as _};
 use wire_e2e_identity::pki_env;
 use x509_cert::der::DecodePem as _;
 
-use crate::{CoreCryptoError, CoreCryptoFfi, CoreCryptoResult, Database};
+use crate::{CoreCryptoError, CoreCryptoFfi, CoreCryptoResult, Database, cancellation::CancellationSlot};
 
 /// HttpMethod used for PKI hooks.
 #[derive(uniffi::Enum)]
@@ -174,12 +175,15 @@ pub trait PkiEnvironmentHooks: Send + Sync {
 }
 
 #[derive(derive_more::Constructor)]
-struct PkiEnvironmentHooksShim(Arc<dyn PkiEnvironmentHooks>);
+struct PkiEnvironmentHooksShim {
+    callbacks: Arc<dyn PkiEnvironmentHooks>,
+    cancellation_slot: Arc<CancellationSlot>,
+}
 
 impl std::fmt::Debug for PkiEnvironmentHooksShim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("PkiEnvironmentHooksShim")
-            .field(&fmt::from_fn(|f| write!(f, "{:p}", Arc::as_ptr(&self.0))))
+            .field(&fmt::from_fn(|f| write!(f, "{:p}", Arc::as_ptr(&self.callbacks))))
             .finish()
     }
 }
@@ -195,11 +199,14 @@ impl pki_env::hooks::PkiEnvironmentHooks for PkiEnvironmentHooksShim {
         body: Vec<u8>,
     ) -> Result<pki_env::hooks::HttpResponse, pki_env::hooks::PkiEnvironmentHooksError> {
         let headers = headers.into_iter().map(Into::into).collect();
-        self.0
-            .http_request(method.into(), url, headers, body)
-            .await
-            .map(Into::into)
-            .map_err(Into::into)
+        race_callback(
+            &self.cancellation_slot,
+            self.callbacks
+                .http_request(method.into(), url, headers, body)
+                .map_ok(Into::into)
+                .map_err(Into::into),
+        )
+        .await
     }
 
     async fn authenticate(
@@ -209,35 +216,70 @@ impl pki_env::hooks::PkiEnvironmentHooks for PkiEnvironmentHooksShim {
         acme_aud: String,
         acquisition_snapshot: Vec<u8>,
     ) -> Result<String, pki_env::hooks::PkiEnvironmentHooksError> {
-        self.0
-            .authenticate(idp, key_auth, acme_aud, acquisition_snapshot)
-            .await
-            .map_err(Into::into)
+        race_callback(
+            &self.cancellation_slot,
+            self.callbacks
+                .authenticate(idp, key_auth, acme_aud, acquisition_snapshot)
+                .map_err(Into::into),
+        )
+        .await
     }
 
     async fn get_backend_nonce(&self) -> Result<String, pki_env::hooks::PkiEnvironmentHooksError> {
-        self.0.get_backend_nonce().await.map_err(Into::into)
+        race_callback(
+            &self.cancellation_slot,
+            self.callbacks.get_backend_nonce().map_err(Into::into),
+        )
+        .await
     }
 
     async fn fetch_backend_access_token(
         &self,
         dpop: String,
     ) -> Result<String, pki_env::hooks::PkiEnvironmentHooksError> {
-        self.0.fetch_backend_access_token(dpop).await.map_err(Into::into)
+        race_callback(
+            &self.cancellation_slot,
+            self.callbacks.fetch_backend_access_token(dpop).map_err(Into::into),
+        )
+        .await
+    }
+}
+
+async fn race_callback<T>(
+    slot: &CancellationSlot,
+    callback: impl Future<Output = Result<T, pki_env::hooks::PkiEnvironmentHooksError>>,
+) -> Result<T, pki_env::hooks::PkiEnvironmentHooksError> {
+    let Some(token) = slot
+        .current()
+        .map_err(|error| pki_env::hooks::PkiEnvironmentHooksError {
+            reason: error.to_string(),
+        })?
+    else {
+        return callback.await;
+    };
+
+    futures_util::select_biased! {
+        _ = token.cancelled().fuse() => Err(pki_env::hooks::PkiEnvironmentHooksError {
+            reason: "cancelled via cancellation token".into(),
+        }),
+        result = callback.fuse() => result,
     }
 }
 
 /// The PKI environment used for certificate management during X509 credential acquisition.
-#[derive(uniffi::Object)]
-pub struct PkiEnvironment(Arc<wire_e2e_identity::pki_env::PkiEnvironment>);
+#[derive(Debug, uniffi::Object)]
+pub struct PkiEnvironment {
+    inner: Arc<wire_e2e_identity::pki_env::PkiEnvironment>,
+    pub(crate) cancellation_slot: Arc<CancellationSlot>,
+}
 
 impl PkiEnvironment {
     pub(crate) fn clone_inner(&self) -> Arc<wire_e2e_identity::pki_env::PkiEnvironment> {
-        self.0.clone()
+        self.inner.clone()
     }
 
     pub(crate) fn database(&self) -> Database {
-        self.0.database_arc().into()
+        self.inner.database_arc().into()
     }
 }
 
@@ -246,9 +288,13 @@ impl PkiEnvironment {
     /// Create a new PKI environment.
     #[cfg_attr(any(feature = "wasm", feature = "napi"), uniffi::constructor)]
     pub async fn new(hooks: Arc<dyn PkiEnvironmentHooks>, database: Arc<Database>) -> CoreCryptoResult<Self> {
-        let shim = Arc::new(PkiEnvironmentHooksShim::new(hooks));
+        let cancellation_slot = Arc::new(CancellationSlot::default());
+        let shim = Arc::new(PkiEnvironmentHooksShim::new(hooks, cancellation_slot.clone()));
         let pki_env = wire_e2e_identity::pki_env::PkiEnvironment::new(shim, database.as_ref().clone().into()).await?;
-        Ok(Self(Arc::new(pki_env)))
+        Ok(Self {
+            inner: Arc::new(pki_env),
+            cancellation_slot,
+        })
     }
 }
 
@@ -260,14 +306,14 @@ impl PkiEnvironment {
     /// times will overwrite any previously added trust anchor.
     pub async fn add_trust_anchor(&self, cert_pem: &str) -> CoreCryptoResult<()> {
         let cert = x509_cert::Certificate::from_pem(cert_pem).map_err(CoreCryptoError::generic())?;
-        self.0.add_trust_anchor(cert).await?;
+        self.inner.add_trust_anchor(cert).await?;
         Ok(())
     }
 
     /// Add a PEM-encoded certificate as an intermediate certificate.
     pub async fn add_intermediate_cert(&self, cert_pem: &str) -> CoreCryptoResult<()> {
         let cert = x509_cert::Certificate::from_pem(cert_pem).map_err(CoreCryptoError::generic())?;
-        self.0.add_intermediate_cert(cert).await?;
+        self.inner.add_intermediate_cert(cert).await?;
         Ok(())
     }
 }
@@ -297,9 +343,6 @@ impl CoreCryptoFfi {
     ///
     /// Returns null if it is not set.
     pub async fn get_pki_environment(&self) -> Option<Arc<PkiEnvironment>> {
-        self.inner
-            .get_pki_environment()
-            .await
-            .map(|inner| Arc::new(PkiEnvironment(inner)))
+        self.pki_environment.read().await.clone()
     }
 }

--- a/crypto-ffi/src/pki_env.rs
+++ b/crypto-ffi/src/pki_env.rs
@@ -1,10 +1,13 @@
 use std::{fmt, sync::Arc};
 
+#[cfg(feature = "cancellable-transactions")]
 use futures_util::{FutureExt as _, TryFutureExt as _};
 use wire_e2e_identity::pki_env;
 use x509_cert::der::DecodePem as _;
 
-use crate::{CoreCryptoError, CoreCryptoFfi, CoreCryptoResult, Database, cancellation::CancellationSlot};
+#[cfg(feature = "cancellable-transactions")]
+use crate::cancellation::CancellationSlot;
+use crate::{CoreCryptoError, CoreCryptoFfi, CoreCryptoResult, Database};
 
 /// HttpMethod used for PKI hooks.
 #[derive(uniffi::Enum)]
@@ -177,6 +180,7 @@ pub trait PkiEnvironmentHooks: Send + Sync {
 #[derive(derive_more::Constructor)]
 struct PkiEnvironmentHooksShim {
     callbacks: Arc<dyn PkiEnvironmentHooks>,
+    #[cfg(feature = "cancellable-transactions")]
     cancellation_slot: Arc<CancellationSlot>,
 }
 
@@ -199,14 +203,24 @@ impl pki_env::hooks::PkiEnvironmentHooks for PkiEnvironmentHooksShim {
         body: Vec<u8>,
     ) -> Result<pki_env::hooks::HttpResponse, pki_env::hooks::PkiEnvironmentHooksError> {
         let headers = headers.into_iter().map(Into::into).collect();
-        race_callback(
-            &self.cancellation_slot,
-            self.callbacks
-                .http_request(method.into(), url, headers, body)
-                .map_ok(Into::into)
-                .map_err(Into::into),
-        )
-        .await
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            return race_callback(
+                &self.cancellation_slot,
+                self.callbacks
+                    .http_request(method.into(), url, headers, body)
+                    .map_ok(Into::into)
+                    .map_err(Into::into),
+            )
+            .await;
+        }
+
+        #[cfg(not(feature = "cancellable-transactions"))]
+        self.callbacks
+            .http_request(method.into(), url, headers, body)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     async fn authenticate(
@@ -216,35 +230,60 @@ impl pki_env::hooks::PkiEnvironmentHooks for PkiEnvironmentHooksShim {
         acme_aud: String,
         acquisition_snapshot: Vec<u8>,
     ) -> Result<String, pki_env::hooks::PkiEnvironmentHooksError> {
-        race_callback(
-            &self.cancellation_slot,
-            self.callbacks
-                .authenticate(idp, key_auth, acme_aud, acquisition_snapshot)
-                .map_err(Into::into),
-        )
-        .await
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            return race_callback(
+                &self.cancellation_slot,
+                self.callbacks
+                    .authenticate(idp, key_auth, acme_aud, acquisition_snapshot)
+                    .map_err(Into::into),
+            )
+            .await;
+        }
+
+        #[cfg(not(feature = "cancellable-transactions"))]
+        self.callbacks
+            .authenticate(idp, key_auth, acme_aud, acquisition_snapshot)
+            .await
+            .map_err(Into::into)
     }
 
     async fn get_backend_nonce(&self) -> Result<String, pki_env::hooks::PkiEnvironmentHooksError> {
-        race_callback(
-            &self.cancellation_slot,
-            self.callbacks.get_backend_nonce().map_err(Into::into),
-        )
-        .await
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            return race_callback(
+                &self.cancellation_slot,
+                self.callbacks.get_backend_nonce().map_err(Into::into),
+            )
+            .await;
+        }
+
+        #[cfg(not(feature = "cancellable-transactions"))]
+        self.callbacks.get_backend_nonce().await.map_err(Into::into)
     }
 
     async fn fetch_backend_access_token(
         &self,
         dpop: String,
     ) -> Result<String, pki_env::hooks::PkiEnvironmentHooksError> {
-        race_callback(
-            &self.cancellation_slot,
-            self.callbacks.fetch_backend_access_token(dpop).map_err(Into::into),
-        )
-        .await
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            return race_callback(
+                &self.cancellation_slot,
+                self.callbacks.fetch_backend_access_token(dpop).map_err(Into::into),
+            )
+            .await;
+        }
+
+        #[cfg(not(feature = "cancellable-transactions"))]
+        self.callbacks
+            .fetch_backend_access_token(dpop)
+            .await
+            .map_err(Into::into)
     }
 }
 
+#[cfg(feature = "cancellable-transactions")]
 async fn race_callback<T>(
     slot: &CancellationSlot,
     callback: impl Future<Output = Result<T, pki_env::hooks::PkiEnvironmentHooksError>>,
@@ -270,6 +309,7 @@ async fn race_callback<T>(
 #[derive(Debug, uniffi::Object)]
 pub struct PkiEnvironment {
     inner: Arc<wire_e2e_identity::pki_env::PkiEnvironment>,
+    #[cfg(feature = "cancellable-transactions")]
     pub(crate) cancellation_slot: Arc<CancellationSlot>,
 }
 
@@ -288,11 +328,19 @@ impl PkiEnvironment {
     /// Create a new PKI environment.
     #[cfg_attr(any(feature = "wasm", feature = "napi"), uniffi::constructor)]
     pub async fn new(hooks: Arc<dyn PkiEnvironmentHooks>, database: Arc<Database>) -> CoreCryptoResult<Self> {
+        #[cfg(feature = "cancellable-transactions")]
         let cancellation_slot = Arc::new(CancellationSlot::default());
-        let shim = Arc::new(PkiEnvironmentHooksShim::new(hooks, cancellation_slot.clone()));
+
+        let shim = Arc::new(PkiEnvironmentHooksShim::new(
+            hooks,
+            #[cfg(feature = "cancellable-transactions")]
+            cancellation_slot.clone(),
+        ));
+
         let pki_env = wire_e2e_identity::pki_env::PkiEnvironment::new(shim, database.as_ref().clone().into()).await?;
         Ok(Self {
             inner: Arc::new(pki_env),
+            #[cfg(feature = "cancellable-transactions")]
             cancellation_slot,
         })
     }
@@ -332,17 +380,30 @@ pub async fn create_pki_environment(
 impl CoreCryptoFfi {
     /// Set the PKI environment of the CoreCrypto instance.
     pub async fn set_pki_environment(&self, pki_environment: Option<Arc<PkiEnvironment>>) {
+        #[cfg(feature = "cancellable-transactions")]
         let mut current = self.pki_environment.write().await;
         self.inner
             .set_pki_environment(pki_environment.as_ref().map(|env| env.inner.clone()))
             .await;
-        *current = pki_environment;
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            *current = pki_environment;
+        }
     }
 
     /// Get the PKI environment of the CoreCrypto instance.
     ///
     /// Returns null if it is not set.
     pub async fn get_pki_environment(&self) -> Option<Arc<PkiEnvironment>> {
-        self.pki_environment.read().await.clone()
+        #[cfg(feature = "cancellable-transactions")]
+        {
+            return self.pki_environment.read().await.clone();
+        }
+
+        #[cfg(not(feature = "cancellable-transactions"))]
+        self.inner
+            .get_pki_environment()
+            .await
+            .map(|inner| Arc::new(PkiEnvironment { inner }))
     }
 }

--- a/crypto-ffi/src/pki_env.rs
+++ b/crypto-ffi/src/pki_env.rs
@@ -286,9 +286,11 @@ pub async fn create_pki_environment(
 impl CoreCryptoFfi {
     /// Set the PKI environment of the CoreCrypto instance.
     pub async fn set_pki_environment(&self, pki_environment: Option<Arc<PkiEnvironment>>) {
+        let mut current = self.pki_environment.write().await;
         self.inner
-            .set_pki_environment(pki_environment.map(|env| env.0.clone()))
+            .set_pki_environment(pki_environment.as_ref().map(|env| env.inner.clone()))
             .await;
+        *current = pki_environment;
     }
 
     /// Get the PKI environment of the CoreCrypto instance.

--- a/make/config.mk
+++ b/make/config.mk
@@ -18,6 +18,8 @@ else
   RELEASE_MODE := release
 endif
 
+SWIFT_CARGO_BUILD_ARGS := $(CARGO_BUILD_ARGS) --features cancellable-transactions
+
 TARGET_DIR := target/$(RELEASE_MODE)
 
 # Detect host platform for NDK and library extensions

--- a/make/ffi.mk
+++ b/make/ffi.mk
@@ -26,7 +26,7 @@ $(UNIFFI_BINDGEN): $(uniffi-bindgen-deps)
 		--bin uniffi-bindgen
 
 # Build the FFI library
-FFI_LIBRARY := $(TARGET_DIR)/libcore_crypto_ffi.$(LIBRARY_EXTENSION)
+FFI_LIBRARY := $(TARGET_DIR)/libcore_crypto_ffi.so
 ffi-library-deps := $(RUST_SOURCES)
 $(FFI_LIBRARY): $(ffi-library-deps)
 	cargo build $(CARGO_BUILD_ARGS) \
@@ -34,16 +34,29 @@ $(FFI_LIBRARY): $(ffi-library-deps)
 		--package core-crypto-ffi \
 		--lib
 
+# Build a separate feature-enabled host library for Swift binding generation.
+SWIFT_FFI_TARGET_DIR := target/swift-bindgen
+SWIFT_FFI_LIBRARY := $(SWIFT_FFI_TARGET_DIR)/$(RELEASE_MODE)/libcore_crypto_ffi.dylib
+swift-ffi-library-deps := $(RUST_SOURCES)
+$(SWIFT_FFI_LIBRARY): $(swift-ffi-library-deps)
+	cargo build $(SWIFT_CARGO_BUILD_ARGS) \
+		--target-dir $(SWIFT_FFI_TARGET_DIR) \
+		--locked \
+		--package core-crypto-ffi \
+		--lib
+
 # Make aliases
-.PHONY: uniffi-bindgen ffi-library
+.PHONY: uniffi-bindgen ffi-library swift-ffi-library
 uniffi-bindgen: $(UNIFFI_BINDGEN)  ## Build the uniffi bindgen binary
 ffi-library: $(FFI_LIBRARY) ## Build the libcore_crypto_ffi library
+swift-ffi-library: $(SWIFT_FFI_LIBRARY) ## Build the feature-enabled host library for Swift bindgen
 
 #-------------------------------------------------------------------------------
 # Use stamp files for generators: only re-run when inputs change
 #-------------------------------------------------------------------------------
 
 bindings-deps := $(UNIFFI_BINDGEN) $(FFI_LIBRARY)
+swift-bindings-deps := $(UNIFFI_BINDGEN) $(SWIFT_FFI_LIBRARY)
 
 # Swift bindings
 UNIFFI_SWIFT_OUTPUT := crypto-ffi/bindings/swift/WireCoreCryptoUniffi/WireCoreCryptoUniffi/core_crypto_ffi.swift
@@ -53,17 +66,17 @@ $(UNIFFI_SWIFT_OUTPUT):
 	$(warning Skipping build for "bindings-swift", as swift bindings generation is only supported on \
 	          Darwin because OpenSSL can't be cross-compiled on non-Darwin systems; this is "$(UNAME_S)".)
 else
-$(UNIFFI_SWIFT_OUTPUT): $(bindings-deps)
+$(UNIFFI_SWIFT_OUTPUT): $(swift-bindings-deps)
 	mkdir -p crypto-ffi/bindings/swift/WireCoreCryptoUniffi/WireCoreCryptoUniffi
 	$(UNIFFI_BINDGEN) generate \
 	  --config crypto-ffi/uniffi.toml \
 	  --language swift \
 	  --out-dir crypto-ffi/bindings/swift/WireCoreCryptoUniffi/WireCoreCryptoUniffi \
-	  --library $(FFI_LIBRARY)
+	  --library $(SWIFT_FFI_LIBRARY)
 endif
 
 .PHONY: bindings-swift swift
-bindings-swift-deps := $(bindings-deps)
+bindings-swift-deps := $(swift-bindings-deps)
 bindings-swift: $(UNIFFI_SWIFT_OUTPUT) ## Generate Swift bindings
 
 swift: bindings-swift $(STAMPS)/docs-swift

--- a/make/ios.mk
+++ b/make/ios.mk
@@ -11,7 +11,7 @@ $(IOS_DEVICE): $(ios-device-deps)
 	  --crate-type=cdylib \
 	  --crate-type=staticlib \
 	  --package core-crypto-ffi \
-	  $(CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
+	  $(SWIFT_CARGO_BUILD_ARGS) -- $(RUST_STRIP_FLAGS)
 
 .PHONY: ios-device
 ios-device: $(IOS_DEVICE) ## Build core-crypto-ffi for aarch64-apple-ios for iOS 16.4 (macOS only)
@@ -28,7 +28,7 @@ $(IOS_SIMULATOR_ARM): $(ios-simulator-arm-deps)
 	  --crate-type=cdylib \
 	  --crate-type=staticlib \
 	  --package core-crypto-ffi \
-	  --release -- $(RUST_STRIP_FLAGS)
+	  $(filter-out --release,$(SWIFT_CARGO_BUILD_ARGS)) --release -- $(RUST_STRIP_FLAGS)
 
 .PHONY: ios-simulator-arm
 ios-simulator-arm: $(IOS_SIMULATOR_ARM) ## Build for aarch64-apple-ios-sim, iOS 16.4 (macOS only). Always builds in release mode (see WPB-25954).


### PR DESCRIPTION
Make core crypto ffi transactions cancellable and run the ffi transaction `withTaskCancellationHandler` in the wrapper. 