### PR TITLE
chore: replay keystore migrations from `main` onto `10.x`

### DIFF
--- a/keystore/src/connection/composite-schema.sql
+++ b/keystore/src/connection/composite-schema.sql
@@ -37,10 +37,6 @@ CREATE TABLE "mls_credentials" (
   private_key BLOB NOT NULL
 );
 
-CREATE TABLE "mls_epoch_encryption_keypairs" (id BLOB UNIQUE, keypairs BLOB);
-
-CREATE INDEX idx_mls_epoch_encryption_keypairs_id ON mls_epoch_encryption_keypairs(id);
-
 CREATE TABLE "mls_key_packages" (
   key_package_ref BLOB UNIQUE,
   key_package BLOB
@@ -48,11 +44,7 @@ CREATE TABLE "mls_key_packages" (
 
 CREATE INDEX idx_mls_keypackages_keypackage_ref ON "mls_key_packages"(key_package_ref);
 
-CREATE TABLE "mls_groups" (
-  id BLOB UNIQUE,
-  state BLOB,
-  sender_nonce INTEGER NOT NULL DEFAULT 0
-);
+CREATE TABLE "mls_groups" (id BLOB UNIQUE, state BLOB);
 
 CREATE INDEX idx_mls_groups_id ON mls_groups(id);
 
@@ -92,3 +84,46 @@ CREATE TABLE "mls_pending_messages" (
 );
 
 CREATE INDEX idx_mls_pending_messages_conversation_id ON mls_pending_messages(conversation_id);
+
+CREATE TABLE tnt_secrets (
+  conversation_id BLOB NOT NULL,
+  epoch INTEGER NOT NULL,
+  hpke_private_key BLOB NOT NULL,
+  group_context BLOB NOT NULL,
+  targeted_message_psk BLOB NOT NULL,
+  PRIMARY KEY (conversation_id, epoch),
+  FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);
+
+CREATE TABLE targeted_message_rx_counters (
+  conversation_id BLOB NOT NULL,
+  sender INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (conversation_id, sender, epoch),
+  FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);
+
+CREATE TABLE epoch_encryption_keypairs (
+  conversation_id BLOB NOT NULL,
+  own_leaf_index INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
+  keypairs BLOB NOT NULL,
+  PRIMARY KEY (conversation_id, own_leaf_index, epoch)
+);
+
+CREATE TABLE tnt_message_tx_counters (
+  conversation_id BLOB NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (conversation_id),
+  FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);
+
+CREATE TABLE transient_message_rx_counters (
+  conversation_id BLOB NOT NULL,
+  sender INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (conversation_id, sender, epoch),
+  FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);

--- a/keystore/src/connection/migrations/V32__tnt_message_sender_counters.sql
+++ b/keystore/src/connection/migrations/V32__tnt_message_sender_counters.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mls_groups DROP COLUMN sender_nonce;

--- a/keystore/src/connection/migrations/V33__tnt_secrets_tnt_message_receiver_counters.sql
+++ b/keystore/src/connection/migrations/V33__tnt_secrets_tnt_message_receiver_counters.sql
@@ -1,0 +1,18 @@
+CREATE TABLE tnt_secrets (
+    conversation_id BLOB NOT NULL,
+    epoch INTEGER NOT NULL,
+    hpke_private_key BLOB NOT NULL,
+    group_context BLOB NOT NULL,
+    targeted_message_psk BLOB NOT NULL,
+    PRIMARY KEY (conversation_id, epoch),
+    FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);
+
+CREATE TABLE targeted_message_rx_counters (
+    conversation_id BLOB NOT NULL,
+    sender INTEGER NOT NULL,
+    epoch INTEGER NOT NULL,
+    count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (conversation_id, sender, epoch),
+    FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);

--- a/keystore/src/connection/migrations/V34__split_epoch_encryption_keypair_pk.sql
+++ b/keystore/src/connection/migrations/V34__split_epoch_encryption_keypair_pk.sql
@@ -1,0 +1,20 @@
+-- This isn't this table's Final Form.
+--
+-- The `keypairs` blob is a serialized vector of `(public_key, private_key)` pairs.
+-- In principle, there's no reason that we couldn't make this a type primarily accessed
+-- via bulk actions, with rowid as the primary key and an index over the
+-- (conversation_id, own_leaf_index, epoch) tuple for efficient bulk queries.
+-- Adding and removing keypairs would be more efficient if the table looked like that;
+-- there would be no need for a read->deser->modify->ser->write pipeline in that case.
+--
+-- We don't do that today because ultimately this is an OpenMLS table and that
+-- pipeline is built into the OpenMLS assumptions. It's been like that since
+-- 51a7e1393ac277f0e621b5d2866c666edf74c687 in 2023, and changing it would require
+-- adjusting the `MlsEntity` and `OpenMlsKeyStore` traits.
+CREATE TABLE epoch_encryption_keypairs (
+    conversation_id BLOB NOT NULL,
+    own_leaf_index INTEGER NOT NULL,
+    epoch INTEGER NOT NULL,
+    keypairs BLOB NOT NULL,
+    PRIMARY KEY (conversation_id, own_leaf_index, epoch)
+);

--- a/keystore/src/connection/migrations/V35__drop_old_epoch_encryption_keypairs_table.sql
+++ b/keystore/src/connection/migrations/V35__drop_old_epoch_encryption_keypairs_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE mls_epoch_encryption_keypairs;

--- a/keystore/src/connection/migrations/V36__transient_message_counters.sql
+++ b/keystore/src/connection/migrations/V36__transient_message_counters.sql
@@ -1,0 +1,15 @@
+CREATE TABLE tnt_message_tx_counters (
+    conversation_id BLOB NOT NULL,
+    count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (conversation_id),
+    FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);
+
+CREATE TABLE transient_message_rx_counters (
+    conversation_id BLOB NOT NULL,
+    sender INTEGER NOT NULL,
+    epoch INTEGER NOT NULL,
+    count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (conversation_id, sender, epoch),
+    FOREIGN KEY (conversation_id) REFERENCES mls_groups(id) ON DELETE CASCADE
+);

--- a/keystore/src/connection/migrations/meta_migrations/mod.rs
+++ b/keystore/src/connection/migrations/meta_migrations/mod.rs
@@ -6,3 +6,4 @@ pub(super) mod v18;
 pub(super) mod v19;
 pub(super) mod v28;
 pub(super) mod v31;
+pub(super) mod v34;

--- a/keystore/src/connection/migrations/meta_migrations/v34.rs
+++ b/keystore/src/connection/migrations/meta_migrations/v34.rs
@@ -1,0 +1,51 @@
+//! Parse epoch encryption keypair primary keys and copy parsed data into the new table
+
+use log::warn;
+use rusqlite::named_params;
+
+use crate::{
+    CryptoKeystoreResult, entities::StoredEpochEncryptionKeypairPkRef, migrations::V33StoredEpochEncryptionKeypair,
+    traits::Entity,
+};
+
+pub(crate) const VERSION: i32 = 34;
+
+pub(crate) fn meta_migration(conn: &mut rusqlite::Connection) -> CryptoKeystoreResult<()> {
+    let tx = conn.transaction()?;
+
+    let mut stmt = tx.prepare(
+        "INSERT INTO epoch_encryption_keypairs (
+        conversation_id,
+        own_leaf_index,
+        epoch,
+        keypairs
+    ) VALUES (
+        :conversation_id,
+        :own_leaf_idx,
+        :epoch,
+        :keypairs
+    )",
+    )?;
+
+    let keypairs = V33StoredEpochEncryptionKeypair::load_all(&tx)?;
+    for keypair in keypairs {
+        let Ok(pk) = StoredEpochEncryptionKeypairPkRef::parse_bytes(&keypair.id) else {
+            warn!(
+                "failed to parse StoredEpochEncryptionKeypairPkRef from id: {}",
+                hex::encode(&keypair.id)
+            );
+            continue;
+        };
+        stmt.execute(named_params! {
+            ":conversation_id": pk.conversation_id,
+            ":own_leaf_idx": pk.own_leaf_idx,
+            ":epoch": pk.epoch,
+            ":keypairs": keypair.keypairs,
+        })?;
+    }
+    drop(stmt);
+
+    tx.commit()?;
+
+    Ok(())
+}

--- a/keystore/src/connection/migrations/mod.rs
+++ b/keystore/src/connection/migrations/mod.rs
@@ -62,6 +62,7 @@ fn run_meta_migration(sql_migration_version: i32, conn: &mut rusqlite::Connectio
         meta_migrations::v19::VERSION => meta_migrations::v19::meta_migration(conn),
         meta_migrations::v28::VERSION => meta_migrations::v28::meta_migration(conn),
         meta_migrations::v31::VERSION => meta_migrations::v31::meta_migration(conn),
+        meta_migrations::v34::VERSION => meta_migrations::v34::meta_migration(conn),
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
Only focuses on the migrations themselves in their end state, not replaying the full history.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
