### PR TITLE
ci: remove inactive toolchains after setup-rust [WPB-27025]

### DIFF
--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -39,6 +39,11 @@ runs:
         rustflags: ${{ inputs.rustflags }}
         components: ${{ inputs.components }}
         cache: false
+    - name: Cleanup unused Rust toolchains
+      if: runner.environment == 'self-hosted'
+      shell: bash
+      run: |
+        ./scripts/uninstall_inactive_rust_toolchains.sh
     - name: Cleanup on post
       uses: gacts/run-and-post-run@v1
       with:

--- a/scripts/uninstall_inactive_rust_toolchains.sh
+++ b/scripts/uninstall_inactive_rust_toolchains.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEEP_TOOLCHAIN="$(rustup show active-toolchain | awk '{print $1}')"
+
+rustup toolchain list | awk '{print $1}' | while read -r tc; do
+  if [[ "$tc" != "$KEEP_TOOLCHAIN" ]]; then
+    echo "Removing $tc"
+    rustup toolchain uninstall "$tc" || {
+      echo "::warning::Failed to uninstall $tc"
+    }
+  fi
+done


### PR DESCRIPTION
Automatically uninstall all toolchains but the active one from our self-hosted runners to avoid disk space filling up.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
