### PR TITLE
fix(keystore): adjust refinery schema history if necessary [WPB-28480]

### DIFF
--- a/keystore/src/connection/migrations/mod.rs
+++ b/keystore/src/connection/migrations/mod.rs
@@ -196,6 +196,40 @@ pub(crate) mod test {
         (NamedTempFile::new().unwrap(), DatabaseKey::generate())
     }
 
+    #[test]
+    fn repairs_divergent_v16_checksum_before_running_migrations() {
+        let (db_file, key) = temp_db();
+        let path = db_file
+            .path()
+            .to_str()
+            .expect("tmpfile path is representable in unicode");
+
+        smol::block_on(async {
+            let db = Database::open_at_schema_version(path, &key, MigrationTarget::Version(16))
+                .await
+                .expect("opening the database at V16");
+            let conn = db.conn().await;
+            let expected_checksum: String = conn
+                .query_row(
+                    "SELECT checksum FROM refinery_schema_history WHERE version = 16",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("reading the V16 checksum");
+            let divergent_checksum = (expected_checksum.parse::<u64>().unwrap().wrapping_add(1)).to_string();
+
+            conn.execute(
+                "UPDATE refinery_schema_history SET checksum = ?1 WHERE version = 16",
+                [&divergent_checksum],
+            )
+            .expect("replacing the V16 checksum");
+
+            Database::open(path, &key)
+                .await
+                .expect("reopening and migrating the database");
+        });
+    }
+
     // a close replica of the JVM test in `GeneralTest.kt`, but way more debuggable
     #[test]
     fn can_migrate_key_type_to_bytes() {

--- a/keystore/src/connection/migrations/mod.rs
+++ b/keystore/src/connection/migrations/mod.rs
@@ -36,19 +36,33 @@ pub(super) fn run_migrations(conn: &mut rusqlite::Connection, target: MigrationT
         MigrationTarget::Version(target_argument) => (latest_migration_version).min(target_argument as i32),
     };
 
-    for version in 1..=target_version {
-        // This version is known to have an additional newline in some releases, but the actual migration work is
-        // identical
-        if version == 16 {
-            runner = runner.set_abort_divergent(false);
-        }
+    // This version is known to have an additional newline in some releases, but the actual migration work is
+    // identical. Ensure Refinery sees the checksum of the embedded migration when it validates the history.
+    const BROKEN_MIGRATION_FILE_VERSION: i32 = 16;
+    let expected_checksum = runner
+        .get_migrations()
+        .iter()
+        .find(|migration| migration.version() == BROKEN_MIGRATION_FILE_VERSION)
+        .expect("V16 is embedded")
+        .checksum()
+        .to_string();
 
+    // Adjust the schema history only if it already exists.
+    let has_refinery_schema_history = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'refinery_schema_history')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if has_refinery_schema_history {
+        conn.execute(
+            "UPDATE refinery_schema_history SET checksum = ?1 WHERE version = ?2",
+            (expected_checksum, BROKEN_MIGRATION_FILE_VERSION),
+        )?;
+    }
+
+    for version in 1..=target_version {
         runner = runner.set_target(Target::Version(version));
         let report = runner.run(conn).map_err(Box::new)?;
-
-        if version == 16 {
-            runner = runner.set_abort_divergent(true);
-        }
 
         let Some(updated_version) = report.applied_migrations().iter().map(|m| m.version()).max() else {
             continue;


### PR DESCRIPTION
Second attempt to fix that item. Instead of using
`set_abort_divergent(false)` on the migrations runner, we just pretend that we ran the migration with the correct checksum.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
