### PR TITLE
ci: set xcode to upgraded self-hosted runner version

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -44,7 +44,7 @@ jobs:
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.6.0'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/package-ios.yml
+++ b/.github/workflows/package-ios.yml
@@ -42,7 +42,7 @@ jobs:
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.6.0'
 
       - name: create xcframework
         uses: ./.github/actions/make

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -28,7 +28,7 @@ jobs:
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.6.0'
 
       - name: Install swiftlint
         env:

--- a/scripts/create-ios-sim-device.sh
+++ b/scripts/create-ios-sim-device.sh
@@ -5,6 +5,6 @@ NAME="$1"
 
 UDID=$(xcrun simctl create "$NAME" \
         com.apple.CoreSimulator.SimDeviceType.iPhone-16 \
-        com.apple.CoreSimulator.SimRuntime.iOS-18-6)
+        com.apple.CoreSimulator.SimRuntime.iOS-26-5)
 
 echo "$UDID"


### PR DESCRIPTION
We upgraded xcode and ios runtime on our self-hosted runner. This PR adjusts CI.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
