### PR TITLE
chore(crypto): use a better pattern for matching `TntWireFormat`

### DIFF
--- a/crypto/src/mls/conversation/mutable/decrypt/mod.rs
+++ b/crypto/src/mls/conversation/mutable/decrypt/mod.rs
@@ -187,7 +187,7 @@ impl ConversationMut {
             u16::tls_deserialize_exact(&message[2..4]).map_err(TlsCodecError::deserialize("u16 (wire format)"))?;
 
         let decrypt_message_result = match wire_format {
-            wire_format if TntWireFormat::ALL.contains(&wire_format) => {
+            TntWireFormat::MIN..=TntWireFormat::MAX => {
                 let tnt_message =
                     TntMessage::tls_deserialize_exact(message).map_err(TlsCodecError::deserialize("TntMessage"))?;
                 self.decrypt_tnt_message(tnt_message).await

--- a/crypto/src/mls/conversation/mutable/tnt/mod.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/mod.rs
@@ -55,7 +55,10 @@ impl TntWireFormat {
     pub(crate) const TARGETED_MESSAGE: u16 = 0xF001;
     pub(crate) const TRANSIENT_TARGETED_MESSAGE: u16 = 0xF002;
 
-    pub(crate) const ALL: std::ops::RangeInclusive<u16> = Self::TRANSIENT_MESSAGE..=Self::TRANSIENT_TARGETED_MESSAGE;
+    pub(crate) const MIN: u16 = Self::TRANSIENT_MESSAGE;
+    pub(crate) const MAX: u16 = Self::TRANSIENT_TARGETED_MESSAGE;
+
+    pub(crate) const ALL: std::ops::RangeInclusive<u16> = Self::MIN..=Self::MAX;
 }
 
 /// The to-be-signed [TntMessage].


### PR DESCRIPTION
Turns out that match statements can match ranges, but only literal ranges. Storing a range as a value means it doesn't match anymore.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
