### PR TITLE
chore: use workspace for more dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5131,12 +5131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6449,7 +6443,6 @@ dependencies = [
  "getrandom 0.4.1",
  "js-sys",
  "serde_core",
- "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_derive",
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
@@ -2081,12 +2081,6 @@ name = "futures-task"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -4156,15 +4150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4587,8 +4572,6 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
- "futures-timer",
- "futures-util",
  "rstest_macros",
 ]
 
@@ -4600,7 +4583,6 @@ checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -5878,17 +5860,11 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.10",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_datetime"
@@ -5900,23 +5876,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime 0.6.8",
- "winnow 0.6.20",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
@@ -7207,15 +7172,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "winnow"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,6 @@ dependencies = [
  "async-trait",
  "base64 0.23.0",
  "bitflags",
- "cc",
  "const_format",
  "core-crypto",
  "core-crypto-ffi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,6 @@ version = "10.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "async-fs",
  "async-lock",
  "async-recursion",
  "async-trait",
@@ -2885,7 +2884,6 @@ name = "interop"
 version = "10.3.0"
 dependencies = [
  "anyhow",
- "async-fs",
  "async-trait",
  "base64 0.23.0",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,6 @@ dependencies = [
  "async-fs",
  "async-lock",
  "async-trait",
- "blocking",
  "console_error_panic_hook",
  "core-crypto-keystore",
  "core-crypto-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,6 @@ dependencies = [
  "ed25519-dalek",
  "enum-as-inner",
  "env_logger",
- "futures-lite",
  "futures-util",
  "getrandom 0.2.15",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7204,7 +7204,6 @@ dependencies = [
  "http 1.5.0",
  "http-body-util",
  "hyper",
- "hyper-util",
  "itertools 0.15.0",
  "jwt-simple",
  "keycloak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,10 @@ openidconnect = { version = "4", default-features = false }
 rstest = { version = "0.26", default-features = false }
 rstest_reuse = { version = "0.7", default-features = false }
 scraper = { version = "0.27", default-features = false }
+serde-wasm-bindgen = "0.6"
 tokio = { version = "1.52", default-features = false }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = { version = "0.3" }
 http = { version = "1", default-features = false }
 hyper = { version = "1.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ smol = "2.0"
 smol-macros = "0.1"
 smol-hyper = "0.1.1"
 strum = { version = "0.28", features = ["derive"] }
+tempfile = "3.27"
 thiserror = "2.0"
 tls_codec = "0.4.2"
 typed-builder = "0.23.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ futures-util = "0.3"
 hex = "0.4"
 # temporary, until https://github.com/devashishdxt/idb/pull/42 is merged / released
 idb = { version = "0.6", git = "https://github.com/wireapp/idb.git", rev = "10fad82eb4d4dd7f8be6db7b9427267168331511" }
+js-sys = "0.3"
 itertools = "0.15"
 log = { version = "0.4", features = ["kv_serde"] }
 log-reload = "0.1.3"

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -59,7 +59,7 @@ uniffi_ubrn = { package = "uniffi", version = "0.31", optional = true, features 
 
 # see https://github.com/RustCrypto/hashes/issues/404
 [target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86")))'.dependencies]
-sha2 = { version = "0.10", features = ["force-soft"] }
+sha2 = { workspace = true, features = ["force-soft"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -63,7 +63,7 @@ sha2 = { version = "0.10", features = ["force-soft"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
-js-sys = "0.3"
+js-sys.workspace = true
 web-sys = "0.3"
 console_error_panic_hook.workspace = true
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -91,7 +91,7 @@ uuid = { workspace = true, features = ["v4", "v5", "js"] }
 tempfile = "3.27"
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-js-sys = "0.3"
+js-sys.workspace = true
 rstest.workspace = true
 rstest_reuse.workspace = true
 env_logger.workspace = true

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -84,7 +84,7 @@ serde-wasm-bindgen.workspace = true
 
 [dev-dependencies]
 itertools.workspace = true
-uuid = { workspace = true, features = ["v4", "v5", "js"] }
+uuid = { workspace = true, features = ["v4", "js"] }
 tempfile.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -80,7 +80,6 @@ version = "0.12"
 features = ["x25519", "p256", "p384", "p521"]
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
-async-fs = { version = "2.2", optional = true }
 futures-lite = { version = "2.6", optional = true }
 
 [target.'cfg(target_os = "unknown")'.dependencies]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -79,9 +79,6 @@ rand_chacha = "0.3"
 version = "0.12"
 features = ["x25519", "p256", "p384", "p521"]
 
-[target.'cfg(not(target_os = "unknown"))'.dependencies]
-futures-lite = { version = "2.6", optional = true }
-
 [target.'cfg(target_os = "unknown")'.dependencies]
 serde-wasm-bindgen.workspace = true
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -61,17 +61,17 @@ aes-gcm = "0.10"
 sha2 = { workspace = true, features = ["oid"] }
 chacha20poly1305 = "0.10"
 hmac = "0.13"
-ed25519-dalek = { version = "2.2", features = ["pkcs8"] }
-signature = "2.2"
-ecdsa = { version = "0.16", features = ["der", "pkcs8"] }
-p256 = { version = "0.13", features = ["pkcs8"] }
-p384 = { version = "0.13", features = ["pkcs8"] }
-p521 = { version = "0.13", features = ["pkcs8"] }
+ed25519-dalek = { workspace = true, features = ["pkcs8"] }
+signature.workspace = true
+ecdsa = { workspace = true, features = ["der", "pkcs8"] }
+p256 = { workspace = true, features = ["pkcs8"] }
+p384 = { workspace = true, features = ["pkcs8"] }
+p521 = { workspace = true, features = ["pkcs8"] }
 hkdf = "0.12"
 x509-cert = { workspace = true, features = ["builder", "hazmat"] }
-web-time = "1.1.0"
+web-time.workspace = true
 rand = { workspace = true, features = ["getrandom"] }
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 rand_core = "0.6"
 rand_chacha = "0.3"
 
@@ -93,20 +93,19 @@ tempfile = "3.27"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-rstest = "0.26"
-rstest_reuse = "0.7"
-env_logger = "0.11"
+rstest.workspace = true
+rstest_reuse.workspace = true
+env_logger.workspace = true
 futures-util = { workspace = true, features = ["std", "alloc"] }
 async-trait.workspace = true
 wire-e2e-identity = { workspace = true, features = ["builder"] }
-web-time.workspace = true
-time = { version = "0.3", features = ["wasm-bindgen"] }
+time = { workspace = true, features = ["wasm-bindgen"] }
 core-crypto-keystore = { workspace = true, features = ["dummy-entity"] }
-rmp-serde = { workspace = true }
+rmp-serde.workspace = true
 smol.workspace = true
 smol-macros.workspace = true
 macro_rules_attribute.workspace = true
-wasm-bindgen-test = { workspace = true }
+wasm-bindgen-test.workspace = true
 openmls.workspace = true
 hex-literal = "1.1"
 
@@ -115,7 +114,7 @@ smol-macros.workspace = true
 macro_rules_attribute.workspace = true
 
 [build-dependencies]
-anyhow = "1.0.102"
+anyhow.workspace = true
 # this is appropriate if we always and only build in environments where `git`
 # is available on the command line. If not, we should replace this with
 # `vergen-gix` or `vergen-git2`.

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -88,7 +88,7 @@ serde-wasm-bindgen.workspace = true
 [dev-dependencies]
 itertools.workspace = true
 uuid = { workspace = true, features = ["v4", "v5", "js"] }
-tempfile = "3.27"
+tempfile.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 js-sys.workspace = true

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -83,14 +83,14 @@ features = ["x25519", "p256", "p384", "p521"]
 futures-lite = { version = "2.6", optional = true }
 
 [target.'cfg(target_os = "unknown")'.dependencies]
-serde-wasm-bindgen = "0.6"
+serde-wasm-bindgen.workspace = true
 
 [dev-dependencies]
 itertools.workspace = true
 uuid = { workspace = true, features = ["v4", "v5", "js"] }
 tempfile = "3.27"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
 js-sys = "0.3"
 rstest.workspace = true
 rstest_reuse.workspace = true

--- a/e2e-identity/Cargo.toml
+++ b/e2e-identity/Cargo.toml
@@ -87,7 +87,6 @@ oauth2 = { workspace = true, features = ["reqwest"] }
 http.workspace = true
 keycloak.workspace = true
 http-body-util = "0.1"
-hyper-util = { version = "0.1", features = ["full"] }
 testcontainers = { workspace = true, features = ["reusable-containers"] }
 
 [target.'cfg(target_os = "unknown")'.dependencies.uuid]

--- a/e2e-identity/Cargo.toml
+++ b/e2e-identity/Cargo.toml
@@ -80,7 +80,6 @@ rstest.workspace = true
 
 [target.'cfg(not(target_os = "unknown"))'.dev-dependencies]
 reqwest = { workspace = true, features = ["json", "cookies"] }
-tokio = { workspace = true, features = ["macros"] }
 hyper = { workspace = true, features = ["server"] }
 native-tls = { workspace = true, features = ["vendored"] }
 oauth2 = { workspace = true, features = ["reqwest"] }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -31,7 +31,7 @@ const_format.workspace = true
 rand.workspace = true
 bitflags.workspace = true
 uuid = { workspace = true, features = ["v4"] }
-tempfile = { version = "3.27" }
+tempfile.workspace = true
 spinoff = { version = "0.8", features = [
   "aesthetic",
 ], default-features = false }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -39,7 +39,6 @@ serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
-async-fs = "2.2"
 tokio = { version = "1.52", features = ["full"] }
 # Http Server
 warp = { version = "0.4", features = ["server"] }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-env_logger = "0.11"
+env_logger.workspace = true
 core-crypto = { path = "../crypto" }
 core-crypto-ffi = { path = "../crypto-ffi" }
 core-crypto-macros = { path = "../crypto-macros" }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -47,6 +47,3 @@ proteus-wasm = { workspace = true, optional = true }
 which = "8.0.2"
 tree-sitter = "0.26.9"
 tree-sitter-typescript = "0.23.2"
-
-[target.'cfg(not(target_os = "unknown"))'.build-dependencies]
-cc = "1.2.63"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0"
-log = "0.4"
+log.workspace = true
 env_logger.workspace = true
 core-crypto = { path = "../crypto" }
 core-crypto-ffi = { path = "../crypto-ffi" }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -12,7 +12,7 @@ proteus = ["dep:proteus-wasm", "core-crypto/proteus"]
 workspace = true
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 log.workspace = true
 env_logger.workspace = true
 core-crypto = { path = "../crypto" }
@@ -39,7 +39,7 @@ serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
-tokio = { version = "1.52", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 # Http Server
 warp = { version = "0.4", features = ["server"] }
 fantoccini = "0.22"

--- a/keystore-dump/Cargo.toml
+++ b/keystore-dump/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 core-crypto-keystore = { workspace = true }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -24,7 +24,7 @@ async-lock.workspace = true
 async-trait.workspace = true
 core-crypto-macros.workspace = true
 derive_more.workspace = true
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 hex.workspace = true
 itertools.workspace = true
 log = { workspace = true }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -81,7 +81,7 @@ serde-wasm-bindgen.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 web-sys = { version = "0.3", features = ["console"] }
-web-time = "1.1.0"
+web-time.workspace = true
 
 [dev-dependencies]
 core-crypto-keystore = { path = ".", features = ["log-queries"] }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -66,7 +66,6 @@ security-framework-sys = "2.16"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 async-fs = "2.2"
-blocking = "1.6"
 rusqlite = { version = "0.38", default-features = false, features = [
   "bundled-sqlcipher-vendored-openssl",
 ] }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -74,12 +74,12 @@ rusqlite = { version = "0.38", default-features = false, features = [
 idb.workspace = true
 js-sys = "0.3"
 paste = "1.0.5"
-serde-wasm-bindgen = "0.6"
 sqlite-wasm-rs = { version = "0.5.5", features = ["sqlite3mc"] }
 sqlite-wasm-vfs = "0.2.0"
 time = { version = "0.3.5", features = ["wasm-bindgen"] }
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+serde-wasm-bindgen.workspace = true
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
 web-sys = { version = "0.3", features = ["console"] }
 web-time = "1.1.0"
 

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -72,7 +72,7 @@ rusqlite = { version = "0.38", default-features = false, features = [
 
 [target.'cfg(target_os = "unknown")'.dependencies]
 idb.workspace = true
-js-sys = "0.3"
+js-sys.workspace = true
 paste = "1.0.5"
 sqlite-wasm-rs = { version = "0.5.5", features = ["sqlite3mc"] }
 sqlite-wasm-vfs = "0.2.0"

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -89,8 +89,8 @@ env_logger.workspace = true
 futures-lite = "2.6"
 openmls = { workspace = true, features = ["crypto-subtle"] }
 proteus-wasm = { workspace = true }
-rstest = "0.26"
-rstest_reuse = "0.7"
+rstest.workspace = true
+rstest_reuse.workspace = true
 tempfile.workspace = true
 uuid = { workspace = true, features = ["v4", "js"] }
 wasm-bindgen-test = { workspace = true }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -91,7 +91,7 @@ openmls = { workspace = true, features = ["crypto-subtle"] }
 proteus-wasm = { workspace = true }
 rstest = "0.26"
 rstest_reuse = "0.7"
-tempfile = "3.27.0"
+tempfile.workspace = true
 uuid = { workspace = true, features = ["v4", "js"] }
 wasm-bindgen-test = { workspace = true }
 

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -85,7 +85,7 @@ web-time.workspace = true
 
 [dev-dependencies]
 core-crypto-keystore = { path = ".", features = ["log-queries"] }
-env_logger = "0.11"
+env_logger.workspace = true
 futures-lite = "2.6"
 openmls = { workspace = true, features = ["crypto-subtle"] }
 proteus-wasm = { workspace = true }


### PR DESCRIPTION
This makes it easier to maintain deps and minimises the chance of mismatch among crates.