### PR TITLE
refactor(keystore): simplify `ProteusIdentity`'s `PrimaryKey` [WPB-27719]

### DIFF
--- a/keystore/src/connection/idb_migration/legacy/entities/proteus/identity.rs
+++ b/keystore/src/connection/idb_migration/legacy/entities/proteus/identity.rs
@@ -24,7 +24,7 @@ impl EntityBase for ProteusIdentity {
 }
 
 impl UniqueEntity for ProteusIdentity {
-    const KEY: [u8; 1] = [1];
+    const KEY: () = ();
 }
 
 #[async_trait(?Send)]

--- a/keystore/src/entities/proteus/identity.rs
+++ b/keystore/src/entities/proteus/identity.rs
@@ -80,23 +80,14 @@ impl crate::traits::EntityDatabaseMutation for ProteusIdentity {
     }
 }
 
-#[cfg(not(target_os = "unknown"))]
-type KeyType = ();
-
-#[cfg(target_os = "unknown")]
-type KeyType = [u8; 1];
-
 impl PrimaryKey for ProteusIdentity {
-    type PrimaryKey = KeyType;
+    type PrimaryKey = ();
+
     fn primary_key(&self) -> Self::PrimaryKey {
         Self::KEY
     }
 }
 
 impl UniqueEntity for ProteusIdentity {
-    #[cfg(not(target_os = "unknown"))]
     const KEY: Self::PrimaryKey = ();
-
-    #[cfg(target_os = "unknown")]
-    const KEY: Self::PrimaryKey = [1];
 }

--- a/keystore/src/traits/key_type.rs
+++ b/keystore/src/traits/key_type.rs
@@ -71,6 +71,3 @@ impl_keytype_for_integer!(i16);
 impl_keytype_for_integer!(i32);
 impl_keytype_for_integer!(i64);
 impl_keytype_for_integer!(i128);
-
-// Some unique entities use a single byte as a key type
-impl_keytype!([u8; 1], |self| self, |bytes| bytes.try_into().ok());


### PR DESCRIPTION
We used to distinguish it between `()` on native and `[u8; 1]` on wasm, because IndexedDB requires an actual non-empty primary key.

Even though we're changing the key type on wasm, this is safe: no `ProteusIdentity` operation actually uses the primary key for anything, and the idb-to-sql migration uses `load_all` followed by a `.save` loop.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
