### PR TITLE
chore(keystore): partially revert dd270e6afbc414bd8b9d9b0844cbe540993c8507

### DIFF
--- a/crypto/src/mls/conversation/immutable/mod.rs
+++ b/crypto/src/mls/conversation/immutable/mod.rs
@@ -33,6 +33,7 @@ impl MlsGroupState {
         &mut self.group
     }
 
+    #[expect(unused)]
     pub(in crate::mls::conversation) fn tnt_message_counter(&self) -> TntMessageCounter {
         self.tnt_message_counter
     }

--- a/crypto/src/mls/conversation/immutable/persistence.rs
+++ b/crypto/src/mls/conversation/immutable/persistence.rs
@@ -41,11 +41,7 @@ impl Conversation {
             .map_err(KeystoreError::wrap("finding a persisted mls group"))?;
         let Some(group) = group else { return Ok(None) };
         let mut group = Arc::unwrap_or_clone(group);
-        let conversation = Self::from_serialized_state(
-            session,
-            std::mem::take(&mut group.state),
-            group.tnt_message_counter.into(),
-        )?;
+        let conversation = Self::from_serialized_state(session, std::mem::take(&mut group.state), 0.into())?;
         Ok(Some(conversation))
     }
 
@@ -62,11 +58,7 @@ impl Conversation {
                 // we can't just destructure the fields straight out of the group, because we derive `Zeroize`, which
                 // zeroizes on drop, which means we are forced to clone all the group's fields, because
                 // otherwise the drop impl couldn't run.
-                let conversation = Self::from_serialized_state(
-                    session.clone(),
-                    group.state.clone(),
-                    group.tnt_message_counter.into(),
-                )?;
+                let conversation = Self::from_serialized_state(session.clone(), group.state.clone(), 0.into())?;
                 Ok((group.id.clone().into(), conversation))
             })
             .collect()

--- a/crypto/src/mls/conversation/mutable/group_mutation.rs
+++ b/crypto/src/mls/conversation/mutable/group_mutation.rs
@@ -50,7 +50,6 @@ impl ConversationMut {
             id: id.to_bytes(),
             state: core_crypto_keystore::ser(group.mls_group())
                 .map_err(KeystoreError::wrap("serializing group state"))?,
-            tnt_message_counter: group.tnt_message_counter().into(),
         })
         .await
         .map_err(KeystoreError::wrap("persisting mls group"))?;

--- a/crypto/src/transaction_context/conversation/persistence.rs
+++ b/crypto/src/transaction_context/conversation/persistence.rs
@@ -46,7 +46,6 @@ impl TransactionContext {
             .save(PersistedMlsGroup {
                 id: id.to_bytes(),
                 state: group_state,
-                tnt_message_counter: tnt_message_counter.into(),
             })
             .await
             .map_err(KeystoreError::wrap("persisting mls group"))?;

--- a/keystore/src/connection/composite-schema.sql
+++ b/keystore/src/connection/composite-schema.sql
@@ -51,7 +51,7 @@ CREATE INDEX idx_mls_keypackages_keypackage_ref ON "mls_key_packages"(key_packag
 CREATE TABLE "mls_groups" (
   id BLOB UNIQUE,
   state BLOB,
-  tnt_message_counter INTEGER NOT NULL DEFAULT 0
+  sender_nonce INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX idx_mls_groups_id ON mls_groups(id);

--- a/keystore/src/connection/migrations/V24__message_sender_nonce.sql
+++ b/keystore/src/connection/migrations/V24__message_sender_nonce.sql
@@ -1,1 +1,1 @@
-ALTER TABLE mls_groups ADD COLUMN tnt_message_counter INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE mls_groups ADD COLUMN sender_nonce INTEGER NOT NULL DEFAULT 0;

--- a/keystore/src/entities/mls/persisted_mls_group.rs
+++ b/keystore/src/entities/mls/persisted_mls_group.rs
@@ -29,5 +29,4 @@ impl<'a> KeyType for ParentGroupId<'a> {
 pub struct PersistedMlsGroup {
     pub id: Vec<u8>,
     pub state: Vec<u8>,
-    pub tnt_message_counter: u32,
 }

--- a/keystore/src/mls.rs
+++ b/keystore/src/mls.rs
@@ -72,12 +72,11 @@ impl Database {
         &self,
         group_id: impl AsRef<[u8]> + Send,
         state: &[u8],
-        tnt_message_counter: u32,
+        _tnt_message_counter: u32,
     ) -> CryptoKeystoreResult<()> {
         self.save(PersistedMlsGroup {
             id: group_id.as_ref().to_owned(),
             state: state.into(),
-            tnt_message_counter,
         })
         .await?;
         Ok(())

--- a/keystore/tests/z_entities.rs
+++ b/keystore/tests/z_entities.rs
@@ -485,7 +485,7 @@ pub mod utils {
     impl_entity_random_update_ext!(StoredHpkePrivateKey, blob_fields=[pk id_like:true,sk,]);
     impl_entity_random_update_ext!(StoredEncryptionKeyPair, blob_fields=[pk id_like:true,sk,]);
     impl_entity_random_update_ext!(StoredPskBundle, blob_fields=[psk,psk_id id_like:true,]);
-    impl_entity_random_update_ext!(PersistedMlsGroup, id_field=id, blob_fields=[state,], additional_fields=[(tnt_message_counter: rand::random()),]);
+    impl_entity_random_update_ext!(PersistedMlsGroup, id_field = id, blob_fields = [state,]);
     impl_entity_random_update_ext!(PersistedMlsPendingGroup, id_field=id, blob_fields=[state,custom_configuration,], additional_fields=[(parent_id: None),]);
     impl_entity_random_update_ext!(MlsPendingMessage, id_field = conversation_id, blob_fields = [message,]);
     impl_entity_random_update_ext!(StoredEpochEncryptionKeypair, id_field = id, blob_fields = [keypairs,]);


### PR DESCRIPTION
We need to do this because we have already released the V24 migration. So we need to add a new migration instead of modifying the existing one.

(cherry picked from commit 47bb3c116dd1f4a2611796237f4e455c0ea71929)

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
