### PR TITLE
feat(keystore): use immediate-mode transactions [WPB-27875]

### DIFF
--- a/keystore/src/transaction/mod.rs
+++ b/keystore/src/transaction/mod.rs
@@ -11,6 +11,7 @@ use std::{borrow::Cow, collections::HashSet, sync::Arc};
 use async_lock::{RwLock, SemaphoreGuardArc};
 use itertools::Itertools;
 use ordermap::OrderMap;
+use rusqlite::TransactionBehavior;
 
 use crate::{
     CryptoKeystoreError, CryptoKeystoreResult, Database, UniqueArc,
@@ -121,7 +122,7 @@ impl UniqueArc<Transaction> {
         // Because `rusqlite::Transaction: !Send + !Sync`, it's critical that
         // we don't hold this transaction over any `.await` points.
         let mut conn = database.conn().await;
-        let tx = conn.transaction()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         for entity in cache.values() {
             entity.execute_save(&tx)?;


### PR DESCRIPTION
Sqlite transactions default to Deferred mode, in which a transaction doesn't actually claim the write lock until the first time it attempts to write. This opens the door to a `SQLITE_BUSY` error happening on the first saved entity instead of the transaction's creation.

Choosing immediate mode explicitly claims the write lock: it eliminates a failure mode in the actual `entity.execute_save` path.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
