### PR TITLE
ci: only deactivate AppArmor on Ubuntu runner

### DIFF
--- a/.github/workflows/benchmark-ts-browser.yml
+++ b/.github/workflows/benchmark-ts-browser.yml
@@ -93,6 +93,7 @@ jobs:
 
       # See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
       - name: disable Ubuntu's AppArmor for puppeteer
+        if: contains(fromJSON(inputs.runs_on), 'ubuntu')
         run: |
           echo disabling AppArmor on ubuntu runner
           echo "See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md"


### PR DESCRIPTION
We deactivated AppArmor to make allow chrome installation on ubuntu runners. This should not run on our self hosted runner.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
