### PR TITLE
refactor: move transaction file lock into rust WPB-28130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ dependencies = [
  "async-fs",
  "async-lock",
  "async-trait",
+ "blocking",
  "console_error_panic_hook",
  "core-crypto-keystore",
  "core-crypto-macros",

--- a/crypto-ffi/Cargo.toml
+++ b/crypto-ffi/Cargo.toml
@@ -22,6 +22,10 @@ workspace = true
 [features]
 default = ["proteus"]
 cancellable-transactions = ["dep:futures-channel"]
+# Guard keystore transactions across processes, not just within one. Intended for targets where
+# more than one process shares a keystore, such as iOS apps with extensions.
+# Not supported on `target_os = "unknown"`; see the keystore feature of the same name.
+cross-process-lock = ["core-crypto/cross-process-lock"]
 proteus = ["core-crypto/proteus", "dep:proteus-wasm"]
 wasm = ["dep:uniffi_ubrn"]
 napi = ["dep:uniffi_ubrn"]

--- a/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
+++ b/crypto-ffi/bindings/swift/WireCoreCrypto/WireCoreCrypto/CoreCrypto.swift
@@ -59,10 +59,7 @@ public final class CoreCrypto: CoreCryptoProtocol, @unchecked Sendable {
     public func transaction<Result>(
         _ block: @escaping (_ context: CoreCryptoContextProtocol) async throws -> Result
     ) async throws -> Result {
-        let dbLocation = await database?.getLocation()
-        let filePath = dbLocation.map { FilePath(stringLiteral: $0) }
-        let transactionExecutor = try TransactionExecutor<Result>(
-            keystorePath: filePath, block)
+        let transactionExecutor = try TransactionExecutor<Result>(block)
         let token = CoreCryptoCancellationToken()
 
         do {
@@ -147,34 +144,14 @@ final actor TransactionExecutor<Result>: WireCoreCryptoUniffi.CoreCryptoCommand 
     let block: (_ context: CoreCryptoContextProtocol) async throws -> Result
     var result: Result?
     var innerError: Error?
-    var fileDescriptor: FileDescriptor?
 
     init(
-        keystorePath: FilePath?,
         _ block: @escaping (_ context: CoreCryptoContextProtocol) async throws -> Result
     ) throws {
         self.block = block
-
-        if let keystorePath {
-            let path = keystorePath.absolutePath().removingLastComponent()
-            self.fileDescriptor = try FileDescriptor.open(path, .readOnly, options: .directory)
-        }
-    }
-
-    deinit {
-        try? fileDescriptor?.close()
     }
 
     func execute(context: WireCoreCryptoUniffi.CoreCryptoContext) async throws {
-        // Only aquire lock if we are using an instance which persists to disk
-        if fileDescriptor != nil {
-            acquireFileLock()
-        }
-
-        defer {
-            releaseFileLock()
-        }
-
         do {
             result = try await block(context)
         } catch {
@@ -182,23 +159,6 @@ final actor TransactionExecutor<Result>: WireCoreCryptoUniffi.CoreCryptoCommand 
             throw error
         }
     }
-
-    func acquireFileLock() {
-        guard let fileDescriptor else { return }
-        let result = flock(fileDescriptor.rawValue, LOCK_EX)
-        if result != 0 {
-            fatalError("Failed aquire lock: \(errno))")
-        }
-    }
-
-    func releaseFileLock() {
-        guard let fileDescriptor else { return }
-        let result = flock(fileDescriptor.rawValue, LOCK_UN)
-        if result != 0 {
-            fatalError("Failed release lock: \(errno))")
-        }
-    }
-
 }
 
 extension PkiEnvironment {

--- a/crypto-ffi/src/core_crypto/command/transaction_helper.rs
+++ b/crypto-ffi/src/core_crypto/command/transaction_helper.rs
@@ -5,7 +5,7 @@ use async_lock::{Mutex, OnceCell};
 use super::CoreCryptoCommand;
 use crate::{CoreCryptoContext, CoreCryptoResult};
 
-/// Helper for working with the new transasction interface.
+/// Helper for working with the new transaction interface.
 ///
 /// This helper serves two purposes: to present a `FnOnce` interface for transactions,
 /// and to allow the extraction of data from within transactions.

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -17,6 +17,9 @@ proteus = [
   "dep:proteus-traits",
   "core-crypto-keystore/proteus-keystore",
 ]
+# Guard keystore transactions across processes, not just within one.
+# Not supported on `target_os = "unknown"`; see the keystore feature of the same name.
+cross-process-lock = ["core-crypto-keystore/cross-process-lock"]
 # for test/bench all cipher suites
 test-all-cipher = []
 

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -62,6 +62,9 @@ security-framework-sys = "2.16"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 async-fs = "2.2"
+# runtime-agnostic thread pool, used to wait on the cross-process file lock without blocking the
+# executor; already in the tree as a dependency of `async-fs`
+blocking = { version = "1.6", optional = true }
 rusqlite = { version = "0.38", default-features = false, features = [
   "bundled-sqlcipher-vendored-openssl",
 ] }

--- a/keystore/Cargo.toml
+++ b/keystore/Cargo.toml
@@ -14,6 +14,10 @@ workspace = true
 default = ["proteus-keystore"]
 proteus-keystore = ["dep:proteus-traits"]
 log-queries = ["rusqlite/trace"]
+# Extend the guarantee that at most one keystore transaction runs at a time from a single process
+# to every process on the machine, via an advisory lock on a file next to the database.
+# Requires a real filesystem, so it must stay off for `target_os = "unknown"`.
+cross-process-lock = ["dep:blocking"]
 # kept here because legacy keystore module is using this feature.
 serde = []
 dummy-entity = []

--- a/keystore/src/connection/file_lock.rs
+++ b/keystore/src/connection/file_lock.rs
@@ -1,0 +1,115 @@
+use std::{
+    fs::{File, TryLockError},
+    io,
+    sync::Arc,
+};
+
+use crate::{CryptoKeystoreError, CryptoKeystoreResult};
+
+/// Appended to the database path to name its lock file.
+///
+/// The lock deliberately lives on a sibling file rather than on the database itself: SQLite
+/// takes its own advisory locks on the database, and on Windows those are byte-range locks in
+/// the very range `File::lock` claims, so locking the database directly would collide with it.
+const LOCK_FILE_SUFFIX: &str = "-cc-tx.lock";
+
+fn lock_file_path(database_path: &str) -> String {
+    format!("{database_path}{LOCK_FILE_SUFFIX}")
+}
+
+/// Remove the lock file belonging to the database at `database_path`.
+///
+/// Only meaningful when the database itself is going away; a lock file with no database is
+/// just litter. Safe to call while still holding the lock, as the lock lives on the open file
+/// rather than on its name.
+pub(crate) async fn remove_lock_file(database_path: &str) -> CryptoKeystoreResult<()> {
+    let path = lock_file_path(database_path);
+    match async_fs::remove_file(&path).await {
+        // the lock file is only created on demand, so its absence is the normal case for a
+        // database which never opened a transaction
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        result => result.map_err(|source| CryptoKeystoreError::TransactionLock { path, source }),
+    }
+}
+
+/// An advisory lock on a file next to the database, held for as long as a transaction runs.
+///
+/// The lock is released by the OS if the holding process dies, so a crashed peer cannot wedge
+/// everyone else out of the database.
+#[derive(Debug)]
+pub(crate) struct FileLock {
+    file: File,
+    path: String,
+}
+
+impl FileLock {
+    /// Open (creating if necessary) the lock file guarding the database at `database_path`.
+    ///
+    /// Produces `None` for in-memory databases, which have an empty path and are unreachable
+    /// from other processes anyway.
+    pub(crate) fn open(database_path: &str) -> CryptoKeystoreResult<Option<Arc<Self>>> {
+        if database_path.is_empty() {
+            return Ok(None);
+        }
+
+        let path = lock_file_path(database_path);
+        let file = File::create(&path).map_err(|source| CryptoKeystoreError::TransactionLock {
+            path: path.clone(),
+            source,
+        })?;
+
+        Ok(Some(Arc::new(Self { file, path })))
+    }
+
+    fn error(&self, source: io::Error) -> CryptoKeystoreError {
+        CryptoKeystoreError::TransactionLock {
+            path: self.path.clone(),
+            source,
+        }
+    }
+
+    /// Wait until no other process holds this lock, then take it.
+    pub(crate) async fn lock(self: &Arc<Self>) -> CryptoKeystoreResult<FileLockGuard> {
+        let lock = self.clone();
+        // `File::lock` parks the calling thread, so it goes to the blocking pool; that keeps
+        // us independent of whichever async runtime the consumer is driving us with.
+        //
+        // The guard is constructed inside the closure rather than out here so that this stays
+        // cancellation-safe: dropping the returned future lets the blocking call finish and
+        // then drops its output, which releases the lock we just took. Returning the bare
+        // `Arc` instead would silently leave the lock held until the database is closed.
+        blocking::unblock(move || match lock.file.lock() {
+            Ok(()) => Ok(FileLockGuard { lock }),
+            Err(source) => Err(lock.error(source)),
+        })
+        .await
+    }
+
+    /// Take this lock, or produce `None` if another process holds it.
+    pub(crate) fn try_lock(self: &Arc<Self>) -> CryptoKeystoreResult<Option<FileLockGuard>> {
+        match self.file.try_lock() {
+            Ok(()) => Ok(Some(FileLockGuard { lock: self.clone() })),
+            Err(TryLockError::WouldBlock) => Ok(None),
+            Err(TryLockError::Error(source)) => Err(self.error(source)),
+        }
+    }
+}
+
+/// Releases the file lock when dropped.
+pub(crate) struct FileLockGuard {
+    lock: Arc<FileLock>,
+}
+
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        // unlocking is a single non-blocking syscall, so it is fine to run inline here
+        if let Err(error) = self.lock.file.unlock() {
+            // dropping the file would release the lock too, but the `FileLock` outlives this
+            // guard, so a failure here really does leave the lock held; all we can do is say so
+            log::error!(
+                "failed to release the cross-process transaction lock at {}: {error}",
+                self.lock.path
+            );
+        }
+    }
+}

--- a/keystore/src/connection/file_lock.rs
+++ b/keystore/src/connection/file_lock.rs
@@ -106,7 +106,7 @@ impl Drop for FileLockGuard {
         if let Err(error) = self.lock.file.unlock() {
             // dropping the file would release the lock too, but the `FileLock` outlives this
             // guard, so a failure here really does leave the lock held; all we can do is say so
-            log::error!(
+            panic!(
                 "failed to release the cross-process transaction lock at {}: {error}",
                 self.lock.path
             );

--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -1,6 +1,8 @@
 mod encryption;
 mod entity_extension_methods;
 mod fetch_from_database;
+#[cfg(feature = "cross-process-lock")]
+mod file_lock;
 mod filesystem;
 #[cfg(target_os = "unknown")]
 mod idb_migration;
@@ -10,18 +12,20 @@ mod migrations;
 #[cfg(target_os = "unknown")]
 mod os_unknown;
 mod transaction;
+mod transaction_lock;
 
 use std::sync::Arc;
 
-use async_lock::{Mutex, MutexGuard, Semaphore};
+use async_lock::{Mutex, MutexGuard};
 use rusqlite::Connection;
 #[cfg(feature = "log-queries")]
 use rusqlite::trace::{TraceEvent, TraceEventCodes};
 
-pub(crate) use self::filesystem::Filesystem;
 #[cfg(target_os = "unknown")]
 pub use self::idb_migration::{delete_legacy_idb, legacy_idb_exists};
 pub use self::migrations::migrate_db_key_type_to_bytes;
+use self::transaction_lock::TransactionLock;
+pub(crate) use self::{filesystem::Filesystem, transaction_lock::TransactionGuard};
 use crate::{
     CryptoKeystoreResult, DatabaseKey, connection::migrations::MigrationTarget, transaction::Transaction,
     unique_arc::UniqueWeak,
@@ -46,9 +50,8 @@ pub struct Database {
     pub(crate) filesystem: Mutex<Box<dyn Filesystem>>,
     #[debug(skip)]
     pub(crate) transaction: Mutex<Option<UniqueWeak<Transaction>>>,
-    // we need this `Arc` so we can create an owned guard, so that
-    // `self.transaction` doesn't need a self-referential lifetime.
-    transaction_semaphore: Arc<Semaphore>,
+    // ensures at most one transaction is in flight against this database at a time
+    transaction_lock: TransactionLock,
 }
 
 impl Database {
@@ -98,8 +101,6 @@ impl Database {
         filesystem: Box<dyn Filesystem>,
         migration_target: MigrationTarget,
     ) -> CryptoKeystoreResult<Self> {
-        const ALLOWED_CONCURRENT_TRANSACTIONS_COUNT: usize = 1;
-
         #[cfg(feature = "log-queries")]
         conn.trace_v2(TraceEventCodes::SQLITE_TRACE_STMT, Some(log_query));
 
@@ -112,13 +113,15 @@ impl Database {
         }
 
         migrations::run_migrations(&mut conn, migration_target)?;
+
+        let transaction_lock = TransactionLock::new(conn.path().unwrap_or_default())?;
         let conn = conn.into();
 
         Ok(Self {
             conn,
             filesystem: filesystem.into(),
             transaction: Default::default(),
-            transaction_semaphore: Arc::new(Semaphore::new(ALLOWED_CONCURRENT_TRANSACTIONS_COUNT)),
+            transaction_lock,
         })
     }
 
@@ -168,14 +171,17 @@ impl Database {
 
     /// Wait for any running transaction to finish, then take the connection out of this database,
     /// preventing this from being used again.
-    async fn take(self) -> CryptoKeystoreResult<(Connection, Box<dyn Filesystem>)> {
-        let _semaphore = self.transaction_semaphore.acquire().await;
-        Ok((self.conn.into_inner(), self.filesystem.into_inner()))
+    ///
+    /// The returned guard keeps other processes out for as long as the caller holds it, so that
+    /// teardown is not interleaved with somebody else's transaction.
+    async fn take(self) -> CryptoKeystoreResult<(Connection, Box<dyn Filesystem>, TransactionGuard)> {
+        let guard = self.transaction_lock.acquire().await?;
+        Ok((self.conn.into_inner(), self.filesystem.into_inner(), guard))
     }
 
     // Close this database connection
     pub async fn close(self) -> CryptoKeystoreResult<()> {
-        let (conn, _fs) = self.take().await?;
+        let (conn, _fs, _guard) = self.take().await?;
         conn.close().map_err(|(_conn, err)| err)?;
         Ok(())
     }
@@ -186,7 +192,7 @@ impl Database {
     /// Future opens will always succeed with any arbitrary encryption key; they will
     /// simply open an empty database.
     pub async fn wipe(self) -> CryptoKeystoreResult<()> {
-        let (conn, fs) = self.take().await?;
+        let (conn, fs, _guard) = self.take().await?;
         conn.execute_batch(
             "
             PRAGMA writable_schema = 1;
@@ -200,6 +206,10 @@ impl Database {
         if let Some(path) = location {
             // not in-memory
             fs.delete(&path).await?;
+            // `_guard` is still alive, so we unlink the lock file while still holding it; that
+            // keeps a peer from acquiring the fresh lock file before the database is really gone.
+            #[cfg(feature = "cross-process-lock")]
+            file_lock::remove_lock_file(&path).await?;
         }
         Ok(())
     }

--- a/keystore/src/connection/transaction.rs
+++ b/keystore/src/connection/transaction.rs
@@ -15,20 +15,25 @@ use crate::{
 /// These impls control the keystore transaction lifecycle.
 impl Database {
     /// Waits for the current transaction to be committed or rolled back, then starts a new one.
+    ///
+    /// With the `cross-process-lock` feature enabled, this also waits on transactions running
+    /// against the same database in other processes.
     pub async fn new_transaction(self: &Arc<Self>) -> CryptoKeystoreResult<UniqueArc<Transaction>> {
-        let semaphore = self.transaction_semaphore.acquire_arc().await;
-        Transaction::new(semaphore, self.clone()).await
+        let lock_guard = self.transaction_lock.acquire().await?;
+        Transaction::new(lock_guard, self.clone()).await
     }
 
     /// Start a new transaction if no other transaction is currently in progress.
     ///
     /// If a transaction is currently in progress, this will produce a `TransactionInProgress` error.
+    /// With the `cross-process-lock` feature enabled, a transaction in progress in another process
+    /// counts too.
     pub async fn try_new_immediate_transaction(self: &Arc<Self>) -> CryptoKeystoreResult<UniqueArc<Transaction>> {
-        let semaphore = self
-            .transaction_semaphore
-            .try_acquire_arc()
+        let lock_guard = self
+            .transaction_lock
+            .try_acquire()?
             .ok_or(CryptoKeystoreError::TransactionInProgress)?;
-        Transaction::new(semaphore, self.clone()).await
+        Transaction::new(lock_guard, self.clone()).await
     }
 
     /// Do an operation on a new keystore transaction on this database.
@@ -43,8 +48,8 @@ impl Database {
         self: &Arc<Self>,
         operation: impl AsyncFnOnce(&Transaction) -> CryptoKeystoreResult<R>,
     ) -> CryptoKeystoreResult<R> {
-        let semaphore = self.transaction_semaphore.acquire_arc().await;
-        let transaction = Transaction::new(semaphore, self.clone()).await?;
+        let lock_guard = self.transaction_lock.acquire().await?;
+        let transaction = Transaction::new(lock_guard, self.clone()).await?;
 
         let result = operation(&transaction).await;
         if result.is_ok() {
@@ -102,7 +107,7 @@ impl Database {
     /// NOTE: Because of TOCTOU, there is an interval between when we check if an existing
     /// transaction exists, and when we create our own. If a separate process creates a transaction
     /// during that interval, then this function must wait for that external transaction to
-    /// complete before it can acquire the semaphore. This might be surprising, but isn't
+    /// complete before it can acquire the transaction lock. This might be surprising, but isn't
     /// worth putting in the effort to change; it's not strictly a bug.
     pub async fn ensure_transaction<T, E>(
         self: &Arc<Self>,

--- a/keystore/src/connection/transaction_lock.rs
+++ b/keystore/src/connection/transaction_lock.rs
@@ -98,3 +98,141 @@ impl TransactionLock {
         }))
     }
 }
+
+#[cfg(all(test, feature = "cross-process-lock", not(target_os = "unknown")))]
+mod tests {
+    use std::time::Duration;
+
+    use futures_lite::future;
+    use smol::Timer;
+
+    use crate::{CryptoKeystoreError, Database, DatabaseKey};
+
+    /// Long enough that a lock which is genuinely free gets taken well within it.
+    const TIMEOUT: Duration = Duration::from_secs(10);
+    /// Short enough to keep the suite quick, since the expected outcome is that nothing happens.
+    const CONTENTION_WINDOW: Duration = Duration::from_millis(250);
+
+    /// Two `Database` handles over one path are what a second process looks like to the file lock:
+    /// each has its own semaphore and its own open lock file, so only the file lock can separate
+    /// them. That makes this a faithful stand-in for genuine cross-process contention without
+    /// having to spawn one.
+    async fn two_handles(dir: &std::path::Path) -> (std::sync::Arc<Database>, std::sync::Arc<Database>) {
+        let path = dir.join("keystore.db");
+        let path = path.to_str().expect("temp dir path is utf-8");
+        let key = DatabaseKey::generate();
+        (
+            Database::open(path, &key).await.expect("opening the first handle"),
+            Database::open(path, &key).await.expect("opening the second handle"),
+        )
+    }
+
+    #[test]
+    fn an_immediate_transaction_is_refused_while_another_handle_holds_one() {
+        future::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let (first, second) = two_handles(dir.path()).await;
+
+            let transaction = first.new_transaction().await.unwrap();
+
+            match second.try_new_immediate_transaction().await {
+                Err(CryptoKeystoreError::TransactionInProgress) => {}
+                Err(error) => panic!("expected the second handle to be locked out, got {error}"),
+                Ok(_) => panic!("the second handle started a transaction while the first held one"),
+            }
+
+            // committing releases the lock, so the other handle can take it
+            transaction.commit().await.unwrap();
+            second.try_new_immediate_transaction().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn a_waiting_transaction_blocks_until_the_other_handle_is_done() {
+        future::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let (first, second) = two_handles(dir.path()).await;
+
+            let transaction = first.new_transaction().await.unwrap();
+
+            // the file lock is held elsewhere, so this must not resolve
+            let acquired = future::or(async { Some(second.new_transaction().await) }, async {
+                Timer::after(CONTENTION_WINDOW).await;
+                None
+            })
+            .await;
+            assert!(
+                acquired.is_none(),
+                "the second handle acquired a lock it should have waited for"
+            );
+
+            // rolling back by drop releases the lock just as committing does
+            drop(transaction);
+
+            future::or(async { Some(second.new_transaction().await) }, async {
+                Timer::after(TIMEOUT).await;
+                None
+            })
+            .await
+            .expect("timed out waiting for the released lock")
+            .unwrap();
+        });
+    }
+
+    /// Dropping a pending acquisition must not strand the lock: the blocking acquire may still
+    /// land after the future is gone, and its guard has to release what it took.
+    #[test]
+    fn abandoning_a_pending_acquisition_leaves_the_lock_free() {
+        future::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let (first, second) = two_handles(dir.path()).await;
+
+            let transaction = first.new_transaction().await.unwrap();
+            // start waiting, then walk away
+            future::or(async { Some(second.new_transaction().await) }, async {
+                Timer::after(CONTENTION_WINDOW).await;
+                None
+            })
+            .await;
+            drop(transaction);
+
+            // the abandoned wait may win the race for the lock, but only transiently; retry until
+            // its guard has been dropped
+            let acquired = future::or(
+                async {
+                    loop {
+                        if let Ok(transaction) = second.try_new_immediate_transaction().await {
+                            return Some(transaction);
+                        }
+                        Timer::after(Duration::from_millis(10)).await;
+                    }
+                },
+                async {
+                    Timer::after(TIMEOUT).await;
+                    None
+                },
+            )
+            .await;
+            assert!(acquired.is_some(), "the abandoned acquisition stranded the file lock");
+        });
+    }
+
+    #[test]
+    fn wiping_a_database_removes_its_lock_file() {
+        future::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("keystore.db");
+            let database = Database::open(path.to_str().unwrap(), &DatabaseKey::generate())
+                .await
+                .unwrap();
+
+            database.new_transaction().await.unwrap().commit().await.unwrap();
+
+            let lock_file = dir.path().join("keystore.db-cc-tx.lock");
+            assert!(lock_file.exists(), "expected a lock file next to the database");
+
+            std::sync::Arc::into_inner(database).unwrap().wipe().await.unwrap();
+            assert!(!lock_file.exists(), "wipe left the lock file behind");
+        });
+    }
+}

--- a/keystore/src/connection/transaction_lock.rs
+++ b/keystore/src/connection/transaction_lock.rs
@@ -1,0 +1,100 @@
+//! Exclusion between keystore transactions.
+//!
+//! At most one keystore transaction may be in flight against a given database at a time.
+//! The in-process half of that guarantee is a [`Semaphore`]; the cross-process half, compiled in
+//! by the `cross-process-lock` feature, is an advisory lock on a file next to the database.
+//!
+//! The two halves are always taken together, and in that order: the semaphore first, so tasks
+//! within this process queue up in the async runtime instead of piling blocking-pool threads onto
+//! a file lock; the file lock second, so at most one process at a time is past both.
+//!
+//! [`Database`]: crate::Database
+
+#[cfg(all(feature = "cross-process-lock", target_os = "unknown"))]
+compile_error!(
+    "the `cross-process-lock` feature locks a file in the local filesystem, which the wasm \
+     keystore (backed by IndexedDB) has none of; disable it for `target_os = \"unknown\"`"
+);
+
+use std::sync::Arc;
+
+use async_lock::{Semaphore, SemaphoreGuardArc};
+
+use crate::CryptoKeystoreResult;
+#[cfg(feature = "cross-process-lock")]
+use crate::connection::file_lock::{FileLock, FileLockGuard};
+
+/// Only one keystore transaction may be in flight against a database at a time.
+const ALLOWED_CONCURRENT_TRANSACTIONS_COUNT: usize = 1;
+
+/// Gates the start of a keystore transaction.
+#[derive(Debug)]
+pub(crate) struct TransactionLock {
+    // we need this `Arc` so we can create an owned guard, so that the transaction doesn't need
+    // a self-referential lifetime into the database.
+    semaphore: Arc<Semaphore>,
+    #[cfg(feature = "cross-process-lock")]
+    /// `None` for in-memory databases, and whenever cross-process locking is compiled out.
+    file: Option<Arc<FileLock>>,
+}
+
+/// Proof that its holder is the only one running a keystore transaction against this database.
+///
+/// Both halves of the lock are released when this is dropped.
+pub(crate) struct TransactionGuard {
+    _semaphore: SemaphoreGuardArc,
+    #[cfg(feature = "cross-process-lock")]
+    _file: Option<FileLockGuard>,
+}
+
+impl TransactionLock {
+    /// Construct the lock guarding the database at `database_path`.
+    ///
+    /// `database_path` is empty for in-memory databases, which no other process can reach, so
+    /// those get the in-process half only.
+    pub(crate) fn new(#[allow(unused)] database_path: &str) -> CryptoKeystoreResult<Self> {
+        Ok(Self {
+            semaphore: Arc::new(Semaphore::new(ALLOWED_CONCURRENT_TRANSACTIONS_COUNT)),
+            #[cfg(feature = "cross-process-lock")]
+            file: FileLock::open(database_path)?,
+        })
+    }
+
+    /// Wait until no other transaction is in flight, in this process or in any other.
+    pub(crate) async fn acquire(&self) -> CryptoKeystoreResult<TransactionGuard> {
+        let semaphore = self.semaphore.acquire_arc().await;
+        #[cfg(feature = "cross-process-lock")]
+        let file = match self.file.as_ref() {
+            Some(file) => Some(file.lock().await?),
+            None => None,
+        };
+        Ok(TransactionGuard {
+            _semaphore: semaphore,
+            #[cfg(feature = "cross-process-lock")]
+            _file: file,
+        })
+    }
+
+    /// Acquire the lock, or produce `None` if a transaction is already in flight.
+    pub(crate) fn try_acquire(&self) -> CryptoKeystoreResult<Option<TransactionGuard>> {
+        let Some(semaphore) = self.semaphore.try_acquire_arc() else {
+            return Ok(None);
+        };
+        #[cfg(feature = "cross-process-lock")]
+        let file = match self.file.as_ref() {
+            Some(file) => match file.try_lock()? {
+                Some(guard) => Some(guard),
+                // Another process holds the lock. Returning here drops `semaphore`, releasing the
+                // in-process half again: it would be wrong to make local callers queue behind a
+                // transaction we never started.
+                None => return Ok(None),
+            },
+            None => None,
+        };
+        Ok(Some(TransactionGuard {
+            _semaphore: semaphore,
+            #[cfg(feature = "cross-process-lock")]
+            _file: file,
+        }))
+    }
+}

--- a/keystore/src/error.rs
+++ b/keystore/src/error.rs
@@ -7,6 +7,12 @@ pub enum CryptoKeystoreError {
     MutatingOperationWithoutTransaction,
     #[error("cannot open a new transaction as there exists another transaction currently in progress")]
     TransactionInProgress,
+    #[error("failed to operate the cross-process transaction lock at {path}")]
+    TransactionLock {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
     #[error(transparent)]
     TryFromSliceError(#[from] std::array::TryFromSliceError),
     #[error("One of the Keystore locks has been poisoned")]

--- a/keystore/src/transaction/mod.rs
+++ b/keystore/src/transaction/mod.rs
@@ -12,13 +12,15 @@ mod specializations;
 
 use std::{collections::HashMap, sync::Arc};
 
-use async_lock::{RwLock, SemaphoreGuardArc};
+use async_lock::RwLock;
 use rusqlite::TransactionBehavior;
 
 pub use self::dynamic_dispatch::EntityId;
 pub(crate) use self::{bulk_delete_filter::BulkDeleteFilter, read_outcome::ReadOutcome};
 use self::{dynamic_dispatch::Operation, operations::Operations};
-use crate::{CryptoKeystoreError, CryptoKeystoreResult, Database, UniqueArc, traits::Entity};
+use crate::{
+    CryptoKeystoreError, CryptoKeystoreResult, Database, UniqueArc, connection::TransactionGuard, traits::Entity,
+};
 
 /// This is an in-flight transaction: all operations are buffered in memory, and only
 /// applied to the database on [`commit`][UniqueArc<Self>::commit].
@@ -32,21 +34,21 @@ use crate::{CryptoKeystoreError, CryptoKeystoreResult, Database, UniqueArc, trai
 /// Just be aware that you'll need to take the unique arc out in order to commit.
 pub struct Transaction {
     operations: RwLock<Operations>,
-    _semaphore_guard: SemaphoreGuardArc,
+    _lock_guard: TransactionGuard,
     database: Arc<Database>,
 }
 
 impl Transaction {
     /// Instantiate a new transaction.
     ///
-    /// Requires a semaphore guard to ensure that only one exists at a time.
+    /// Requires a transaction lock guard to ensure that only one exists at a time.
     pub(crate) async fn new(
-        semaphore_guard: SemaphoreGuardArc,
+        lock_guard: TransactionGuard,
         database: Arc<Database>,
     ) -> CryptoKeystoreResult<UniqueArc<Self>> {
         let transaction = UniqueArc::from(Self {
             operations: Default::default(),
-            _semaphore_guard: semaphore_guard,
+            _lock_guard: lock_guard,
             database,
         });
 
@@ -128,7 +130,7 @@ impl UniqueArc<Transaction> {
         let Transaction {
             operations,
             database,
-            _semaphore_guard,
+            _lock_guard,
         } = UniqueArc::into_inner(self).await;
         let operations = operations.into_inner();
 

--- a/make/config.mk
+++ b/make/config.mk
@@ -18,7 +18,7 @@ else
   RELEASE_MODE := release
 endif
 
-SWIFT_CARGO_BUILD_ARGS := $(CARGO_BUILD_ARGS) --features cancellable-transactions
+SWIFT_CARGO_BUILD_ARGS := $(CARGO_BUILD_ARGS) --features cancellable-transactions,cross-process-lock
 
 TARGET_DIR := target/$(RELEASE_MODE)
 


### PR DESCRIPTION
Move the transaction file lock into rust so that it can also be enabled for the ios target of kmp builds.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
