### PR TITLE
fix(keystore): allow divergent V16 migration [WPB-28480]

### DIFF
--- a/keystore/src/connection/migrations/V16__prepare_credential_merge.sql
+++ b/keystore/src/connection/migrations/V16__prepare_credential_merge.sql
@@ -6,3 +6,4 @@ CREATE TABLE mls_credentials_new (
     public_key BLOB NOT NULL,
     private_key BLOB NOT NULL
 );
+

--- a/keystore/src/connection/migrations/mod.rs
+++ b/keystore/src/connection/migrations/mod.rs
@@ -37,8 +37,18 @@ pub(super) fn run_migrations(conn: &mut rusqlite::Connection, target: MigrationT
     };
 
     for version in 1..=target_version {
+        // This version is known to have an additional newline in some releases, but the actual migration work is
+        // identical
+        if version == 16 {
+            runner = runner.set_abort_divergent(false);
+        }
+
         runner = runner.set_target(Target::Version(version));
         let report = runner.run(conn).map_err(Box::new)?;
+
+        if version == 16 {
+            runner = runner.set_abort_divergent(true);
+        }
 
         let Some(updated_version) = report.applied_migrations().iter().map(|m| m.version()).max() else {
             continue;


### PR DESCRIPTION
In some releases we accidentally included a whitespace-only modification
of the V16 migration file. This breaks refinery's check of executed vs.
filesystem checksums and consequently migrations fail for some clients
that had already executed the migration with the extra whitespace.

Since it's just whitespace, it's safe to ignore the divergency in this
case, assuming we're not going to accidentally change the actual SQL in
there. Luckily, due to our stepwise migration scheme, we can scope
refinery's divergency tolerance to a single migration step.