### PR TITLE
fix: align the naming of ts  benchmark parameters with jvm

### DIFF
--- a/crypto-ffi/bindings/js/shared/benches/createMessage.bench.ts
+++ b/crypto-ffi/bindings/js/shared/benches/createMessage.bench.ts
@@ -22,7 +22,7 @@ export async function setupCreateMessageBench() {
             const conversationId = await helpers.createConversation(cc);
 
             bench.add(
-                `cipherSuite=${cipherSuite} size=${size}B count=${count}`,
+                `cipherSuite=${cipherSuite} messageSize=${size} messageCount=${count}`,
                 async () => {
                     await cc.transaction(async (ctx) => {
                         for (let i = 0; i < count; i++) {

--- a/crypto-ffi/bindings/js/shared/benches/processMessage.bench.ts
+++ b/crypto-ffi/bindings/js/shared/benches/processMessage.bench.ts
@@ -33,7 +33,7 @@ export async function setupProcessMessageBench() {
             // This means that we can't encrypt the messages beforehand as this would lead to bob decrypting
             // the same messages over and over again.
             bench.add(
-                `cipherSuite=${cipherSuite} size=${size}B count=${count}`,
+                `cipherSuite=${cipherSuite} messageSize=${size} messageCount=${count}`,
                 async () => {
                     const encryptedMessages = await aliceCc.transaction(
                         async (ctx) => {


### PR DESCRIPTION
These parameters were overlooked when the previous alignment was done.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
