### PR TITLE
test: fix mixed cipher suite test

### DIFF
--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -285,12 +285,8 @@ mod tests {
             _ => CipherSuite(Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519),
         };
 
-        let x509_test_chain = case.set_test_chain(&[], &[], None).await;
-        let [bob_id] = case.client_ids();
-        let x509_intermediate = x509_test_chain.find_local_intermediate_ca();
-        let certificate = CertificateBundle::rand(&bob_id, x509_intermediate);
-        let credential = Credential::x509(other_cipher_suite, certificate).unwrap();
-        let bob = SessionContext::new_with_credential(&case, credential).await.unwrap();
+        let mixed_cipher_suite_case = TestContext::new(CredentialType::X509, *other_cipher_suite);
+        let [bob] = mixed_cipher_suite_case.sessions_x509().await;
 
         let bob_kp = bob
             .transaction


### PR DESCRIPTION
The previous version of the test was incorrectly combining cipher suites and sign algorithms. This fixed version does everything in a simpler way: we create the key package with the other cipher suite from a fresh `TestContext`, so it's easier to get it right.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
