### PR TITLE
chore: `FetchFromDatabase` returns arcs

### DIFF
--- a/crypto/src/immutable_database.rs
+++ b/crypto/src/immutable_database.rs
@@ -19,7 +19,7 @@ pub struct ImmutableDatabase(Arc<Database>);
 #[cfg_attr(not(target_os = "unknown"), async_trait)]
 #[cfg_attr(target_os = "unknown", async_trait(?Send))]
 impl FetchFromDatabase for ImmutableDatabase {
-    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: Entity + Clone + Send + Sync + 'static,
     {
@@ -33,14 +33,17 @@ impl FetchFromDatabase for ImmutableDatabase {
         self.0.count::<E>().await
     }
 
-    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<E>>
+    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: Entity + Clone + Send + Sync + 'static,
     {
         self.0.load_all::<E>().await
     }
 
-    async fn get_borrowed<E>(&self, id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get_borrowed<E>(
+        &self,
+        id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey,
+    ) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: EntityGetBorrowed + Clone + Send + Sync + 'static,
         E::PrimaryKey: Borrow<E::BorrowedPrimaryKey>,
@@ -49,7 +52,7 @@ impl FetchFromDatabase for ImmutableDatabase {
         self.0.get_borrowed::<E>(id).await
     }
 
-    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<E>>
+    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: Entity + SearchableEntity<SearchKey> + Clone + Send + Sync + 'static,
         SearchKey: KeyType,

--- a/crypto/src/mls/conversation/immutable/persistence.rs
+++ b/crypto/src/mls/conversation/immutable/persistence.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use core_crypto_keystore::{entities::PersistedMlsGroup, traits::FetchFromDatabase};
 use openmls::group::MlsGroup;
@@ -39,7 +39,8 @@ impl Conversation {
             .get_borrowed::<PersistedMlsGroup>(id.as_ref())
             .await
             .map_err(KeystoreError::wrap("finding a persisted mls group"))?;
-        let Some(mut group) = group else { return Ok(None) };
+        let Some(group) = group else { return Ok(None) };
+        let mut group = Arc::unwrap_or_clone(group);
         let conversation = Self::from_serialized_state(
             session,
             std::mem::take(&mut group.state),

--- a/crypto/src/mls/conversation/mutable/decrypt/buffer_commit.rs
+++ b/crypto/src/mls/conversation/mutable/decrypt/buffer_commit.rs
@@ -35,7 +35,7 @@ impl ConversationMut {
         database
             .get_borrowed::<StoredBufferedCommit>(self.id().as_ref())
             .await
-            .map(|option| option.map(StoredBufferedCommit::into_commit_data))
+            .map(|option| option.map(|commit| commit.commit_data().to_owned()))
             .map_err(KeystoreError::wrap("attempting to retrieve buffered commit"))
             .map_err(Into::into)
     }

--- a/crypto/src/mls/credential/credential_ref/persistence.rs
+++ b/crypto/src/mls/credential/credential_ref/persistence.rs
@@ -4,6 +4,8 @@
 //! useful to end users. Clients building on the CC API can't do anything useful with a full [`Credential`],
 //! and it's wasteful to transfer one across the FFI boundary.
 
+use std::sync::Arc;
+
 use core_crypto_keystore::{entities::StoredCredential, traits::FetchFromDatabase};
 
 use super::{Error, Result};
@@ -20,7 +22,7 @@ impl CredentialRef {
             .map_err(KeystoreError::wrap("finding credential"))?
             .ok_or(Error::CredentialNotFound)
             .and_then(|stored_credential| {
-                Credential::try_from(&stored_credential)
+                Credential::try_from(stored_credential)
                     .map_err(RecursiveError::mls_credential(
                         "creating credential from stored credential",
                     ))
@@ -41,7 +43,10 @@ impl CredentialRef {
             .map_err(KeystoreError::wrap("finding credential"))?
             .ok_or(Error::CredentialNotFound)
             .map_err(RecursiveError::mls_credential_ref("retrieving public key"))
-            .map(|mut stored_credential| std::mem::take(&mut stored_credential.public_key))
+            .map(|stored_credential| {
+                let mut stored_credential = Arc::unwrap_or_clone(stored_credential);
+                std::mem::take(&mut stored_credential.public_key)
+            })
             .map_err(Into::into)
     }
 }

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod ext;
 mod persistence;
 pub(crate) mod x509;
 
+use std::sync::Arc;
+
 use core_crypto_keystore::entities::StoredCredential;
 use openmls::prelude::{Credential as MlsCredential, CredentialWithKey, SignatureScheme};
 use openmls_basic_credential::SignatureKeyPair;
@@ -52,10 +54,10 @@ pub struct Credential {
     pub(crate) earliest_validity: u64,
 }
 
-impl TryFrom<&StoredCredential> for Credential {
+impl TryFrom<Arc<StoredCredential>> for Credential {
     type Error = Error;
 
-    fn try_from(stored_credential: &StoredCredential) -> Result<Credential> {
+    fn try_from(stored_credential: Arc<StoredCredential>) -> Result<Credential> {
         let mls_credential = MlsCredential::tls_deserialize(&mut stored_credential.credential.as_slice())
             .map_err(Error::tls_deserialize("mls credential"))?;
         let cipher_suite = CipherSuite::try_from(stored_credential.ciphersuite)

--- a/crypto/src/mls/credential/persistence.rs
+++ b/crypto/src/mls/credential/persistence.rs
@@ -18,7 +18,7 @@ impl Credential {
             .await
             .map_err(KeystoreError::wrap("getting credential by public key"))?
             .ok_or_else(|| Error::CredentialNotFound(public_key.clone()))?;
-        stored_credential.try_into()
+        stored_credential.clone().try_into()
     }
 
     /// Should only be used when really requiring the credential data itself, e.g., when checking for validity or
@@ -29,6 +29,7 @@ impl Credential {
             .await
             .map_err(KeystoreError::wrap("getting all credentials"))?
             .iter()
+            .cloned()
             .map(TryInto::try_into)
             .collect()
     }

--- a/crypto/src/mls/session/key_package.rs
+++ b/crypto/src/mls/session/key_package.rs
@@ -46,7 +46,7 @@ impl Session {
             .get_borrowed::<StoredKeyPackage>(kp_ref.hash_ref())
             .await
             .map_err(KeystoreError::wrap("loading keypackage from database"))?
-            .map(|stored_keypackage| from_stored(stored_keypackage))
+            .map(from_stored)
             .transpose()
     }
 }

--- a/crypto/src/mls/session/key_package.rs
+++ b/crypto/src/mls/session/key_package.rs
@@ -1,9 +1,11 @@
+use std::sync::Arc;
+
 use core_crypto_keystore::{entities::StoredKeyPackage, traits::FetchFromDatabase};
 
 use super::Result;
 use crate::{Keypackage, KeypackageRef, KeystoreError, Session, mls::key_package::KeypackageExt};
 
-pub(crate) fn from_stored(stored_keypackage: &StoredKeyPackage) -> Result<Keypackage> {
+pub(crate) fn from_stored(stored_keypackage: Arc<StoredKeyPackage>) -> Result<Keypackage> {
     core_crypto_keystore::deser::<Keypackage>(&stored_keypackage.key_package)
         .map_err(KeystoreError::wrap("deserializing keypackage"))
         .map_err(Into::into)
@@ -12,14 +14,14 @@ pub(crate) fn from_stored(stored_keypackage: &StoredKeyPackage) -> Result<Keypac
 impl Session {
     /// Get all [`Keypackage`]s in the database.
     pub(crate) async fn get_key_packages(&self) -> Result<Vec<Keypackage>> {
-        let stored_keypackages: Vec<StoredKeyPackage> = self
+        let stored_keypackages = self
             .database
-            .load_all()
+            .load_all::<StoredKeyPackage>()
             .await
             .map_err(KeystoreError::wrap("finding all keypackages"))?;
 
         let keypackages = stored_keypackages
-            .iter()
+            .iter().cloned()
             .map(from_stored)
             // if any ref from loading all fails to load now, skip it
             // strictly we could panic, but this is safer--maybe someone removed it concurrently
@@ -44,7 +46,7 @@ impl Session {
             .get_borrowed::<StoredKeyPackage>(kp_ref.hash_ref())
             .await
             .map_err(KeystoreError::wrap("loading keypackage from database"))?
-            .map(|stored_keypackage| from_stored(&stored_keypackage))
+            .map(|stored_keypackage| from_stored(stored_keypackage))
             .transpose()
     }
 }

--- a/crypto/src/test_utils/context.rs
+++ b/crypto/src/test_utils/context.rs
@@ -145,6 +145,7 @@ impl SessionContext {
             .get::<StoredHpkePrivateKey>(&skp.tls_serialize_detached().unwrap())
             .await
             .unwrap()
+            .map(Arc::unwrap_or_clone)
     }
 
     pub async fn find_credential_from_keystore(&self, cb: &Credential) -> Option<StoredCredential> {
@@ -158,6 +159,7 @@ impl SessionContext {
             .unwrap()
             .into_iter()
             .find(|c| c.credential[..] == credential)
+            .map(Arc::unwrap_or_clone)
     }
 
     pub async fn count_hpke_private_key(&self) -> u32 {

--- a/crypto/src/transaction_context/conversation/mod.rs
+++ b/crypto/src/transaction_context/conversation/mod.rs
@@ -4,6 +4,8 @@ pub mod external_commit;
 mod persistence;
 pub mod welcome;
 
+use std::sync::Arc;
+
 use core_crypto_keystore::{
     entities::{PersistedMlsPendingGroup, StoredBufferedCommit},
     traits::FetchFromDatabase as _,
@@ -114,6 +116,7 @@ impl TransactionContext {
         else {
             return Err(LeafError::ConversationNotFound(id.to_owned()).into());
         };
+        let pending_group = Arc::unwrap_or_clone(pending_group);
         Ok(PendingConversation::new(pending_group, self.clone()))
     }
 

--- a/crypto/src/transaction_context/key_package.rs
+++ b/crypto/src/transaction_context/key_package.rs
@@ -174,7 +174,7 @@ impl TransactionContext {
             .get_borrowed::<StoredKeyPackage>(key_package_ref)
             .await
             .map_err(KeystoreError::wrap("loading keypackage from database"))?
-            .map(|stored_keypackage| crate::mls::session::key_package::from_stored(stored_keypackage))
+            .map(crate::mls::session::key_package::from_stored)
             .transpose()
             .map_err(RecursiveError::mls_client("loading key package"))?
         else {

--- a/crypto/src/transaction_context/key_package.rs
+++ b/crypto/src/transaction_context/key_package.rs
@@ -174,7 +174,7 @@ impl TransactionContext {
             .get_borrowed::<StoredKeyPackage>(key_package_ref)
             .await
             .map_err(KeystoreError::wrap("loading keypackage from database"))?
-            .map(|stored_keypackage| crate::mls::session::key_package::from_stored(&stored_keypackage))
+            .map(|stored_keypackage| crate::mls::session::key_package::from_stored(stored_keypackage))
             .transpose()
             .map_err(RecursiveError::mls_client("loading key package"))?
         else {

--- a/crypto/src/transaction_context/mod.rs
+++ b/crypto/src/transaction_context/mod.rs
@@ -279,7 +279,7 @@ impl TransactionContext {
     pub async fn get_data(&self) -> Result<Option<Vec<u8>>> {
         let inner = self.inner().await?;
         match inner.transaction.get_unique::<ConsumerData>().await {
-            Ok(maybe_data) => Ok(maybe_data.map(Into::into)),
+            Ok(maybe_data) => Ok(maybe_data.map(Arc::unwrap_or_clone).map(Into::into)),
             Err(CryptoKeystoreError::NotFound(..)) => Ok(None),
             Err(err) => Err(KeystoreError::wrap("finding unique consumer data")(err).into()),
         }

--- a/e2e-identity/src/pki_env/mod.rs
+++ b/e2e-identity/src/pki_env/mod.rs
@@ -217,7 +217,8 @@ impl PkiEnvironment {
         guard.clear_trust_anchor_sources();
 
         let mut source = TaSource::new();
-        for mut anchor in anchors {
+        for anchor in anchors {
+            let mut anchor = Arc::unwrap_or_clone(anchor);
             source.push(certval::CertFile {
                 filename: "".to_string(),
                 bytes: std::mem::take(&mut anchor.content),

--- a/keystore/src/connection/entity_extension_methods.rs
+++ b/keystore/src/connection/entity_extension_methods.rs
@@ -1,5 +1,7 @@
 //! The methods defined in this module are extensions designed to improve entity ergonomics.
 
+use std::sync::Arc;
+
 use crate::{CryptoKeystoreResult, Database, entities::MlsPendingMessage, traits::SearchableEntity as _};
 
 // These and all other database impls should not refer directly to `self.conn` but should go through the `self.conn()`
@@ -8,10 +10,12 @@ impl Database {
     pub async fn find_pending_messages_by_conversation_id(
         &self,
         conversation_id: &[u8],
-    ) -> CryptoKeystoreResult<Vec<MlsPendingMessage>> {
+    ) -> CryptoKeystoreResult<Vec<Arc<MlsPendingMessage>>> {
         let conn = self.conn().await;
         let conversation_id = conversation_id.to_vec().into();
-        let persisted_records = MlsPendingMessage::find_all_matching(&conn, &conversation_id)?;
+        let persisted_records = MlsPendingMessage::find_all_matching(&conn, &conversation_id)?
+            .into_iter()
+            .map(Arc::new);
         self.merge_with_transaction(persisted_records, async |transaction, persisted_records| {
             transaction
                 .find_pending_messages_by_conversation_id(&conversation_id, persisted_records)

--- a/keystore/src/connection/fetch_from_database.rs
+++ b/keystore/src/connection/fetch_from_database.rs
@@ -20,7 +20,7 @@ fn no_transaction_to_default_read_outcome<E>(err: CryptoKeystoreError) -> Crypto
 #[cfg_attr(target_os = "unknown", async_trait(?Send))]
 #[cfg_attr(not(target_os = "unknown"), async_trait)]
 impl FetchFromDatabase for Database {
-    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync,
     {
@@ -30,17 +30,20 @@ impl FetchFromDatabase for Database {
             .or_else(no_transaction_to_default_read_outcome)?;
 
         if let Some(record) = read_outcome.entity {
-            return Ok(record.map(Arc::unwrap_or_clone));
+            return Ok(record);
         }
 
         // Otherwise get it from the database
         let conn = self.conn().await;
         let db_entity = E::get(&conn, id)?.filter(|entity| !read_outcome.should_omit(entity));
 
-        Ok(db_entity)
+        Ok(db_entity.map(Arc::new))
     }
 
-    async fn get_borrowed<E>(&self, id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get_borrowed<E>(
+        &self,
+        id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey,
+    ) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + EntityGetBorrowed + Clone + Send + Sync,
         E::PrimaryKey: Borrow<E::BorrowedPrimaryKey>,
@@ -52,13 +55,13 @@ impl FetchFromDatabase for Database {
             .or_else(no_transaction_to_default_read_outcome)?;
 
         if let Some(cached_record) = read_outcome.entity {
-            return Ok(cached_record.map(Arc::unwrap_or_clone));
+            return Ok(cached_record);
         }
 
         // Otherwise get it from the database
         let conn = self.conn().await;
         let db_entity = E::get_borrowed(&conn, id)?.filter(|entity| !read_outcome.should_omit(entity));
-        Ok(db_entity)
+        Ok(db_entity.map(Arc::new))
     }
 
     async fn count<E>(&self) -> CryptoKeystoreResult<u32>
@@ -76,12 +79,12 @@ impl FetchFromDatabase for Database {
         }
     }
 
-    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<E>>
+    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync,
     {
         let conn = self.conn().await;
-        let persisted_records = E::load_all(&conn)?;
+        let persisted_records = E::load_all(&conn)?.into_iter().map(Arc::new);
 
         self.merge_with_transaction(persisted_records, async |transaction, persisted_records| {
             Ok(transaction.find_all(persisted_records).await.collect())
@@ -89,13 +92,13 @@ impl FetchFromDatabase for Database {
         .await
     }
 
-    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<E>>
+    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + SearchableEntity<SearchKey> + Clone + Send + Sync,
         SearchKey: KeyType,
     {
         let conn = self.conn().await;
-        let persisted_records = E::find_all_matching(&conn, search_key)?;
+        let persisted_records = E::find_all_matching(&conn, search_key)?.into_iter().map(Arc::new);
 
         self.merge_with_transaction(persisted_records, async |transaction, persisted_records| {
             Ok(transaction.search(persisted_records, search_key).await.collect())

--- a/keystore/src/connection/transaction.rs
+++ b/keystore/src/connection/transaction.rs
@@ -143,17 +143,20 @@ impl Database {
     /// Merge database records with the active transaction's view of them.
     ///
     /// If no transaction is in progress, the database records are returned unchanged.
-    pub(super) async fn merge_with_transaction<E>(
+    pub(super) async fn merge_with_transaction<E, Persisted>(
         &self,
-        persisted_records: Vec<E>,
-        merge: impl AsyncFnOnce(&Transaction, Vec<E>) -> CryptoKeystoreResult<Vec<E>>,
-    ) -> CryptoKeystoreResult<Vec<E>> {
+        persisted_records: Persisted,
+        merge: impl AsyncFnOnce(&Transaction, Persisted) -> CryptoKeystoreResult<Vec<Arc<E>>>,
+    ) -> CryptoKeystoreResult<Vec<Arc<E>>>
+    where
+        Persisted: IntoIterator<Item = Arc<E>>,
+    {
         let guard = self.transaction.lock().await;
         let Some(weak) = guard.as_ref() else {
-            return Ok(persisted_records);
+            return Ok(persisted_records.into_iter().collect());
         };
         let Some(tx) = weak.upgrade().await else {
-            return Ok(persisted_records);
+            return Ok(persisted_records.into_iter().collect());
         };
         merge(&tx, persisted_records).await
     }

--- a/keystore/src/entities/mls/mls_pending_message.rs
+++ b/keystore/src/entities/mls/mls_pending_message.rs
@@ -170,7 +170,7 @@ mod tests {
             tx.commit().await.unwrap();
 
             assert_eq!(
-                store.get::<MlsPendingMessage>(&primary_key).await.unwrap().as_ref(),
+                store.get::<MlsPendingMessage>(&primary_key).await.unwrap().as_deref(),
                 Some(&pending_message()),
                 "a buffered message must survive commit even though its conversation is not a pending group"
             );
@@ -198,7 +198,7 @@ mod tests {
                 .await
                 .unwrap()
                 .expect("the pending message was committed, so it must be gettable by primary key");
-            assert_eq!(fetched, expected);
+            assert_eq!(*fetched, expected);
         });
     }
 

--- a/keystore/src/traits/fetch_from_database.rs
+++ b/keystore/src/traits/fetch_from_database.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use std::{borrow::Borrow, sync::Arc};
 
 use async_trait::async_trait;
 
@@ -12,7 +12,7 @@ use crate::{
 #[cfg_attr(not(target_os = "unknown"), async_trait)]
 pub trait FetchFromDatabase: Send + Sync {
     /// Get an instance of `E` from the database by its primary key.
-    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync;
 
@@ -22,7 +22,7 @@ pub trait FetchFromDatabase: Send + Sync {
         E: 'static + Entity + Clone + Send + Sync;
 
     /// Load all `E`s from the database.
-    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<E>>
+    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync;
 
@@ -30,14 +30,14 @@ pub trait FetchFromDatabase: Send + Sync {
     async fn get_borrowed<E>(
         &self,
         id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey,
-    ) -> CryptoKeystoreResult<Option<E>>
+    ) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + EntityGetBorrowed + Clone + Send + Sync,
         E::PrimaryKey: Borrow<E::BorrowedPrimaryKey>,
         for<'a> &'a E::BorrowedPrimaryKey: KeyType;
 
     /// Get the requested unique entity from the database.
-    async fn get_unique<'a, U>(&self) -> CryptoKeystoreResult<Option<U>>
+    async fn get_unique<'a, U>(&self) -> CryptoKeystoreResult<Option<Arc<U>>>
     where
         U: 'static + UniqueEntityExt + Entity + Clone + Send + Sync,
     {
@@ -54,7 +54,7 @@ pub trait FetchFromDatabase: Send + Sync {
     }
 
     /// Search for relevant instances of `E` given a search key.
-    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<E>>
+    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + SearchableEntity<SearchKey> + Clone + Send + Sync,
         SearchKey: KeyType;

--- a/keystore/src/transaction/entity_read.rs
+++ b/keystore/src/transaction/entity_read.rs
@@ -147,29 +147,30 @@ impl Transaction {
     }
 
     /// Find all the entities of type `E` in the database as modified by the operations in this transaction.
-    pub(crate) async fn find_all<E>(&self, persisted_records: impl IntoIterator<Item = E>) -> impl Iterator<Item = E>
+    pub(crate) async fn find_all<E>(
+        &self,
+        persisted_records: impl IntoIterator<Item = Arc<E>>,
+    ) -> impl Iterator<Item = Arc<E>>
     where
         E: 'static + Clone + Entity + Send + Sync,
     {
         let cached_records = self.find_all_in_cache::<E>().await;
-        self.merge_records(cached_records.into_iter().map(Arc::unwrap_or_clone), persisted_records)
-            .await
+        self.merge_records(cached_records, persisted_records).await
     }
 
     /// Find all the entities of type `E` in the database which match `search_key`,
     /// as modified by the operations in this transaction.
     pub(crate) async fn search<E, SearchKey>(
         &self,
-        persisted_records: impl IntoIterator<Item = E>,
+        persisted_records: impl IntoIterator<Item = Arc<E>>,
         search_key: &SearchKey,
-    ) -> impl Iterator<Item = E>
+    ) -> impl Iterator<Item = Arc<E>>
     where
         E: 'static + Clone + Entity + SearchableEntity<SearchKey> + Send + Sync,
         SearchKey: KeyType,
     {
         let cached_records = self.search_in_cache(search_key).await;
-        self.merge_records(cached_records.map(Arc::unwrap_or_clone), persisted_records)
-            .await
+        self.merge_records(cached_records, persisted_records).await
     }
 }
 

--- a/keystore/src/transaction/fetch_from_database.rs
+++ b/keystore/src/transaction/fetch_from_database.rs
@@ -17,22 +17,25 @@ use crate::{
 #[cfg_attr(target_os = "unknown", async_trait(?Send))]
 #[cfg_attr(not(target_os = "unknown"), async_trait)]
 impl FetchFromDatabase for Transaction {
-    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync,
     {
         let read_outcome = <Self>::get::<E>(self, id).await;
         if let Some(result) = read_outcome.entity {
-            return Ok(result.map(Arc::unwrap_or_clone));
+            return Ok(result);
         };
 
         // Otherwise get it from the database
         let conn = self.database.conn().await;
         let db_entity = E::get(&conn, id)?.filter(|entity| !read_outcome.should_omit(entity));
-        Ok(db_entity)
+        Ok(db_entity.map(Arc::new))
     }
 
-    async fn get_borrowed<E>(&self, id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get_borrowed<E>(
+        &self,
+        id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey,
+    ) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + EntityGetBorrowed + Clone + Send + Sync,
         E::PrimaryKey: Borrow<E::BorrowedPrimaryKey>,
@@ -40,12 +43,12 @@ impl FetchFromDatabase for Transaction {
     {
         let read_outcome = <Self>::get_borrowed::<E>(self, id).await;
         if let Some(result) = read_outcome.entity {
-            return Ok(result.map(Arc::unwrap_or_clone));
+            return Ok(result);
         }
 
         let conn = self.database.conn().await;
         let db_entity = E::get_borrowed(&conn, id)?.filter(|entity| !read_outcome.should_omit(entity));
-        Ok(db_entity)
+        Ok(db_entity.map(Arc::new))
     }
 
     async fn count<E>(&self) -> CryptoKeystoreResult<u32>
@@ -58,23 +61,23 @@ impl FetchFromDatabase for Transaction {
         Ok(count as _)
     }
 
-    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<E>>
+    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync,
     {
         let conn = self.database.conn().await;
-        let persisted_records = E::load_all(&conn)?;
+        let persisted_records = E::load_all(&conn)?.into_iter().map(Arc::new);
 
         Ok(<Self>::find_all(self, persisted_records).await.collect())
     }
 
-    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<E>>
+    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + SearchableEntity<SearchKey> + Clone + Send + Sync,
         SearchKey: KeyType,
     {
         let conn = self.database.conn().await;
-        let persisted_records = E::find_all_matching(&conn, search_key)?;
+        let persisted_records = E::find_all_matching(&conn, search_key)?.into_iter().map(Arc::new);
 
         Ok(<Self>::search(self, persisted_records, search_key).await.collect())
     }

--- a/keystore/src/transaction/mod.rs
+++ b/keystore/src/transaction/mod.rs
@@ -87,9 +87,9 @@ impl Transaction {
     /// The returned order is unspecified, as the merge runs through a `HashMap`.
     async fn merge_records<E>(
         &self,
-        from_tx_cache: impl IntoIterator<Item = E>,
-        from_database: impl IntoIterator<Item = E>,
-    ) -> impl Iterator<Item = E>
+        from_tx_cache: impl IntoIterator<Item = Arc<E>>,
+        from_database: impl IntoIterator<Item = Arc<E>>,
+    ) -> impl Iterator<Item = Arc<E>>
     where
         E: 'static + Clone + Entity + Send + Sync,
     {
@@ -102,7 +102,7 @@ impl Transaction {
             from_database
                 .into_iter()
                 .filter_map(|entity| {
-                    let entity_id = EntityId::from_entity(&entity);
+                    let entity_id = EntityId::from_entity(&*entity);
 
                     // the delete may have been overwritten by a later upsert, true,
                     // but in that case we lose nothing by deleting here, because we
@@ -110,7 +110,7 @@ impl Transaction {
                     //
                     // bulk-deletes apply to the database entities regardless of when they happen
                     let excluded =
-                        operations.last_delete_idx_for(&entity_id).is_some() || filters.applies_after(&entity, 0);
+                        operations.last_delete_idx_for(&entity_id).is_some() || filters.applies_after(&*entity, 0);
                     (!excluded).then_some((entity_id, entity))
                 })
                 .collect::<HashMap<_, _>>()
@@ -118,7 +118,7 @@ impl Transaction {
 
         // update with everything which was inserted by the tx cache
         for entity in from_tx_cache {
-            let id = EntityId::from_entity(&entity);
+            let id = EntityId::from_entity(&*entity);
             cache.insert(id, entity);
         }
 

--- a/keystore/src/transaction/proteus.rs
+++ b/keystore/src/transaction/proteus.rs
@@ -8,7 +8,7 @@ impl proteus_traits::PreKeyStore for Transaction {
     async fn prekey(&self, id: proteus_traits::RawPreKeyId) -> Result<Option<proteus_traits::RawPreKey>, Self::Error> {
         FetchFromDatabase::get::<ProteusPrekey>(self, &id)
             .await
-            .map(|maybe_prekey| maybe_prekey.map(|mut db_prekey| std::mem::take(&mut db_prekey.prekey)))
+            .map(|maybe_prekey| maybe_prekey.map(|db_prekey| db_prekey.prekey.clone()))
     }
 
     async fn remove(&self, id: proteus_traits::RawPreKeyId) -> Result<(), Self::Error> {

--- a/keystore/src/transaction/specializations.rs
+++ b/keystore/src/transaction/specializations.rs
@@ -1,5 +1,7 @@
 //! These methods are specialized for performing certain entity-specific queries.
 
+use std::sync::Arc;
+
 use crate::{
     CryptoKeystoreResult,
     entities::{ConversationId, MlsPendingMessage},
@@ -18,8 +20,8 @@ impl Transaction {
     pub(crate) async fn find_pending_messages_by_conversation_id(
         &self,
         conversation_id: &[u8],
-        persisted_records: impl IntoIterator<Item = MlsPendingMessage>,
-    ) -> CryptoKeystoreResult<Vec<MlsPendingMessage>> {
+        persisted_records: impl IntoIterator<Item = Arc<MlsPendingMessage>>,
+    ) -> CryptoKeystoreResult<Vec<Arc<MlsPendingMessage>>> {
         let conversation_id = conversation_id.to_vec().into();
         Ok(self.search(persisted_records, &conversation_id).await.collect())
     }

--- a/keystore/src/unique_arc.rs
+++ b/keystore/src/unique_arc.rs
@@ -137,7 +137,7 @@ where
     T: FetchFromDatabase,
 {
     /// Get an instance of `E` from the database by its primary key.
-    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get<E>(&self, id: &E::PrimaryKey) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync,
     {
@@ -153,7 +153,7 @@ where
     }
 
     /// Load all `E`s from the database.
-    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<E>>
+    async fn load_all<E>(&self) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + Clone + Send + Sync,
     {
@@ -161,7 +161,10 @@ where
     }
 
     /// Get an instance of `E` from the database by the borrowed form of its primary key.
-    async fn get_borrowed<E>(&self, id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey) -> CryptoKeystoreResult<Option<E>>
+    async fn get_borrowed<E>(
+        &self,
+        id: &<E as BorrowPrimaryKey>::BorrowedPrimaryKey,
+    ) -> CryptoKeystoreResult<Option<Arc<E>>>
     where
         E: 'static + EntityGetBorrowed + Clone + Send + Sync,
         E::PrimaryKey: Borrow<E::BorrowedPrimaryKey>,
@@ -171,7 +174,7 @@ where
     }
 
     /// Get the requested unique entity from the database.
-    async fn get_unique<'a, U>(&self) -> CryptoKeystoreResult<Option<U>>
+    async fn get_unique<'a, U>(&self) -> CryptoKeystoreResult<Option<Arc<U>>>
     where
         U: 'static + UniqueEntityExt + Entity + Clone + Send + Sync,
     {
@@ -187,7 +190,7 @@ where
     }
 
     /// Search for relevant instances of `E` given a search key.
-    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<E>>
+    async fn search<E, SearchKey>(&self, search_key: &SearchKey) -> CryptoKeystoreResult<Vec<Arc<E>>>
     where
         E: 'static + Entity + SearchableEntity<SearchKey> + Clone + Send + Sync,
         SearchKey: KeyType,

--- a/keystore/tests/searchable_entities.rs
+++ b/keystore/tests/searchable_entities.rs
@@ -23,6 +23,8 @@ fn random_bytes(len: impl SampleRange<usize>) -> Vec<u8> {
 
 #[cfg(test)]
 mod stored_credential {
+    use std::sync::Arc;
+
     use core_crypto_keystore::{
         entities::{CredentialFindFilters, StoredCredential},
         traits::{FetchFromDatabase as _, PrimaryKey as _},
@@ -87,7 +89,7 @@ mod stored_credential {
             .search::<StoredCredential, CredentialFindFilters>(&search_key)
             .await
             .unwrap();
-        assert_eq!(found, vec![entity]);
+        assert_eq!(found, vec![Arc::new(entity)]);
     }
 
     #[apply(all_storage_types)]
@@ -112,6 +114,8 @@ mod stored_credential {
             .await
             .unwrap();
         found.sort_unstable_by(|e1, e2| e1.public_key.cmp(&e2.public_key));
+
+        let entities = entities.into_iter().map(Arc::new).collect::<Vec<_>>();
 
         assert_eq!(entities, found);
     }
@@ -142,7 +146,7 @@ mod stored_credential {
             .await
             .unwrap();
 
-        assert_eq!(found, vec![relevant_entity]);
+        assert_eq!(found, vec![Arc::new(relevant_entity)]);
     }
 
     #[apply(all_storage_types)]
@@ -159,7 +163,7 @@ mod stored_credential {
             .search::<StoredCredential, CredentialFindFilters>(&search_key)
             .await
             .unwrap();
-        assert_eq!(found, vec![entity]);
+        assert_eq!(found, vec![Arc::new(entity)]);
     }
 
     #[apply(all_storage_types)]

--- a/keystore/tests/z_entities.rs
+++ b/keystore/tests/z_entities.rs
@@ -142,18 +142,20 @@ mod tests_impl {
                 .unwrap()
                 .pop()
                 .unwrap();
-            assert_eq!(*pending_message, pending_message_from_store);
+            assert_eq!(*pending_message, *pending_message_from_store);
         } else if let Some(credential) = any_e.downcast_ref::<StoredCredential>() {
-            let mut credential_from_store = store
-                .get::<StoredCredential>(&credential.primary_key())
-                .await
-                .unwrap()
-                .unwrap();
+            let mut credential_from_store = Arc::unwrap_or_clone(
+                store
+                    .get::<StoredCredential>(&credential.primary_key())
+                    .await
+                    .unwrap()
+                    .unwrap(),
+            );
             credential_from_store.equalize();
             assert_eq!(*credential, credential_from_store);
         } else {
             let primary_key = entity.primary_key();
-            let mut entity_from_store = store.get::<E>(&primary_key).await.unwrap().unwrap();
+            let mut entity_from_store = Arc::unwrap_or_clone(store.get::<E>(&primary_key).await.unwrap().unwrap());
             entity_from_store.equalize();
             assert_eq!(*entity, entity_from_store);
         };
@@ -190,11 +192,13 @@ mod tests_impl {
         tx.commit().await.unwrap();
 
         assert_no_transaction_in_flight(store).await;
-        let mut found = store
-            .get_borrowed::<E>(primary_key.borrow())
-            .await
-            .unwrap()
-            .expect("an entity which was just saved is findable by its borrowed primary key");
+        let mut found = Arc::unwrap_or_clone(
+            store
+                .get_borrowed::<E>(primary_key.borrow())
+                .await
+                .unwrap()
+                .expect("an entity which was just saved is findable by its borrowed primary key"),
+        );
         found.equalize();
         assert_eq!(entity, found);
 
@@ -237,8 +241,8 @@ mod tests_impl {
         tx.commit().await.unwrap();
 
         assert_no_transaction_in_flight(store).await;
-        let entity2: E = store.get(&entity.primary_key()).await.unwrap().unwrap();
-        assert_eq!(*entity, entity2);
+        let entity2 = store.get::<E>(&entity.primary_key()).await.unwrap().unwrap();
+        assert_eq!(*entity, *entity2);
     }
 
     pub(crate) async fn can_remove_entity<E>(store: &Arc<CryptoKeystore>, entity: E)
@@ -250,7 +254,7 @@ mod tests_impl {
         tx.commit().await.unwrap();
 
         assert_no_transaction_in_flight(store).await;
-        let entity2: Option<E> = store.get(&entity.primary_key()).await.unwrap();
+        let entity2 = store.get::<E>(&entity.primary_key()).await.unwrap();
         assert!(entity2.is_none());
 
         // The check above binds the primary key into a `WHERE` clause, so it reports "absent" both


### PR DESCRIPTION
We still often have to `Arc::unwrap_or_clone`, but at least now it's not literally every time. Should be a trivial perf boost.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
