### PR TITLE
fix(kotlin)!: migrate timestamps to kotlin.time.Instant

### DIFF
--- a/cc-book/src/release_notes.md
+++ b/cc-book/src/release_notes.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Kotlin: Timestamps (Instant) are now using `kotlin.time` instead of `kotlinx.datetime`.
+
 - Kotlin: transactions are now cancellable. This applies to all Kotlin bindings: jvm, android and kmp.
 
 - Kotlin(iOS): The macos/ios targets now have a file lock guarding against concurrent access from separate CoreCrypto

--- a/crypto-ffi/bindings/gradle/libs.versions.toml
+++ b/crypto-ffi/bindings/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.3.10"
 coroutines = "1.7.3"
-kotlinx-datetime = "0.6.1"
+kotlinx-datetime = "0.7.1"
 jna = "5.17.0"
 assertj = "3.24.2"
 espresso = "3.6.1"

--- a/crypto-ffi/uniffi-android.toml
+++ b/crypto-ffi/uniffi-android.toml
@@ -4,9 +4,9 @@ android_cleaner = true
 
 [bindings.kotlin.custom_types.KotlinInstant]
 imports = [
-  "kotlinx.datetime.Instant",
-  "kotlinx.datetime.toKotlinInstant",
-  "kotlinx.datetime.toJavaInstant",
+  "kotlin.time.Instant",
+  "kotlin.time.toKotlinInstant",
+  "kotlin.time.toJavaInstant",
 ]
 type_name = "Instant"
 lift = "{}.toKotlinInstant()"

--- a/crypto-ffi/uniffi.toml
+++ b/crypto-ffi/uniffi.toml
@@ -4,9 +4,9 @@ cdylib_name = "core_crypto_ffi"
 
 [bindings.kotlin.custom_types.Timestamp]
 imports = [
-  "kotlinx.datetime.Instant",
-  "kotlinx.datetime.toKotlinInstant",
-  "kotlinx.datetime.toJavaInstant",
+  "kotlin.time.Instant",
+  "kotlin.time.toKotlinInstant",
+  "kotlin.time.toJavaInstant",
 ]
 type_name = "Instant"
 lift = "{}.toKotlinInstant()"


### PR DESCRIPTION
Targets `main` for Core Crypto 11, since this changes the public Kotlin API.

Core Crypto's Kotlin bindings still use kotlinx-datetime 0.6.1 and expose kotlinx.datetime.Instant. This keeps consumers such as Kalium dependent on the 0.6.x compatibility artifact when moving to kotlinx-datetime 0.7.1.

Update kotlinx-datetime to 0.7.1 and migrate the UniFFI timestamp mappings to kotlin.time.Instant and the standard library's Java conversion functions.

**Breaking API change:** the generated JVM and Android Timestamp alias now resolves to kotlin.time.Instant. This affects certificate validity fields such as notBefore and notAfter. Consumers must rebuild and migrate any uses of kotlinx.datetime.Instant at this boundary.

Validation before rebasing from `release/10.x` onto `main` (the migration diff is unchanged; CI will validate the new base):
- All 61 JVM tests passed against the locally built native library.
- All 61 Android instrumented tests passed on an ARM64 Android 16 emulator, with no skipped tests and with the native library included.
- Built native Android libraries for arm64-v8a, armeabi-v7a, and x86_64, then built the debug AAR with all three libraries included. No build steps were skipped.
- JVM test static analysis passed after removing the converter-only test.

Local Android validation used NDK 29, Rust 1.96, and JDK 25. Runtime tests covered ARM64; ARMv7 and x86_64 were built and packaged.

