### PR TITLE
feat(conversation): process welcome: retain key package on error [WPB-27413]

### DIFF
--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -200,6 +200,9 @@ impl CoreCryptoContext {
     }
 
     /// Joins a conversation by processing an MLS Welcome message, returning the new conversation's ID.
+    ///
+    /// NOTE: Will retain the referenced key package in case of an error only if it was created in an earlier
+    /// transaction.
     pub async fn process_welcome_message(&self, welcome_message: Arc<Welcome>) -> CoreCryptoResult<ConversationId> {
         let result = self
             .inner

--- a/crypto/src/mls/session/key_package.rs
+++ b/crypto/src/mls/session/key_package.rs
@@ -3,7 +3,7 @@ use core_crypto_keystore::{entities::StoredKeypackage, traits::FetchFromDatabase
 use super::Result;
 use crate::{Keypackage, KeypackageRef, KeystoreError, Session, mls::key_package::KeypackageExt};
 
-fn from_stored(stored_keypackage: &StoredKeypackage) -> Result<Keypackage> {
+pub(crate) fn from_stored(stored_keypackage: &StoredKeypackage) -> Result<Keypackage> {
     core_crypto_keystore::deser::<Keypackage>(&stored_keypackage.keypackage)
         .map_err(KeystoreError::wrap("deserializing keypackage"))
         .map_err(Into::into)

--- a/crypto/src/transaction_context/conversation/welcome.rs
+++ b/crypto/src/transaction_context/conversation/welcome.rs
@@ -31,10 +31,21 @@ impl TransactionContext {
             ..Default::default()
         };
 
-        let conversation = self
-            .persist_conversation_from_welcome_message(welcome, configuration)
-            .await?;
+        let welcome_clone = welcome.clone();
+        let conversation_result = self
+            .persist_conversation_from_welcome_message(welcome_clone, configuration)
+            .await;
 
+        if conversation_result.is_err() {
+            // If persisting failed, we want to pretend we didn't process the welcome at all and restore the key
+            // package that may have been marked for deletion by openmls:
+            // https://github.com/wireapp/openmls/blob/c9cde17076508968c9cbead5728454f0a1f60c4f/openmls/src/group/mls_group/creation.rs#L166
+            for key_package_hash_ref in welcome.secrets().iter().map(|secret| secret.new_member().as_slice()) {
+                self.restore_key_package(key_package_hash_ref).await?;
+            }
+        }
+
+        let conversation = conversation_result?;
         let id = conversation.id().to_owned();
 
         Ok(id)

--- a/crypto/src/transaction_context/conversation/welcome.rs
+++ b/crypto/src/transaction_context/conversation/welcome.rs
@@ -83,7 +83,7 @@ mod tests {
     async fn process_welcome_should_fail_when_already_exists(case: TestContext) {
         use crate::LeafError;
 
-        let [alice, bob] = case.sessions().await;
+        let [alice, mut bob] = case.sessions().await;
         Box::pin(async move {
             let credential_ref = &bob.initial_credential;
             let commit = case.create_conversation([&alice]).await.invite([&bob]).await;
@@ -96,11 +96,26 @@ mod tests {
                     .await
                     .unwrap();
 
+                // Bob's key packages before processing the welcome
+                let key_package_refs_before = bob.transaction.get_key_package_refs().await.unwrap();
+
                 let welcome = conversation.transport().await.latest_welcome_message().await;
+
+                // We need Bob's created key package to be persisted, so we can restore it on error.
+                // Assuming that key package creation happens in its own transaction matches a sufficiently large
+                // portion of real-world usage.
+                bob.commit_transaction().await;
+
                 let join_welcome = bob
                     .transaction
                     .process_welcome_message(welcome)
                     .await;
+
+                // Bob's key packages after processing the welcome
+                let key_package_refs_after = bob.transaction.get_key_package_refs().await.unwrap();
+
+                assert!(!key_package_refs_before.is_empty());
+                assert_eq!(key_package_refs_before, key_package_refs_after);
                 assert!(innermost_source_matches!(join_welcome.unwrap_err(), LeafError::ConversationAlreadyExists(i) if i == &id));
             })
         .await;

--- a/crypto/src/transaction_context/key_package.rs
+++ b/crypto/src/transaction_context/key_package.rs
@@ -2,7 +2,10 @@
 
 use std::time::Duration;
 
-use core_crypto_keystore::entities::{StoredEncryptionKeyPair, StoredHpkePrivateKey, StoredKeypackage};
+use core_crypto_keystore::{
+    entities::{StoredEncryptionKeyPair, StoredHpkePrivateKey, StoredKeypackage},
+    traits::FetchFromDatabase as _,
+};
 use openmls::prelude::{CryptoConfig, Lifetime};
 
 use super::{Error, Result, TransactionContext};
@@ -142,5 +145,42 @@ impl TransactionContext {
             None => Ok(()),
             Some(err) => Err(err),
         }
+    }
+
+    /// Restore a key package that was deleted in this transaction by removing it from the deleted list. This is
+    /// idempotent: if the key package doesn't exist in the deleted list, do nothing.
+    ///
+    /// NOTE: This will only work if the key package has been added in an earlier transaction, because otherwise,
+    /// removing its id from the deleted list wouldn't suffice: we'd need to replay its insertion.
+    pub(crate) async fn restore_key_package(&self, key_package_ref: &[u8]) -> Result<()> {
+        let database = self.database().await?;
+        database
+            .restore::<StoredKeypackage>(key_package_ref)
+            .await
+            .map_err(KeystoreError::wrap(
+                "restoring key package deleted in current transaction",
+            ))?;
+
+        let Some(key_package) = database
+            .get_borrowed::<StoredKeypackage>(key_package_ref)
+            .await
+            .map_err(KeystoreError::wrap("loading keypackage from database"))?
+            .map(|stored_keypackage| crate::mls::session::key_package::from_stored(&stored_keypackage))
+            .transpose()
+            .map_err(RecursiveError::mls_client("loading key package"))?
+        else {
+            return Ok(());
+        };
+
+        database
+            .restore::<StoredHpkePrivateKey>(key_package.hpke_init_key().as_slice())
+            .await
+            .map_err(KeystoreError::wrap("restoring private key from keystore"))?;
+        database
+            .restore::<StoredEncryptionKeyPair>(key_package.leaf_node().encryption_key().as_slice())
+            .await
+            .map_err(KeystoreError::wrap("restoring encryption keypair from keystore"))?;
+
+        Ok(())
     }
 }

--- a/keystore/src/connection/keystore_transaction.rs
+++ b/keystore/src/connection/keystore_transaction.rs
@@ -142,4 +142,17 @@ impl Database {
         self.with_transaction(async |transaction| transaction.remove_borrowed::<E>(id).await)
             .await
     }
+
+    /// Restore an entity that was deleted in this transaction by removing it from the deleted list. This is
+    /// idempotent: if the entity doesn't exist in the deleted list, do nothing.
+    ///
+    /// NOTE: This will only work if the entity has been added in an earlier transaction, because otherwise,
+    /// removing its id from the deleted list wouldn't suffice: we'd need to replay its insertion.
+    pub async fn restore<E>(&self, id: &E::BorrowedPrimaryKey) -> CryptoKeystoreResult<()>
+    where
+        E: Entity + EntityDatabaseMutation + BorrowPrimaryKey + EntityDeleteBorrowed,
+    {
+        self.with_transaction(async |transaction| transaction.restore::<E>(id).await)
+            .await
+    }
 }

--- a/keystore/src/transaction/mod.rs
+++ b/keystore/src/transaction/mod.rs
@@ -121,6 +121,22 @@ impl KeystoreTransaction {
         self.remove_by_entity_id::<E>(entity_id).await
     }
 
+    /// Restore an entity that was deleted in this transaction by removing it from the deleted list. This is
+    /// idempotent: if the entity doesn't exist in the deleted list, do nothing.
+    ///
+    /// NOTE: This will only work if the entity has been added in an earlier transaction, because otherwise,
+    /// removing its id from the deleted list wouldn't suffice: we'd need to replay its insertion.
+    pub(crate) async fn restore<E>(&self, id: &E::BorrowedPrimaryKey) -> CryptoKeystoreResult<()>
+    where
+        E: EntityDeleteBorrowed + BorrowPrimaryKey,
+    {
+        let entity_id = EntityId::from_borrowed_primary_key::<E>(id)
+            .ok_or(CryptoKeystoreError::UnknownCollectionName(E::COLLECTION_NAME))?;
+        let mut deleted = self.deleted.write().await;
+        deleted.remove(&entity_id);
+        Ok(())
+    }
+
     pub(crate) async fn child_groups(
         &self,
         entity: PersistedMlsGroup,


### PR DESCRIPTION
This is needed for correctness, see corresponding item.

Unfortunately it's a bit more complex than expected, and we need a condition to hold for this to work: the keypackage must have been created in an earlier transaction. It's reasonable to assume that, though, imo
