### PR TITLE
ci: pin github actions to commit hashes

### DIFF
--- a/.github/actions/build-cc-book/action.yml
+++ b/.github/actions/build-cc-book/action.yml
@@ -6,7 +6,7 @@ runs:
 
   steps:
     - name: Install mdBook tools
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
       with:
         tool: |
           mdbook

--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
     - name: setup fd
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
       with:
         tool: fd-find
     - name: Set MAKE

--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -147,7 +147,7 @@ runs:
 
     - name: Upload artifact if it doesn't exist for this workflow run
       if: steps.download.outputs.found_in_this_run != 'true'
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.compute-key.outputs.key }}
         path: artifact.tar.gz

--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -45,7 +45,7 @@ runs:
       run: |
         ./scripts/uninstall_inactive_rust_toolchains.sh
     - name: Cleanup on post
-      uses: gacts/run-and-post-run@v1
+      uses: gacts/run-and-post-run@598d7a875d5620e0457490555b5e18e46082aa47 # v1.4.4
       with:
           post: |
             sh ./scripts/clean.sh

--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -32,7 +32,7 @@ runs:
       run: |
         perl -0777 -pi -e 's/^targets = \[.*?\]//ms' rust-toolchain.toml
     - name:
-      uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
+      uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:
         toolchain: ${{ inputs.toolchain }}
         target: ${{ inputs.target }}

--- a/.github/actions/setup-and-cache-rust/action.yml
+++ b/.github/actions/setup-and-cache-rust/action.yml
@@ -50,7 +50,7 @@ runs:
           post: |
             sh ./scripts/clean.sh
     - name: Cache build artifacts
-      uses: actions/cache@v6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/registry/index/

--- a/.github/actions/setup-wasm-bindgen/action.yml
+++ b/.github/actions/setup-wasm-bindgen/action.yml
@@ -14,6 +14,6 @@ runs:
         echo "wasm_bindgen_version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Install wasm-bindgen-cli
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
       with:
         tool: wasm-bindgen-cli@${{ steps.cargo_metadata.outputs.wasm_bindgen_version }}

--- a/.github/actions/sonatype/release/action.yml
+++ b/.github/actions/sonatype/release/action.yml
@@ -28,7 +28,7 @@ runs:
         distribution: adopt
 
     - name: gradle setup
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       with:
         cache-provider: basic
 

--- a/.github/actions/sonatype/release/action.yml
+++ b/.github/actions/sonatype/release/action.yml
@@ -32,9 +32,6 @@ runs:
       with:
         cache-provider: basic
 
-    - name: validate gradle wrapper
-      uses: gradle/actions/wrapper-validation@v6.2.0
-
     - name: release artifact
       shell: bash
       working-directory: crypto-ffi/bindings

--- a/.github/actions/sonatype/release/action.yml
+++ b/.github/actions/sonatype/release/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: set up jdk 25
-      uses: actions/setup-java@v5.4.0
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: 25
         distribution: adopt

--- a/.github/workflows/benchmark-jvm-publish.yml
+++ b/.github/workflows/benchmark-jvm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download benchmark result
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: benchmark-jvm-results
           path: crypto-ffi/bindings/jvm/build/reports/jmh

--- a/.github/workflows/benchmark-jvm-publish.yml
+++ b/.github/workflows/benchmark-jvm-publish.yml
@@ -23,7 +23,7 @@ jobs:
           path: crypto-ffi/bindings/jvm/build/reports/jmh
 
       - name: Publish benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "JVM Benchmarks"
           tool: 'jmh'

--- a/.github/workflows/benchmark-jvm.yml
+++ b/.github/workflows/benchmark-jvm.yml
@@ -83,8 +83,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
 
       - name: download linux library
         uses: ./.github/actions/make

--- a/.github/workflows/benchmark-jvm.yml
+++ b/.github/workflows/benchmark-jvm.yml
@@ -80,7 +80,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/benchmark-jvm.yml
+++ b/.github/workflows/benchmark-jvm.yml
@@ -114,7 +114,7 @@ jobs:
         run: make jvm-bench
 
       - name: Upload benchmark result
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-jvm-results
           path: crypto-ffi/bindings/jvm/build/reports/jmh/results.json

--- a/.github/workflows/benchmark-ts-browser-publish.yml
+++ b/.github/workflows/benchmark-ts-browser-publish.yml
@@ -22,7 +22,7 @@ jobs:
           name: benchmark-ts-browser-results
 
       - name: Publish benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "Browser Benchmarks"
           tool: 'customBiggerIsBetter'

--- a/.github/workflows/benchmark-ts-browser-publish.yml
+++ b/.github/workflows/benchmark-ts-browser-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download benchmark result
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: benchmark-ts-browser-results
 

--- a/.github/workflows/benchmark-ts-browser.yml
+++ b/.github/workflows/benchmark-ts-browser.yml
@@ -106,7 +106,7 @@ jobs:
         run: jq -s add crypto-ffi/bindings/js/benches_result/*.json > benches_result.json
 
       - name: Upload benchmark result
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-ts-browser-results
           path: benches_result.json

--- a/.github/workflows/benchmark-ts-browser.yml
+++ b/.github/workflows/benchmark-ts-browser.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/benchmark-ts-native-publish.yml
+++ b/.github/workflows/benchmark-ts-native-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download benchmark result
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: benchmark-ts-native-results
 

--- a/.github/workflows/benchmark-ts-native-publish.yml
+++ b/.github/workflows/benchmark-ts-native-publish.yml
@@ -22,7 +22,7 @@ jobs:
           name: benchmark-ts-native-results
 
       - name: Publish benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: "TS Native Benchmarks"
           tool: 'customBiggerIsBetter'

--- a/.github/workflows/benchmark-ts-native.yml
+++ b/.github/workflows/benchmark-ts-native.yml
@@ -94,7 +94,7 @@ jobs:
         run: jq -s add crypto-ffi/bindings/js/benches_result/*.json > benches_result.json
 
       - name: Upload benchmark result
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-ts-native-results
           path: benches_result.json

--- a/.github/workflows/benchmark-ts-native.yml
+++ b/.github/workflows/benchmark-ts-native.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup android sdk
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
         with:
           # Don't download unnecessary packages.
           # We only need sdkmanager for the next step.

--- a/.github/workflows/check-ts.yml
+++ b/.github/workflows/check-ts.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
           tool: cargo-deny@0.19
       - name: "check licenses / supply chain"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: download pre-rendered docs
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: '{cc-book,typescript,swift,kotlin,rust}'
         path: "./target/doc/${{ env.GIT_TAG }}"

--- a/.github/workflows/docs-cc-book.yml
+++ b/.github/workflows/docs-cc-book.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: ./.github/actions/build-cc-book
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cc-book
           path: cc-book/book

--- a/.github/workflows/docs-jvm.yml
+++ b/.github/workflows/docs-jvm.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/docs-jvm.yml
+++ b/.github/workflows/docs-jvm.yml
@@ -46,7 +46,7 @@ jobs:
           artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
 
       - name: upload kotlin docs
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kotlin
           path: target/kotlin/doc/html

--- a/.github/workflows/docs-jvm.yml
+++ b/.github/workflows/docs-jvm.yml
@@ -23,8 +23,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
 
       - name: download linux library
         uses: ./.github/actions/make/jvm

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -50,7 +50,7 @@ jobs:
       - name: install jazzy
         run: gem install jazzy
 
-      - uses: swift-actions/setup-swift@v3
+      - uses: swift-actions/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9 # v3.0.0-beta.1
         with:
           swift-version: "6.0"
 

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -63,7 +63,7 @@ jobs:
           	  --build-tool-arguments -project,WireCoreCrypto.xcodeproj,-scheme,WireCoreCrypto,-configuration,Release \
           	  -o ../../../../target/swift/doc
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: swift
           path: target/swift/doc

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           xcode-version: '26.3.0'
       - name: Set up Ruby environment
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.3'
 

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -39,7 +39,7 @@ jobs:
           artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
 
       - name: setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '26.3.0'
       - name: Set up Ruby environment

--- a/.github/workflows/docs-ts.yml
+++ b/.github/workflows/docs-ts.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: setup bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: latest
 

--- a/.github/workflows/docs-ts.yml
+++ b/.github/workflows/docs-ts.yml
@@ -36,7 +36,7 @@ jobs:
     - name: make ts docs
       run: make docs-ts
 
-    - uses: actions/upload-artifact@v7.0.1
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: typescript
         path: target/typescript/doc

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -43,7 +43,7 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.6.0'
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
       - name: Install chrome-headless-shell

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -24,8 +24,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
 
       - name: setup android sdk
         uses: android-actions/setup-android@v4

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -26,7 +26,7 @@ jobs:
           cache-provider: basic
 
       - name: setup android sdk
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
         with:
           # Don't download unnecessary packages.
           # We only need sdkmanager for the next step.

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -40,7 +40,7 @@ jobs:
           echo ANDROID_NDK_ROOT=$ANDROID_NDK_HOME >> $GITHUB_ENV
 
       - name: setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '26.6.0'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/kotlin-check.yml
+++ b/.github/workflows/kotlin-check.yml
@@ -28,8 +28,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
 
       - name: download linux library
         uses: ./.github/actions/make/jvm

--- a/.github/workflows/kotlin-check.yml
+++ b/.github/workflows/kotlin-check.yml
@@ -25,7 +25,7 @@ jobs:
           chmod a+x ktlint
           echo "$PWD" >> $GITHUB_PATH
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: setup fd
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
           tool: fd-find
       - name: install mdformat

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -24,7 +24,7 @@ jobs:
           cache-provider: basic
 
       - name: setup android sdk
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
       - name: install ndk and set up environment
         run: |
           ndk_version=$(cat crypto-ffi/bindings/android/ndk.version)

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -22,8 +22,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
+
       - name: setup android sdk
         uses: android-actions/setup-android@v4
       - name: install ndk and set up environment

--- a/.github/workflows/package-ios.yml
+++ b/.github/workflows/package-ios.yml
@@ -40,7 +40,7 @@ jobs:
           artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
 
       - name: setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '26.6.0'
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -299,7 +299,7 @@ jobs:
       - uses: ./.github/actions/setup-and-cache-rust
       - run: cargo doc --all --no-deps --locked
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rust
           path: target/doc

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
       - name: build ts
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
       - name: build ts
@@ -227,7 +227,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
       - name: build ts

--- a/.github/workflows/prepare-publish-android.yml
+++ b/.github/workflows/prepare-publish-android.yml
@@ -44,7 +44,7 @@ jobs:
           cache-provider: basic
 
       - name: setup android sdk
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       - name: download android package
         uses: ./.github/actions/make/android/package

--- a/.github/workflows/prepare-publish-android.yml
+++ b/.github/workflows/prepare-publish-android.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: adopt
 
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
 

--- a/.github/workflows/prepare-publish-android.yml
+++ b/.github/workflows/prepare-publish-android.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           cache-provider: basic
 
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
-
       - name: setup android sdk
         uses: android-actions/setup-android@v4
 

--- a/.github/workflows/prepare-publish-jvm.yml
+++ b/.github/workflows/prepare-publish-jvm.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           cache-provider: basic
 
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
-
       - name: download jvm bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
         with:

--- a/.github/workflows/prepare-publish-jvm.yml
+++ b/.github/workflows/prepare-publish-jvm.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: adopt
 
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
 

--- a/.github/workflows/prepare-publish-kmp.yml
+++ b/.github/workflows/prepare-publish-kmp.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           cache-provider: basic
 
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
-
       - name: download ffi library
         uses: ./.github/actions/make/ffi-library
         with:

--- a/.github/workflows/prepare-publish-kmp.yml
+++ b/.github/workflows/prepare-publish-kmp.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: adopt
 
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -24,8 +24,7 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
+
       - name: enable kvm group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/test-e2ei.yml
+++ b/.github/workflows/test-e2ei.yml
@@ -28,9 +28,8 @@ jobs:
           - keycloak
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.17.0
+      - uses: ./.github/actions/setup-and-cache-rust
         with:
           rustflags: ''
-          toolchain: 'stable'
       - uses: taiki-e/install-action@nextest
       - run: TEST_IDP=${{ matrix.idp }} sh scripts/run-e2ei-tests.sh

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '26.6.0'
 

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Cleanup on post
-        uses: gacts/run-and-post-run@v1
+        uses: gacts/run-and-post-run@598d7a875d5620e0457490555b5e18e46082aa47 # v1.4.4
         with:
             post: |
               sh ./scripts/clean.sh

--- a/.github/workflows/test-jvm.yml
+++ b/.github/workflows/test-jvm.yml
@@ -24,8 +24,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
 
       - name: download linux library
         uses: ./.github/actions/make/jvm

--- a/.github/workflows/test-jvm.yml
+++ b/.github/workflows/test-jvm.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/test-kmp.yml
+++ b/.github/workflows/test-kmp.yml
@@ -27,8 +27,6 @@ jobs:
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v6.2.0
 
       - name: download ffi library
         uses: ./.github/actions/make/ffi-library

--- a/.github/workflows/test-kmp.yml
+++ b/.github/workflows/test-kmp.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: 25
           distribution: adopt
       - name: gradle setup
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
       - name: validate gradle wrapper

--- a/.github/workflows/test-ts-browser.yml
+++ b/.github/workflows/test-ts-browser.yml
@@ -20,7 +20,7 @@ jobs:
         id: setup-chrome
         with:
           chrome-version: stable
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/test-ts-native.yml
+++ b/.github/workflows/test-ts-native.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: uncenter/setup-taplo@v2
+      - uses: uncenter/setup-taplo@b18c8c8302695fe63d6853bc004006215ac52b91 # v2
       - name: setup fd
         uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:

--- a/.github/workflows/toml.yml
+++ b/.github/workflows/toml.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: uncenter/setup-taplo@v2
       - name: setup fd
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
         with:
           tool: fd-find
       - run: fd --glob --hidden '*.toml' -X taplo fmt --check


### PR DESCRIPTION
This PR pins all github actions to commit hashes of the release tag to harden our CI.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
