### PR TITLE
chore: review testing updates for each entity [WPB-9649]

### DIFF
--- a/keystore/src/entities/mls/stored_credential.rs
+++ b/keystore/src/entities/mls/stored_credential.rs
@@ -113,7 +113,7 @@ impl crate::traits::EntityDatabaseMutation for StoredCredential {
     fn save(&self, tx: &rusqlite::Transaction) -> crate::CryptoKeystoreResult<()> {
         use crate::traits::PrimaryKey as _;
         let mut stmt = tx.prepare_cached(
-            "INSERT INTO mls_credentials \
+            "INSERT OR REPLACE INTO mls_credentials \
              (public_key_sha256, public_key, session_id, credential, created_at, ciphersuite, private_key) \
              VALUES \
              (:public_key_sha256, :public_key, :session_id, :credential, datetime(:created_at, 'unixepoch'), :ciphersuite, :private_key)",

--- a/keystore/tests/z_entities.rs
+++ b/keystore/tests/z_entities.rs
@@ -253,7 +253,9 @@ mod tests_impl {
 
         assert_no_transaction_in_flight(store).await;
         let entity2 = store.get::<E>(&entity.primary_key()).await.unwrap().unwrap();
-        assert_eq!(*entity, *entity2);
+        let mut entity2 = Arc::into_inner(entity2).expect("this had to come from the db; no tx in flight");
+        entity2.equalize();
+        assert_eq!(*entity, entity2);
     }
 
     pub(crate) async fn can_remove_entity<E>(store: &Arc<CryptoKeystore>, entity: E)
@@ -332,7 +334,7 @@ mod tests {
     test_for_entity!(test_tnt_message_counter, TargetedMessageTxCounter no_borrowed_key:true);
     test_for_entity!(test_persisted_mls_pending_group, PersistedMlsPendingGroup);
     test_for_entity!(test_mls_pending_message, MlsPendingMessage ignore_entity_count: true ignore_update:true ignore_remove:true ignore_find_many:true no_borrowed_key:true);
-    test_for_entity!(test_mls_credential, StoredCredential ignore_update:true no_borrowed_key:true);
+    test_for_entity!(test_mls_credential, StoredCredential no_borrowed_key:true);
     test_for_entity!(test_mls_keypackage, StoredKeyPackage);
     test_for_entity!(test_mls_psk_bundle, StoredPskBundle);
     test_for_entity!(test_mls_encryption_keypair, StoredEncryptionKeyPair);
@@ -501,7 +503,7 @@ pub mod utils {
             }
 
     impl_entity_random_update_ext!(StoredKeyPackage, blob_fields=[key_package,], additional_fields=[(key_package_ref: uuid::Uuid::new_v4().hyphenated().to_string().into()),]);
-    impl_entity_random_update_ext!(StoredCredential, blob_fields=[credential,public_key,private_key,], additional_fields=[(session_id: uuid::Uuid::new_v4().hyphenated().to_string().into()),(created_at: 0; auto-generated:true),(ciphersuite: rand::random()),]);
+    impl_entity_random_update_ext!(StoredCredential, id_field = public_key, blob_fields=[credential,private_key,], additional_fields=[(session_id: uuid::Uuid::new_v4().hyphenated().to_string().into()),(created_at: 0; auto-generated:true),(ciphersuite: rand::random()),]);
     impl_entity_random_update_ext!(StoredHpkePrivateKey, blob_fields=[pk id_like:true,sk,]);
     impl_entity_random_update_ext!(StoredEncryptionKeyPair, blob_fields=[pk id_like:true,sk,]);
     impl_entity_random_update_ext!(StoredPskBundle, blob_fields=[psk,psk_id id_like:true,]);

--- a/keystore/tests/z_entities.rs
+++ b/keystore/tests/z_entities.rs
@@ -39,10 +39,9 @@ macro_rules! test_for_entity {
 
             borrowed_key_round_trip!(&store, $entity, $($no_borrowed_key)?);
 
-            // TODO: entities which do not support update tend not to have a primary key constraint. Tracking issue: WPB-9649
-            // This can cause complications with the "default" remove implementation which does not support deleting many entities.
-            // We should have an automated way to test this here
-
+            // Certain entities have PKs which are the hash of all fields in the entity, such as MlsPendingMessage.
+            // Other entities completely ignore their PK, such as ProteusIdentity.
+            // In both cases the update test trivially succeeds without telling us anything.
             if !pat_to_bool!($($ignore_update)?) {
                 crate::tests_impl::can_update_entity::<$entity>(&store, &mut entity).await;
             }


### PR DESCRIPTION
There was one entity where update testing made sense and we weren't previously doing it. Everything else which ignores it did so properly.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
