### PR TITLE
fix: swift docs failing

### DIFF
--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -50,7 +50,10 @@ jobs:
           ruby-version: '3.3'
 
       - name: install jazzy
-        run: gem install jazzy
+        run: | # pinned mustache to avoid https://github.com/mustache/mustache/issues/293
+          gem install jazzy
+          gem uninstall mustache -aIx
+          gem install mustache -v 1.1.1
 
       - uses: swift-actions/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9 # v3.0.0-beta.1
         with:


### PR DESCRIPTION
The mustache v1.1.3 dependency has some issue https://github.com/mustache/mustache/issues/293

We are pinning it to v1.1.1 until there's a fix.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
