### PR TITLE
chore(ffi): adjust log levels for all contexts [WPB-27724]

### DIFF
--- a/crypto-ffi/src/core_crypto/logger.rs
+++ b/crypto-ffi/src/core_crypto/logger.rs
@@ -131,12 +131,7 @@ impl log::Log for LogShim {
         let context = serde_json::to_string(&visitor.0).ok();
 
         // adjust the loglevel for sqlite migrations
-        #[cfg(not(target_os = "unknown"))]
         let loglevel = CoreCryptoLogLevel::from(self.adjusted_log_level(record.metadata()));
-
-        // no adjustment needed for wasm/idb
-        #[cfg(target_os = "unknown")]
-        let loglevel = record.metadata().level().into();
 
         let log_result = self.logger.log(loglevel, message.clone(), context);
 


### PR DESCRIPTION
Refinery migrations now run on all platforms, so we need to adapt the log filter to also run on all platforms.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
