### PR TITLE
refactor: rm `EntityDatabaseMutation::count` [WPB-27721]

### DIFF
--- a/crypto-macros/src/entity_derive/derive_impl.rs
+++ b/crypto-macros/src/entity_derive/derive_impl.rs
@@ -162,10 +162,6 @@ impl Entity {
                     Ok(())
                 }
 
-                fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-                    crate::entities::helpers::count_helper_tx::<Self>(tx)
-                }
-
                 fn delete(tx: &rusqlite::Transaction, id: &Self::PrimaryKey) -> crate::CryptoKeystoreResult<bool> {
                     <Self as crate::traits::EntityDeleteBorrowed>::delete_borrowed(tx, id)
                 }

--- a/keystore/src/entities/helpers.rs
+++ b/keystore/src/entities/helpers.rs
@@ -43,17 +43,6 @@ pub(crate) fn count_helper<E: Entity>(conn: &Connection) -> CryptoKeystoreResult
     statement.query_one([], |row| row.get(0)).map_err(Into::into)
 }
 
-/// Helper to perform an SQL query to count these entities in the database.
-///
-/// This function prepares and caches a statement of the form `SELECT count(*) FROM table_name`.
-pub(crate) fn count_helper_tx<E: Entity>(tx: &Transaction<'_>) -> CryptoKeystoreResult<u32> {
-    let mut statement = tx.prepare_cached(&format!(
-        "SELECT count(*) FROM {table_name}",
-        table_name = E::TABLE_NAME
-    ))?;
-    statement.query_one([], |row| row.get(0)).map_err(Into::into)
-}
-
 /// Helper to perform an SQL query to load all entities from the database.
 ///
 /// This function prepares and caches a statement of the form `SELECT * FROM table_name`.

--- a/keystore/src/entities/mls/mls_pending_message.rs
+++ b/keystore/src/entities/mls/mls_pending_message.rs
@@ -100,10 +100,6 @@ impl crate::traits::EntityDatabaseMutation for MlsPendingMessage {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(_tx: &rusqlite::Transaction, _id: &MlsPendingMessagePrimaryKey) -> crate::CryptoKeystoreResult<bool> {
         panic!("cannot delete `MlsPendingMessage` by primary key as it has no distinct primary key")
     }

--- a/keystore/src/entities/mls/persisted_mls_pending_group.rs
+++ b/keystore/src/entities/mls/persisted_mls_pending_group.rs
@@ -94,10 +94,6 @@ impl crate::traits::EntityDatabaseMutation for PersistedMlsPendingGroup {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(tx: &rusqlite::Transaction, id: &Vec<u8>) -> crate::CryptoKeystoreResult<bool> {
         crate::entities::helpers::delete_helper::<Self>(tx, "id", id.as_slice())
     }

--- a/keystore/src/entities/mls/stored_credential.rs
+++ b/keystore/src/entities/mls/stored_credential.rs
@@ -141,10 +141,6 @@ impl crate::traits::EntityDatabaseMutation for StoredCredential {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(tx: &rusqlite::Transaction, id: &crate::Sha256Hash) -> crate::CryptoKeystoreResult<bool> {
         crate::entities::helpers::delete_helper::<Self>(tx, "public_key_sha256", *id)
     }

--- a/keystore/src/entities/mls/stored_encryption_key_pair.rs
+++ b/keystore/src/entities/mls/stored_encryption_key_pair.rs
@@ -80,10 +80,6 @@ impl crate::traits::EntityDatabaseMutation for StoredEncryptionKeyPair {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(tx: &rusqlite::Transaction, id: &Vec<u8>) -> crate::CryptoKeystoreResult<bool> {
         let hash = crate::Sha256Hash::hash_from(id);
         crate::entities::helpers::delete_helper::<Self>(tx, "pk_sha256", hash)

--- a/keystore/src/entities/mls/stored_hpke_private_key.rs
+++ b/keystore/src/entities/mls/stored_hpke_private_key.rs
@@ -80,10 +80,6 @@ impl crate::traits::EntityDatabaseMutation for StoredHpkePrivateKey {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(tx: &rusqlite::Transaction, id: &Vec<u8>) -> crate::CryptoKeystoreResult<bool> {
         let hash = crate::Sha256Hash::hash_from(id);
         crate::entities::helpers::delete_helper::<Self>(tx, "pk_sha256", hash)

--- a/keystore/src/entities/mls/stored_psk_bundle.rs
+++ b/keystore/src/entities/mls/stored_psk_bundle.rs
@@ -80,10 +80,6 @@ impl crate::traits::EntityDatabaseMutation for StoredPskBundle {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(tx: &rusqlite::Transaction, id: &Vec<u8>) -> crate::CryptoKeystoreResult<bool> {
         let hash = crate::Sha256Hash::hash_from(id);
         crate::entities::helpers::delete_helper::<Self>(tx, "id_sha256", hash)

--- a/keystore/src/entities/proteus/identity.rs
+++ b/keystore/src/entities/proteus/identity.rs
@@ -69,10 +69,6 @@ impl crate::traits::EntityDatabaseMutation for ProteusIdentity {
         Ok(())
     }
 
-    fn count(tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<u32> {
-        crate::entities::helpers::count_helper_tx::<Self>(tx)
-    }
-
     fn delete(tx: &rusqlite::Transaction, _id: &Self::PrimaryKey) -> crate::CryptoKeystoreResult<bool> {
         let mut stmt = tx.prepare_cached("DELETE FROM proteus_identities")?;
         let updated = stmt.execute([])?;

--- a/keystore/src/entities/proteus/prekey.rs
+++ b/keystore/src/entities/proteus/prekey.rs
@@ -2,7 +2,7 @@ use zeroize::Zeroize;
 
 use crate::{
     CryptoKeystoreError, CryptoKeystoreResult, Transaction,
-    entities::helpers::{count_helper, count_helper_tx, delete_helper, get_helper, load_all_helper},
+    entities::helpers::{count_helper, delete_helper, get_helper, load_all_helper},
     traits::{Entity, EntityDatabaseMutation, PrimaryKey},
 };
 
@@ -97,10 +97,6 @@ impl EntityDatabaseMutation for ProteusPrekey {
         let mut stmt = tx.prepare_cached("INSERT OR REPLACE INTO proteus_prekeys (id, key) VALUES (?, ?)")?;
         stmt.execute(rusqlite::params![self.id, self.prekey])?;
         Ok(())
-    }
-
-    fn count(tx: &rusqlite::Transaction) -> CryptoKeystoreResult<u32> {
-        count_helper_tx::<Self>(tx)
     }
 
     fn delete(tx: &rusqlite::Transaction, id: &u16) -> CryptoKeystoreResult<bool> {

--- a/keystore/src/traits/entity_database_mutation.rs
+++ b/keystore/src/traits/entity_database_mutation.rs
@@ -31,9 +31,6 @@ pub trait EntityDatabaseMutation: Entity + Into<dynamic_dispatch::Entity> {
     /// Use the transaction's interface to save this entity to the database
     fn save(&self, tx: &Transaction) -> CryptoKeystoreResult<()>;
 
-    /// Use the transaction's interface to count the number of entities of this type in the database.
-    fn count(tx: &Transaction) -> CryptoKeystoreResult<u32>;
-
     /// Use the transaction's inteface to delete this entity from the database.
     ///
     /// Returns `true` if at least one entity was deleted, or `false` if the id was not found in the database.

--- a/keystore/src/traits/unique_entity.rs
+++ b/keystore/src/traits/unique_entity.rs
@@ -2,7 +2,7 @@ use rusqlite::{Connection, OptionalExtension as _, ToSql, Transaction, params};
 
 use crate::{
     CryptoKeystoreResult,
-    entities::helpers::{count_helper, count_helper_tx, delete_helper, load_all_helper},
+    entities::helpers::{count_helper, delete_helper, load_all_helper},
     traits::{Entity, PrimaryKey, entity_database_mutation::EntityDatabaseMutation},
     transaction::dynamic_dispatch,
 };
@@ -95,8 +95,7 @@ where
     ///
     /// Returns `true` if the entity was saved, or `false` if it aborted due to an already-existing entity.
     fn set_if_absent(&self, tx: &Transaction) -> CryptoKeystoreResult<bool> {
-        let count = <Self as EntityDatabaseMutation>::count(tx)?;
-        if count > 0 {
+        if Self::exists(tx)? {
             return Ok(false);
         }
         self.save(tx)?;
@@ -105,7 +104,7 @@ where
 
     /// Returns whether or not the database contains an instance of this unique entity.
     fn exists(conn: &Connection) -> CryptoKeystoreResult<bool> {
-        <Self as Entity>::count(conn).map(|count| count > 0)
+        Self::count(conn).map(|count| count > 0)
     }
 }
 
@@ -152,10 +151,6 @@ where
         ))?;
         stmt.execute(params![Self::KEY, self.content()])?;
         Ok(())
-    }
-
-    fn count(tx: &Transaction) -> CryptoKeystoreResult<u32> {
-        count_helper_tx::<Self>(tx)
     }
 
     fn delete(tx: &Transaction, id: &Self::PrimaryKey) -> CryptoKeystoreResult<bool> {


### PR DESCRIPTION
Given that in sqlite `Transaction: Deref<Target = Connection>`, it is redundant.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
