### PR TITLE
[DO NOT MERGE] feat: automatically recover from `ConversationAlreadyExists` caused by epoch-0 groups

### DIFF
--- a/crypto/src/transaction_context/conversation/external_commit.rs
+++ b/crypto/src/transaction_context/conversation/external_commit.rs
@@ -2,7 +2,7 @@
 
 use openmls::prelude::{MlsGroup, group_info::VerifiableGroupInfo};
 
-use super::{Error, Result};
+use super::Result;
 use crate::{
     CommitBundle, ConversationConfiguration, ConversationId, CredentialRef, GroupInfoBundle, LeafError, OpenMlsError,
     RecursiveError,
@@ -120,19 +120,14 @@ impl TransactionContext {
     }
 
     pub(crate) async fn pending_conversation_exists(&self, id: &ConversationIdRef) -> Result<bool> {
-        match self.pending_conversation(id).await {
-            Ok(_) => Ok(true),
-            Err(Error::Leaf(LeafError::ConversationNotFound(_))) => Ok(false),
-            Err(e) => Err(e),
-        }
+        Ok(self.pending_conversation(id).await?.is_some())
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use super::Error;
-    use crate::{ConversationConfiguration, LeafError, test_utils::*};
+    use crate::{ConversationConfiguration, LeafError, test_utils::*, transaction_context::Error};
 
     #[apply(all_cred_cipher)]
     async fn join_by_external_commit_should_succeed(case: TestContext) {
@@ -245,19 +240,17 @@ mod tests {
     }
 
     #[apply(all_cred_cipher)]
-    async fn should_fail_when_no_pending_external_commit(case: TestContext) {
+    async fn should_not_find_conversation_when_no_pending_external_commit(case: TestContext) {
         let [session] = case.sessions().await;
         let non_existent_id = conversation_id();
         // try to get a non-existent pending group
-        let err = session
+        let pending_conversation_option = session
             .transaction
             .pending_conversation(&non_existent_id)
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(matches!(
-           err, Error::Leaf(LeafError::ConversationNotFound(id)) if non_existent_id == id
-        ));
+        assert!(pending_conversation_option.is_none());
     }
 
     #[apply(all_cred_cipher)]

--- a/crypto/src/transaction_context/conversation/mod.rs
+++ b/crypto/src/transaction_context/conversation/mod.rs
@@ -43,22 +43,27 @@ impl TransactionContext {
         if let Some(inner) = inner {
             return Ok(ConversationMut::new(inner, self.clone()));
         }
-        // Check if there is a pending conversation with
-        // the same id
-        let pending = self.pending_conversation(id).await.map(Error::PendingConversation)?;
-        Err(pending)
+
+        // Check if there is a pending conversation with the same id
+        if let Some(pending) = self.pending_conversation(id).await? {
+            return Err(Error::PendingConversation(pending));
+        }
+
+        Err(LeafError::ConversationNotFound(id.to_owned()).into())
     }
 
-    pub(crate) async fn pending_conversation(&self, id: &ConversationIdRef) -> Result<PendingConversation> {
+    pub(crate) async fn pending_conversation(&self, id: &ConversationIdRef) -> Result<Option<PendingConversation>> {
         let keystore = self.database().await?;
         let Some(pending_group) = keystore
             .get_borrowed::<PersistedMlsPendingGroup>(id.as_ref())
             .await
             .map_err(KeystoreError::wrap("finding persisted mls pending group"))?
         else {
-            return Err(LeafError::ConversationNotFound(id.to_owned()).into());
+            return Ok(None);
         };
-        Ok(PendingConversation::new(pending_group, self.clone()))
+
+        let pending_conversation = PendingConversation::new(pending_group, self.clone());
+        Ok(Some(pending_conversation))
     }
 
     /// Create a new empty conversation

--- a/crypto/src/transaction_context/conversation/mod.rs
+++ b/crypto/src/transaction_context/conversation/mod.rs
@@ -31,6 +31,15 @@ impl TransactionContext {
     ///
     /// This helper struct permits mutations on a conversation.
     pub async fn conversation(&self, id: &ConversationIdRef) -> Result<ConversationMut> {
+        self.conversation_maybe(id)
+            .await?
+            .ok_or_else(|| LeafError::ConversationNotFound(id.to_owned()).into())
+    }
+
+    /// Acquire a conversation guard if the conversation exists.
+    ///
+    /// This helper struct permits mutations on a conversation.
+    pub async fn conversation_maybe(&self, id: &ConversationIdRef) -> Result<Option<ConversationMut>> {
         let keystore = self.database().await?;
         let session = self.session().await?;
         let inner = self
@@ -41,7 +50,7 @@ impl TransactionContext {
             .map_err(RecursiveError::root("fetching conversation from mls groups by id"))?;
 
         if let Some(inner) = inner {
-            return Ok(ConversationMut::new(inner, self.clone()));
+            return Ok(Some(ConversationMut::new(inner, self.clone())));
         }
 
         // Check if there is a pending conversation with the same id
@@ -49,7 +58,7 @@ impl TransactionContext {
             return Err(Error::PendingConversation(pending));
         }
 
-        Err(LeafError::ConversationNotFound(id.to_owned()).into())
+        Ok(None)
     }
 
     pub(crate) async fn pending_conversation(&self, id: &ConversationIdRef) -> Result<Option<PendingConversation>> {

--- a/crypto/src/transaction_context/conversation/persistence.rs
+++ b/crypto/src/transaction_context/conversation/persistence.rs
@@ -86,8 +86,28 @@ impl TransactionContext {
 
         let id = ConversationId::from(group.group_id().as_slice());
 
-        if self.conversation_exists(&id).await? || self.pending_conversation_exists(&id).await? {
-            return Err(LeafError::ConversationAlreadyExists(id).into());
+        // If the conversation exists locally as a pending conversation or as a conversation with epoch 0, we can clear
+        // it and keep the one we just created, because this will lead to the desired state, compatible with what we had
+        // locally. A fresh group with this `id`, just not created by us.
+        // This resolves WPB-21116.
+        if let Some(mut pending_conversation) = self.pending_conversation(&id).await? {
+            pending_conversation
+                .clear()
+                .await
+                .map_err(RecursiveError::mls_conversation(
+                    "clearing pending conversation while processing welcome",
+                ))?;
+        }
+
+        if let Some(mut conv) = self.conversation_maybe(&id).await? {
+            if conv.epoch().await > 0 {
+                // If the conversation has already processed commits, this is an error.
+                return Err(LeafError::ConversationAlreadyExists(id).into());
+            }
+
+            conv.wipe().await.map_err(RecursiveError::mls_conversation(
+                "wiping existing conversation at epoch 0 while processing welcome",
+            ))?;
         }
 
         self.persist_conversation_from_mls_group(group, configuration).await

--- a/crypto/src/transaction_context/conversation/welcome.rs
+++ b/crypto/src/transaction_context/conversation/welcome.rs
@@ -89,17 +89,21 @@ mod tests {
             let commit = case.create_conversation([&alice]).await.invite([&bob]).await;
             let conversation = commit.conversation();
             let id = conversation.id().clone();
-                // Meanwhile Bob creates a conversation with the exact same id as the one he's trying to join
+                let welcome = conversation.transport().await.latest_welcome_message().await;
+
+                // Meanwhile, Bob creates a conversation with the exact same id as the one he's trying to join.
                 bob
                     .transaction
                     .new_conversation(&id, credential_ref, case.cfg.clone())
                     .await
                     .unwrap();
 
+                // Bob's local conversation must be in epoch > 0 to match the definition of an already-existing conversation.
+                let mut bob_conversation = bob.transaction.conversation(&id).await.unwrap();
+                bob_conversation.update_key_material().await.unwrap();
+
                 // Bob's key packages before processing the welcome
                 let key_package_refs_before = bob.transaction.get_key_package_refs().await.unwrap();
-
-                let welcome = conversation.transport().await.latest_welcome_message().await;
 
                 // We need Bob's created key package to be persisted, so we can restore it on error.
                 // Assuming that key package creation happens in its own transaction matches a sufficiently large

--- a/crypto/src/transaction_context/conversation/welcome.rs
+++ b/crypto/src/transaction_context/conversation/welcome.rs
@@ -124,4 +124,30 @@ mod tests {
             })
         .await;
     }
+
+    #[apply(all_cred_cipher)]
+    async fn process_welcome_should_work_when_already_exists_at_epoch_0(case: TestContext) {
+        let [alice, bob] = case.sessions().await;
+        Box::pin(async move {
+            let commit = case.create_conversation([&alice]).await.invite([&bob]).await;
+
+            // Meanwhile, Bob creates a conversation with the exact same id as the one he's trying to join.
+            //
+            // However, this group is fresh (epoch 0), so it will be wiped automatically after processing the welcome
+            // and discovering that the IDs match.
+            let conversation_id = commit.conversation().id();
+            bob.transaction
+                .new_conversation(conversation_id, &bob.initial_credential, case.cfg.clone())
+                .await
+                .unwrap();
+
+            // The conversation exists locally.
+            assert!(bob.transaction.conversation_exists(conversation_id).await.unwrap());
+
+            // Bob processes the welcome successfully.
+            let conversation = commit.notify_members().await;
+            assert!(conversation.is_functional_and_contains([&alice, &bob]).await);
+        })
+        .await;
+    }
 }


### PR DESCRIPTION
See above.

Don't merge, because we haven't decided yet that this is the path we'd like to go.