### PR TITLE
chore(dependabot): stop automatically rebasing PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
+    rebase-strategy: "disabled"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 30
     cooldown:
       default-days: 7
+
   - package-ecosystem: "bun"
+    rebase-strategy: "disabled"
     directory: "crypto-ffi/bindings/js"
     schedule:
       interval: "daily"
@@ -15,9 +18,12 @@ updates:
       js-dependencies:
         patterns:
           - "*"
+
     cooldown:
       default-days: 7
+
   - package-ecosystem: "github-actions"
+    rebase-strategy: "disabled"
     directories: # actions have to be listed explicitly
       - "/" # workflows
       - "/.github/actions/**"
@@ -25,7 +31,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+
   - package-ecosystem: "rust-toolchain"
+    rebase-strategy: "disabled"
     directory: /
     schedule:
       interval: "monthly"


### PR DESCRIPTION
This behavior can cause our CI to be blocked for a long time and does more harm than anything else.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
