### PR TITLE
docs: fix 10.x migration guides

### DIFF
--- a/cc-book/src/cc10/migration-guide.md
+++ b/cc-book/src/cc10/migration-guide.md
@@ -56,7 +56,7 @@ when (decryptedMessage) {
 
 <!-- langtabs-end -->
 
-# Migrating from v9.x to v10.0
+## Migrating from v9.x to v10.0
 
 This page covers breaking changes that are identical across all platforms. For platform-specific migration steps, see
 the sub-pages:


### PR DESCRIPTION
We have two sections in there, so we need H2 headings. The H1 heading in the middle isn't displayed in the sidebar.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
