### PR TITLE
ci(docs): replace docs within the same folder

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: deploy static files
       if: github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@v4.1.0
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
@@ -45,7 +45,7 @@ jobs:
         enable_jekyll: true
 
     - name: deploy versioned docs
-      uses: peaceiris/actions-gh-pages@v4.1.0
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,16 +27,19 @@ jobs:
         path: "./target/doc/${{ env.GIT_TAG }}"
         merge-multiple: false
 
-    - name: copy static files
+    - name: prepare static files
+      if: github.ref == 'refs/heads/main'
       run: |
-        cp docs/*.md target/doc/
+        mkdir -p target/static-doc
+        cp docs/*.md target/static-doc/
 
-    - name: deploy docs
+    - name: deploy static files
+      if: github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
-        publish_dir: target/doc
+        publish_dir: target/static-doc
         keep_files: true
         force_orphan: false
         enable_jekyll: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,6 @@
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}-deploy-docs"
-  cancel-in-progress: true
+  group: deploy-docs-gh-pages
+  cancel-in-progress: false
 
 on:
   workflow_call:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,3 +43,14 @@ jobs:
         keep_files: true
         force_orphan: false
         enable_jekyll: true
+
+    - name: deploy versioned docs
+      uses: peaceiris/actions-gh-pages@v4.1.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: target/doc/${{ env.GIT_TAG }}
+        destination_dir: ${{ env.GIT_TAG }}
+        keep_files: false
+        force_orphan: false
+        enable_jekyll: true


### PR DESCRIPTION
`keep_files: true` was thought to be the best solution to not interfere
with other folders. However, `destination_dir` is a much better fit.

Not using `keep_files: true` anymore, solves the problems of
ever-increasing directory sizes and incorrect results in case of struct
renames, where the old struct doc would be kept.