### PR TITLE
chore: add prerelease script

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Make sure you have all prerequisites:
 - Install chrome via puppeteer for browser tests and benchmarks:
 
   ```sh
-  cd crypto-ffi/bindings/js && bun x puppeteer browsers install chrome-headless-shell    
+  cd crypto-ffi/bindings/js && bun x puppeteer browsers install chrome-headless-shell
   ```
 
 - Install [wasm-bindgen-cli](https://github.com/wasm-bindgen/wasm-bindgen):
@@ -591,7 +591,17 @@ The versioning scheme used is [SemVer AKA Semantic Versioning](https://semver.or
 
 ### Making a new release<a name="making-a-new-release"></a>
 
-1. Make a branch based on `main` to prepare for release (`git checkout -b prepare-release/X.Y.Z`)
+1. Run `./scripts/prerelease.sh $major_version` to determine whether we can release from `main` or a release branch.
+
+- If necessary, [cherry-pick the required PRs](https://github.com/134130/gh-cherry-pick#installation) onto the relevant
+  release branch:
+
+  ```sh
+  gh cherry-pick "$pr_number"
+  ```
+
+1. Make a branch based on `main` or the relevant release branch to prepare for release
+   (`git checkout -b prepare-release/X.Y.Z`)
 
 1. Adjust the release notes of the cc-book. Rename the *Unreleased* section to the current release title and summarize
    highlights of the release in the first paragraph:
@@ -608,25 +618,37 @@ The versioning scheme used is [SemVer AKA Semantic Versioning](https://semver.or
    in the table, ordering by version number, descending. Search and replace the first 5 occurrences of `x.x.x` with
    `X.Y.Z`.
 
+1. Commit your changes and retain the commit hash for later.
+
 1. Run `sh scripts/update-versions.sh X.Y.Z` to update the versions of
 
    - all workspace member crates
    - `package.json`
    - `crypto-ffi/bindings/gradle.properties` Make sure the result of the script run is correct.
 
+1. Commit these changes separately.
+
 1. Make sure the changes look reasonable and complete; you can use the previous release as a reference
 
-1. Push your `prepare-release/X.Y.Z` branch and create a PR for it
+1. Push your `prepare-release/X.Y.Z` branch and create a PR for it. Ensure you target the correct branch!
 
-1. Get it reviewed, then merge it into `main` and remove the `prepare-release/X.Y.Z` branch from the remote
+1. Get it reviewed and merged
 
-1. Now, pull your local `main`: `git checkout main && git pull`
+1. Pull the current state of the release branch
 
 1. Create the release tag: `git tag -s vX.Y.Z`
 
 1. Push the new tag: `git push origin tag vX.Y.Z`
 
 1. Create a new release on github, copying the release notes
+
+1. If your release was based on a release branch and not `main`:
+
+   1. Check out a new branch based on the head of `main`
+
+   1. Cherry-pick in the docs commit you made earlier.
+
+   1. Get this PR approved and merged.
 
 1. Voilà!
 

--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -10,7 +10,7 @@ if [ -z "${1:-}" ]; then
 fi
 major_version="$1"
 
-if ! rg '^\d+$' <<< "$major_version" > /dev/null; then
+if ! grep -E '^[0-9]+$' <<< "$major_version" > /dev/null; then
     echo "usage: $0 <MAJOR_VERSION>"
     echo "MAJOR_VERSION must be a bare number"
     exit 1
@@ -18,21 +18,22 @@ fi
 
 remote_refs="$(git ls-remote origin)"
 
-if ! rg 'refs/tags/v(\d+)\.\d+\.\d+$' --replace '$1' -o <<< "$remote_refs" | rg -x "$major_version" > /dev/null; then
+if ! grep -E "refs/tags/v$major_version\.[0-9]+\.[0-9]+$" <<< "$remote_refs" > /dev/null; then
     echo "no tag exists for this major version; base your release on main"
     exit
 fi
 
-if rg "refs/heads/release/$major_version\.x$" <<< "$remote_refs" > /dev/null; then
+if grep -E "refs/heads/release/$major_version\.x$" <<< "$remote_refs" > /dev/null; then
     echo "release branch 'release/$major_version.x' exists"
     echo "cherry-pick the appropriate PRs onto that release branch,"
     echo "then release from there"
     exit
 fi
 
-major_tag_re="$(printf 'refs/tags/(v%d\.\d+\.\d+)$' "$major_version")"
+major_tag_re="refs/tags/v$major_version\.[0-9]+\.[0-9]+$"
 major_tag="$(
-    rg -o "$major_tag_re" --replace '$1' <<< "$remote_refs" |
+    grep -oE "$major_tag_re" <<< "$remote_refs" |
+    sed 's|^refs/tags/||' |
     sort -r --version-sort |
     head -n 1
 )"

--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Determine whether or not we need to create a new release branch
+
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+    echo "usage: $0 <MAJOR_VERSION>"
+    exit 1
+fi
+major_version="$1"
+
+if ! rg '^\d+$' <<< "$major_version" > /dev/null; then
+    echo "usage: $0 <MAJOR_VERSION>"
+    echo "MAJOR_VERSION must be a bare number"
+    exit 1
+fi
+
+remote_refs="$(git ls-remote origin)"
+
+if ! rg 'refs/tags/v(\d+)\.\d+\.\d+$' --replace '$1' -o <<< "$remote_refs" | rg -x "$major_version" > /dev/null; then
+    echo "no tag exists for this major version; base your release on main"
+    exit
+fi
+
+if rg "refs/heads/release/$major_version\.x$" <<< "$remote_refs" > /dev/null; then
+    echo "release branch 'release/$major_version.x' exists"
+    echo "cherry-pick the appropriate PRs onto that release branch,"
+    echo "then release from there"
+    exit
+fi
+
+major_tag_re="$(printf 'refs/tags/(v%d\.\d+\.\d+)$' "$major_version")"
+major_tag="$(
+    rg -o "$major_tag_re" --replace '$1' <<< "$remote_refs" |
+    sort -r --version-sort |
+    head -n 1
+)"
+
+echo "Last tag for this major version: $major_tag"
+echo
+echo "Inspect these PRs. Do **all** of them want to go into this release?"
+echo "- If yes, then release based on main."
+echo "- If no, then create a new release branch on the previous tag and cherry-pick onto it:"
+echo "    git checkout -b release/$major_version.x tags/$major_tag"
+echo
+major_tag_timestamp="$(git log -1 --format=%cI "$major_tag^{commit}")"
+gh pr list --base main --state merged --search "merged:>$major_tag_timestamp"


### PR DESCRIPTION
This should hopefully help us not release more than we intended to.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
