### PR TITLE
fix(tnt/targeted): when decrypting, take protocol version from message

### DIFF
--- a/crypto/src/mls/conversation/mutable/tnt/mod.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/mod.rs
@@ -15,13 +15,15 @@ use crate::{
 };
 
 /// The version of the Transient and Targeted Messages protocol.
-#[derive(TlsSize, TlsSerialize, TlsDeserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, TlsSize, TlsSerialize, TlsDeserialize)]
 #[repr(transparent)]
 struct ProtocolVersion(u16);
 
 impl ProtocolVersion {
     /// Transient and Targeted Messages Version 1
     const V1: Self = Self(1);
+
+    const CURRENT: Self = Self::V1;
 
     const fn as_u16(&self) -> u16 {
         self.0
@@ -72,21 +74,21 @@ impl TntMessageTBS {
     #[expect(dead_code)]
     fn new_transient(transient: ()) -> Self {
         Self {
-            protocol_version: ProtocolVersion::V1,
+            protocol_version: ProtocolVersion::CURRENT,
             body: TntMessageBody::Transient(transient),
         }
     }
 
     fn new_targeted(targeted: TargetedMessage) -> Self {
         Self {
-            protocol_version: ProtocolVersion::V1,
+            protocol_version: ProtocolVersion::CURRENT,
             body: TntMessageBody::Targeted(targeted),
         }
     }
 
     fn new_transient_targeted(targeted: TargetedMessage) -> Self {
         Self {
-            protocol_version: ProtocolVersion::V1,
+            protocol_version: ProtocolVersion::CURRENT,
             body: TntMessageBody::TransientTargeted(targeted),
         }
     }
@@ -154,6 +156,13 @@ impl openmls::prelude::Verifiable for TntMessage {
 impl ConversationMut {
     /// Verify the [TntMessage] signature, then proceed with decryption.
     pub(super) async fn decrypt_tnt_message(&self, message: TntMessage) -> Result<DecryptedMessage> {
+        let protocol_version = message.content.protocol_version;
+        // Currently, we only support `ProtocolVersion::V1`, so we're throwing an error if anyone from a future version
+        // sends us a message.
+        if protocol_version != ProtocolVersion::V1 {
+            return Err(Error::MlsMessageInvalidState("Unsupported tnt protocol version"));
+        }
+
         let crypto_provider = self.crypto_provider().await?;
         let signature_algorithm = self.cipher_suite().signature_algorithm();
         let sender = self
@@ -173,12 +182,22 @@ impl ConversationMut {
         match message.content.body {
             TntMessageBody::Transient(_) => todo!(),
             TntMessageBody::Targeted(targeted_message) => {
-                self.decrypt_targeted(targeted_message, TargetedMessagePolicy::Persisted, &sender)
-                    .await
+                self.decrypt_targeted(
+                    targeted_message,
+                    TargetedMessagePolicy::Persisted,
+                    protocol_version,
+                    &sender,
+                )
+                .await
             }
             TntMessageBody::TransientTargeted(targeted_message) => {
-                self.decrypt_targeted(targeted_message, TargetedMessagePolicy::Transient, &sender)
-                    .await
+                self.decrypt_targeted(
+                    targeted_message,
+                    TargetedMessagePolicy::Transient,
+                    protocol_version,
+                    &sender,
+                )
+                .await
             }
         }
     }

--- a/crypto/src/mls/conversation/mutable/tnt/targeted/decrypt.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/targeted/decrypt.rs
@@ -24,7 +24,10 @@ use crate::{
         conversation::{
             ConversationMut, Error, MlsGroupState, Result, TargetedMessagePolicy,
             config::{MAX_FUTURE_EPOCHS, MAX_PAST_EPOCHS},
-            mutable::{decrypt::DecryptedBytes, tnt::TargetedMessage},
+            mutable::{
+                decrypt::DecryptedBytes,
+                tnt::{ProtocolVersion, TargetedMessage},
+            },
         },
         credential::ext::CredentialExt,
     },
@@ -35,6 +38,7 @@ impl ConversationMut {
         &self,
         message: TargetedMessage,
         policy: TargetedMessagePolicy,
+        protocol_version: ProtocolVersion,
         sender: &Member,
     ) -> Result<DecryptedMessage> {
         let mls_group = self.group().await;
@@ -68,7 +72,7 @@ impl ConversationMut {
         let crypto_provider = self.crypto_provider().await?;
         let cipher_suite = &self.cipher_suite();
         let (context_data, decryption_key) = self
-            .load_hpke_decryption_data(&mls_group, &crypto_provider, &message, policy)
+            .load_hpke_decryption_data(&mls_group, &crypto_provider, &message, policy, protocol_version)
             .await?;
         let aad = message
             .counter
@@ -142,13 +146,15 @@ impl ConversationMut {
         crypto_provider: &CryptoProvider,
         message: &TargetedMessage,
         policy: TargetedMessagePolicy,
+        protocol_version: ProtocolVersion,
     ) -> Result<(HpkeContextData, HpkePrivateKey), Error> {
         if message.epoch == mls_group.epoch() {
             let context = TargetedMessageContext::new(
+                protocol_version,
                 policy,
-                mls_group.export_group_context(),
                 message.sender(),
                 message.recipient,
+                mls_group.export_group_context().clone(),
             );
             let context_data = extract_hpke_context_data(crypto_provider, &context, mls_group)?;
             let decryption_key = self.load_decryption_key(mls_group).await?;
@@ -169,7 +175,12 @@ impl ConversationMut {
             .ok_or(Error::MlsGroupInvalidState("tnt secret is missing"))?;
         let group_context = GroupContext::tls_deserialize(&mut secret.group_context.as_slice())
             .map_err(TlsCodecError::deserialize("TntSecret GroupContext"))?;
-        let context = TargetedMessageContext::new(policy, &group_context, message.sender(), message.recipient);
+        let context = TargetedMessageContext::new_with_current_protocol_version(
+            policy,
+            &group_context,
+            message.sender(),
+            message.recipient,
+        );
         let info = context
             .tls_serialize_detached()
             .map_err(TlsCodecError::serialize("TargetedMessageContext"))?;

--- a/crypto/src/mls/conversation/mutable/tnt/targeted/decrypt.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/targeted/decrypt.rs
@@ -19,7 +19,7 @@ use tls_codec::{Deserialize as _, Serialize as _, VLBytes};
 
 use super::{HpkeContextData, PskId, TargetedMessageContext, derive_targeted_message_psk, extract_hpke_context_data};
 use crate::{
-    CipherSuite, CryptoProvider, DecryptedMessage, KeystoreError, OpenMlsError, RecursiveError, TlsCodecError,
+    CryptoProvider, DecryptedMessage, KeystoreError, OpenMlsError, RecursiveError, TlsCodecError,
     mls::{
         conversation::{
             ConversationMut, Error, MlsGroupState, Result, TargetedMessagePolicy,
@@ -68,7 +68,7 @@ impl ConversationMut {
         let crypto_provider = self.crypto_provider().await?;
         let cipher_suite = &self.cipher_suite();
         let (context_data, decryption_key) = self
-            .load_hpke_decryption_data(&mls_group, &crypto_provider, cipher_suite, &message, policy)
+            .load_hpke_decryption_data(&mls_group, &crypto_provider, &message, policy)
             .await?;
         let aad = message
             .counter
@@ -140,7 +140,6 @@ impl ConversationMut {
         &self,
         mls_group: &MlsGroupState,
         crypto_provider: &CryptoProvider,
-        cipher_suite: &CipherSuite,
         message: &TargetedMessage,
         policy: TargetedMessagePolicy,
     ) -> Result<(HpkeContextData, HpkePrivateKey), Error> {
@@ -151,7 +150,7 @@ impl ConversationMut {
                 message.sender(),
                 message.recipient,
             );
-            let context_data = extract_hpke_context_data(crypto_provider, cipher_suite, &context, mls_group)?;
+            let context_data = extract_hpke_context_data(crypto_provider, &context, mls_group)?;
             let decryption_key = self.load_decryption_key(mls_group).await?;
             return Ok((context_data, decryption_key));
         }
@@ -190,7 +189,7 @@ impl ConversationMut {
     pub(in crate::mls::conversation) async fn create_tnt_secret(&self, mls_group: &MlsGroup) -> Result<TntSecret> {
         let crypto_provider = self.crypto_provider().await?;
         let hpke_private_key = self.load_decryption_key(mls_group).await?;
-        let targeted_message_psk = derive_targeted_message_psk(&crypto_provider, &self.cipher_suite(), mls_group)?;
+        let targeted_message_psk = derive_targeted_message_psk(&crypto_provider, mls_group)?;
 
         Ok(TntSecret {
             conversation_id: mls_group.group_id().to_vec(),

--- a/crypto/src/mls/conversation/mutable/tnt/targeted/encrypt.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/targeted/encrypt.rs
@@ -103,7 +103,7 @@ impl ConversationMut {
             mls_group.own_leaf_index(),
             recipient.index,
         );
-        let context_data = extract_hpke_context_data(crypto_provider, cipher_suite, &context, mls_group)?;
+        let context_data = extract_hpke_context_data(crypto_provider, &context, mls_group)?;
         let message = tls_serialize_padded(message).map_err(TlsCodecError::serialize("TargetedMessageContent"))?;
         let payload = crypto_provider
             .hpke_seal_psk(

--- a/crypto/src/mls/conversation/mutable/tnt/targeted/encrypt.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/targeted/encrypt.rs
@@ -97,7 +97,7 @@ impl ConversationMut {
         let aad = counter
             .tls_serialize_detached()
             .map_err(TlsCodecError::serialize("TntMessageCounter"))?;
-        let context = TargetedMessageContext::new(
+        let context = TargetedMessageContext::new_with_current_protocol_version(
             policy,
             mls_group.export_group_context(),
             mls_group.own_leaf_index(),

--- a/crypto/src/mls/conversation/mutable/tnt/targeted/mod.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/targeted/mod.rs
@@ -16,7 +16,7 @@ use crate::{ConversationConfiguration, OpenMlsError, TlsCodecError};
 
 /// Used to parameterize HPKE Seal/Open.
 /// Not carried with the payload, constructed freshly when decrypting.
-#[derive(TlsSize, TlsSerialize)]
+#[derive(TlsSize, TlsSerialize, derive_more::Constructor)]
 pub(super) struct TargetedMessageContext {
     protocol_version: ProtocolVersion,
     policy: TargetedMessagePolicy,
@@ -26,7 +26,7 @@ pub(super) struct TargetedMessageContext {
 }
 
 impl TargetedMessageContext {
-    fn new(
+    fn new_with_current_protocol_version(
         policy: TargetedMessagePolicy,
         group_context: &GroupContext,
         sender: LeafNodeIndex,
@@ -34,7 +34,7 @@ impl TargetedMessageContext {
     ) -> Self {
         Self {
             policy,
-            protocol_version: ProtocolVersion::V1,
+            protocol_version: ProtocolVersion::CURRENT,
             sender,
             recipient,
             group_context: group_context.clone(),
@@ -74,10 +74,10 @@ pub(super) struct TargetedMessage {
 impl TargetedMessage {
     pub(super) const PADDING_SIZE: usize = ConversationConfiguration::PADDING_SIZE;
     pub(super) const SIGN_LABEL_PERSISTED: &str =
-        concatcp!("TntMessageTBS-Persisted-Targeted v", ProtocolVersion::V1.as_u16());
+        concatcp!("TntMessageTBS-Persisted-Targeted v", ProtocolVersion::CURRENT.as_u16());
     pub(super) const SIGN_LABEL_TRANSIENT: &str =
-        concatcp!("TntMessageTBS-Transient-Targeted v", ProtocolVersion::V1.as_u16());
-    pub(super) const PSK_LABEL: &str = concatcp!("Tnt TargetedMessage Psk v", ProtocolVersion::V1.as_u16());
+        concatcp!("TntMessageTBS-Transient-Targeted v", ProtocolVersion::CURRENT.as_u16());
+    pub(super) const PSK_LABEL: &str = concatcp!("Tnt TargetedMessage Psk v", ProtocolVersion::CURRENT.as_u16());
 
     pub(super) fn sender(&self) -> LeafNodeIndex {
         self.sender

--- a/crypto/src/mls/conversation/mutable/tnt/targeted/mod.rs
+++ b/crypto/src/mls/conversation/mutable/tnt/targeted/mod.rs
@@ -5,7 +5,7 @@ use const_format::concatcp;
 use derive_more::Constructor;
 use openmls::{
     group::{GroupEpoch, GroupId, MlsGroup, group_context::GroupContext},
-    prelude::{Ciphersuite, HpkeCiphertext, LeafNodeIndex},
+    prelude::{HpkeCiphertext, LeafNodeIndex},
 };
 use openmls_traits::OpenMlsCryptoProvider;
 use tls_codec::{Serialize as _, TlsDeserialize, TlsSerialize, TlsSize};
@@ -93,7 +93,6 @@ struct HpkeContextData {
 
 fn extract_hpke_context_data(
     crypto_provider: &impl OpenMlsCryptoProvider,
-    cipher_suite: &Ciphersuite,
     context: &TargetedMessageContext,
     mls_group: &MlsGroup,
 ) -> Result<HpkeContextData> {
@@ -101,7 +100,7 @@ fn extract_hpke_context_data(
         .tls_serialize_detached()
         .map_err(TlsCodecError::serialize("TargetedMessageContext"))?;
 
-    let psk = derive_targeted_message_psk(crypto_provider, cipher_suite, mls_group)?;
+    let psk = derive_targeted_message_psk(crypto_provider, mls_group)?;
     let psk_id = PskId::new(mls_group.group_id().clone(), mls_group.epoch());
     let psk_id = psk_id
         .tls_serialize_detached()
@@ -110,11 +109,8 @@ fn extract_hpke_context_data(
     Ok(HpkeContextData { info, psk_id, psk })
 }
 
-fn derive_targeted_message_psk(
-    crypto_provider: &impl OpenMlsCryptoProvider,
-    cipher_suite: &Ciphersuite,
-    mls_group: &MlsGroup,
-) -> Result<Vec<u8>> {
+fn derive_targeted_message_psk(crypto_provider: &impl OpenMlsCryptoProvider, mls_group: &MlsGroup) -> Result<Vec<u8>> {
+    let cipher_suite = mls_group.ciphersuite();
     // We can use an empty context because we're using a unique label.
     mls_group
         .export_secret(


### PR DESCRIPTION
... and error out if it doesn't match `V1`.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
