### PR TITLE
chore: ignore `.vscode`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,6 @@ cc-book/mermaid.min.js
 cc-book/mermaid-init.js
 cc-book/langtabs.js
 cc-book/langtabs.css
+
+# VS Code repo-specific settings
+.vscode/


### PR DESCRIPTION
This folder contains editor-specific settings which can be useful to i.e. rapidly switch the editor's build settings back and forth between targeting `wasm32-unknown-unknown` and normal builds, but should not be synchronized between team members.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
