### PR TITLE
chore: fix json formatting rule

### DIFF
--- a/crypto-ffi/bindings/js/tsconfig.typedoc.json
+++ b/crypto-ffi/bindings/js/tsconfig.typedoc.json
@@ -1,4 +1,8 @@
 {
-  "extends": "./shared/tsconfig.json",
-  "include": ["packages/**/src/*.ts", "shared/**/src/*.ts", "eslint.config.ts"]
+    "extends": "./shared/tsconfig.json",
+    "include": [
+        "packages/**/src/*.ts",
+        "shared/**/src/*.ts",
+        "eslint.config.ts"
+    ]
 }

--- a/make/fmt.mk
+++ b/make/fmt.mk
@@ -61,7 +61,7 @@ kotlin-check: $(STAMPS)/kotlin-check ## Lint Kotlin files via ktlint and detekt
 
 $(STAMPS)/ts-fmt: $(TS_SRCS) $(TS_TEST_FILES) $(TS_BENCH_FILES) $(JSON_FILES)
 	cd $(JS_DIR) && bun eslint --max-warnings=0 --fix && \
-	bun x prettier --write **/*.json
+	bun x prettier --write $(JSON_FILES)
 	$(TOUCH_STAMP)
 
 .PHONY: ts-fmt
@@ -71,7 +71,7 @@ $(STAMPS)/ts-check: $(TS_SRCS) $(TS_TEST_FILES) $(TS_BENCH_FILES) $(BROWSER_OUT)
 	cd $(JS_DIR) && bun eslint --max-warnings=0 && \
 	bun x tsc --noEmit --project ./packages/browser/tsconfig.json && \
 	bun x tsc --noEmit --project ./packages/native/tsconfig.json && \
-	bun x prettier --check **/*.json
+	bun x prettier --check $(JSON_FILES)
 	$(TOUCH_STAMP)
 
 .PHONY: ts-check


### PR DESCRIPTION
`make ts-fmt` doesn't correctly run prettier on all json files.
This PR fixes it.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
