### PR TITLE
refactor: clean up unique entity implementation helper [WPB-27718]

### DIFF
--- a/keystore/src/traits/unique_entity.rs
+++ b/keystore/src/traits/unique_entity.rs
@@ -38,22 +38,11 @@ pub trait UniqueEntityImplementationHelper {
     fn content(&self) -> &[u8];
 }
 
-// unfortunately we have to implement this trait twice, with nearly-identical but distinct bounds
-
-#[cfg(target_os = "unknown")]
 impl<T> UniqueEntity for T
 where
     T: Entity + UniqueEntityImplementationHelper + PrimaryKey<PrimaryKey = u32>,
 {
     const KEY: u32 = 0;
-}
-
-#[cfg(not(target_os = "unknown"))]
-impl<T> UniqueEntity for T
-where
-    T: Entity + UniqueEntityImplementationHelper + PrimaryKey<PrimaryKey = u64>,
-{
-    const KEY: u64 = 0;
 }
 
 impl<T> PrimaryKey for T
@@ -63,10 +52,7 @@ where
     // The old keystore trait used usize as the primary key type, but that would vary
     // in width across various implementations and so is intentionally not a `KeyType`.
     // So we distinguish between `u32` and `u64` according to whether or not we're on wasm.
-    #[cfg(target_os = "unknown")]
     type PrimaryKey = u32;
-    #[cfg(not(target_os = "unknown"))]
-    type PrimaryKey = u64;
 
     fn primary_key(&self) -> Self::PrimaryKey {
         Self::KEY

--- a/keystore/src/traits/unique_entity.rs
+++ b/keystore/src/traits/unique_entity.rs
@@ -9,15 +9,11 @@ use crate::{
 
 /// Unique entity implementation/migration helper.
 ///
-/// The old `trait UniqueEntity` required two methods:
-///
-/// - `fn new(content: Vec<u8>) -> Self;`
-/// - `fn content(&self) -> &[u8];`
-///
-/// It then provided a bunch of default methods.
-///
-/// The whole structure of the traits has changed, now.
-/// But we can stil offer that same kind of convenience, and replicate those defaults.
+/// Few unique entities actually care about what key gets used; it's arbitrary, imposed
+/// only by the requirement that an [`Entity`] has a [`PrimaryKey`]. Really they only need
+/// to know what table name to use, and how to serialize/deserialize. For reasons of
+/// historical compatibility we express the serialization requirements in terms of inline
+/// methods here instead of a trait implementation.
 ///
 /// If you implement this trait, you get the following traits auto-implemented:
 ///
@@ -25,12 +21,6 @@ use crate::{
 /// - `UniqueEntity`
 /// - `Entity`
 /// - `EntityDatabaseMutation`
-///
-/// ## Warning
-///
-/// If your old `UniqueEntity` implementation defined anything other than the two required methods,
-/// you mut implement these traits manually to preserve the existing behaviors. Otherwise the
-/// behaviors will change!
 pub trait UniqueEntityImplementationHelper {
     /// Table name for this entity.
     const TABLE_NAME: &str;
@@ -49,9 +39,6 @@ impl<T> PrimaryKey for T
 where
     T: UniqueEntityImplementationHelper,
 {
-    // The old keystore trait used usize as the primary key type, but that would vary
-    // in width across various implementations and so is intentionally not a `KeyType`.
-    // So we distinguish between `u32` and `u64` according to whether or not we're on wasm.
     type PrimaryKey = u32;
 
     fn primary_key(&self) -> Self::PrimaryKey {


### PR DESCRIPTION
- Use the same primary key regardless of target. 
- Don't reference old implementation in docs; it's gone.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
