### PR TITLE
ci: improve debuggability

### DIFF
--- a/.github/actions/make/action.yml
+++ b/.github/actions/make/action.yml
@@ -9,8 +9,11 @@ inputs:
     description: The GNU make rule which produces the artifact
     required: true
   target-path:
-    description: The relative path of the final artifact(s)
-    required: true
+    description: >
+      The relative path of the final artifact(s). Omit it for rules whose only output is a
+      stamp file, since `.stamps` is archived unconditionally; the unpack step skips an empty
+      value.
+    required: false
   gh-token:
     description: The github token
     required: true

--- a/.github/actions/make/android/bindings/action.yml
+++ b/.github/actions/make/android/bindings/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make kotlin bindings for android
+description: Fetch or build the Kotlin bindings for Android, along with the ffi library and uniffi-bindgen they are generated from
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/android/lib/action.yml
+++ b/.github/actions/make/android/lib/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make ffi lib for android
+description: Fetch or build the ffi static and shared libraries for a single Android target
 
 inputs:
   task:

--- a/.github/actions/make/android/package/action.yml
+++ b/.github/actions/make/android/package/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make android package
+description: Fetch or build the Android AAR, along with the ffi libraries for all three Android targets
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/android/test/action.yml
+++ b/.github/actions/make/android/test/action.yml
@@ -1,4 +1,5 @@
 name: Test kotlin bindings for android via make
+description: Run the Kotlin bindings test suite on Android, fetching or building the libraries and bindings it needs first
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/bindings-kotlin-jvm/action.yml
+++ b/.github/actions/make/bindings-kotlin-jvm/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make kotlin bindings for jvm
+description: Fetch or build the Kotlin bindings for the JVM, along with the ffi library and uniffi-bindgen they are generated from
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/bindings-swift/action.yml
+++ b/.github/actions/make/bindings-swift/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make swift bindings
+description: Fetch or build the Swift ffi library, the generated bindings, and the hand-written wrapper around them
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/ffi-library/action.yml
+++ b/.github/actions/make/ffi-library/action.yml
@@ -1,4 +1,7 @@
-name: Fetch or make ffi library. Note, don't use this for swift, use make/bindings-swift instead.
+name: Fetch or make the ffi library
+description: >
+  Fetch or build the host ffi shared library. Do not use this for Swift;
+  use make/bindings-swift instead.
 
 inputs:
   gh-token:

--- a/.github/actions/make/interop/build/action.yml
+++ b/.github/actions/make/interop/build/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make interop test binary
+description: Fetch or build the interop test binary
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/interop/test/action.yml
+++ b/.github/actions/make/interop/test/action.yml
@@ -1,4 +1,5 @@
 name: Run e2e interop test via make
+description: Run the end-to-end interop test, fetching or building the web, iOS, Android and interop artifacts it drives
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/ios/build/action.yml
+++ b/.github/actions/make/ios/build/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make ffi lib for ios
+description: Fetch or build the ffi static library for a single iOS target
 
 inputs:
   task:

--- a/.github/actions/make/ios/test/action.yml
+++ b/.github/actions/make/ios/test/action.yml
@@ -1,4 +1,5 @@
 name: Run ios test via make
+description: Run the Swift test suite on iOS, fetching or building the libraries and bindings it needs first
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/jvm/action.yml
+++ b/.github/actions/make/jvm/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make the ffi lib for jvm
+description: Fetch or build the ffi shared library for the JVM, for whichever platform the runner is
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/ts/browser/action.yml
+++ b/.github/actions/make/ts/browser/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make the web bindings files and wrappers
+description: Fetch or build the wasm module for the browser and the TypeScript wrappers generated from it
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/ts/native/action.yml
+++ b/.github/actions/make/ts/native/action.yml
@@ -1,4 +1,5 @@
-name: Fetch or make the web bindings files and wrappers
+name: Fetch or make the native bindings files and wrappers
+description: Fetch or build the native TypeScript bindings for whichever platform the runner is
 inputs:
   gh-token:
     required: true

--- a/.github/actions/make/uniffi-bindgen/action.yml
+++ b/.github/actions/make/uniffi-bindgen/action.yml
@@ -1,4 +1,5 @@
 name: Fetch or make uniffi-bindgen binary
+description: Fetch or build the uniffi-bindgen binary that generates the language bindings
 inputs:
   gh-token:
     required: true

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,60 @@
+name: actionlint
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+# Only the workflows and the actions they call are linted, so only changes to those can
+# break this. Note that actionlint validates workflows against action metadata, so editing
+# an action alone is enough to invalidate a workflow that calls it.
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+env:
+  ACTIONLINT_VERSION: 1.7.12
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # actionlint shells out to shellcheck for `run:` blocks when it is on PATH and silently
+      # skips those checks when it is not. Install it explicitly rather than relying on the
+      # runner image, so that a script which fails locally cannot pass here.
+      - name: install shellcheck
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: shellcheck
+
+      # taiki-e/install-action does not package actionlint, so fetch the pinned release
+      # directly and check it against the published checksums, as we do for binaryen.
+      - name: install actionlint
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          checksums="actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          cd "$RUNNER_TEMP"
+          gh release download "v${ACTIONLINT_VERSION}" --repo rhysd/actionlint \
+            --pattern "$tarball" --pattern "$checksums"
+          # the checksums file covers every platform's asset; we only downloaded one
+          sha256sum --ignore-missing --check "$checksums"
+          tar -xzf "$tarball" actionlint
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - name: lint workflows and actions
+        run: |
+          shellcheck --version | head -2
+          actionlint --version | head -1
+          actionlint -color

--- a/.github/workflows/artifact-generation.yml
+++ b/.github/workflows/artifact-generation.yml
@@ -1,0 +1,43 @@
+name: artifact generation
+
+# `vars.ARTIFACT_GENERATION` is the cache-busting suffix appended to every `make` artifact key.
+# GitHub re-reads the `vars` context whenever a job starts, so a workflow whose jobs each read the
+# variable directly can end up with producers and consumers on different generations:
+#
+#   - bumping the variable mid-run separates the jobs that started before the bump from those that
+#     started after, and
+#   - re-running only the failed jobs of a run that predates a bump leaves those jobs hunting for
+#     keys that no producer in the run ever uploaded, because the producers are green and so are
+#     not re-run.
+#
+# A consumer that misses its artifact falls back to building it locally, which for some jobs is
+# merely slow and for others impossible: the self-hosted macOS interop runner cannot build
+# wasm32-unknown-unknown at all, so the fallback fails with an unrelated-looking clang error.
+#
+# Resolving the variable exactly once per run and threading it through `needs` avoids both cases: a
+# `needs` output is fixed for the life of the run, and re-running failed jobs preserves the outputs
+# of the jobs it does not re-run.
+on:
+  workflow_call:
+    outputs:
+      generation:
+        description: Artifact key generation suffix, pinned for the whole workflow run
+        value: ${{ jobs.resolve.outputs.generation }}
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      generation: ${{ steps.resolve.outputs.generation }}
+    steps:
+      - name: resolve ARTIFACT_GENERATION
+        id: resolve
+        shell: bash -euo pipefail {0}
+        env:
+          ARTIFACT_GENERATION: ${{ vars.ARTIFACT_GENERATION }}
+        run: |
+          if [[ -z "$ARTIFACT_GENERATION" ]]; then
+            echo "::warning::ARTIFACT_GENERATION repository variable is unset; artifact keys are not generation-scoped"
+          fi
+          echo "Artifact generation for this run: '${ARTIFACT_GENERATION}'"
+          echo "generation=${ARTIFACT_GENERATION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark-jvm-publish.yml
+++ b/.github/workflows/benchmark-jvm-publish.yml
@@ -34,8 +34,8 @@ jobs:
           COMMIT_HASH=$(git rev-parse --short HEAD)
           curl -sS --fail-with-body -u "ci-writer:$VM_PASSWORD" --data-binary @metrics.txt \
                --url-query extra_label=job=core-crypto-benchmark \
-               --url-query extra_label=repo=$GITHUB_REPOSITORY \
-               --url-query extra_label=commit=$COMMIT_HASH \
+               --url-query "extra_label=repo=$GITHUB_REPOSITORY" \
+               --url-query "extra_label=commit=$COMMIT_HASH" \
                --url-query extra_label=target=jvm \
               "https://monitoring.zinfra.io/prometheus/api/v1/import/prometheus?"
 

--- a/.github/workflows/benchmark-jvm.yml
+++ b/.github/workflows/benchmark-jvm.yml
@@ -5,6 +5,13 @@ concurrency:
 on:
   workflow_call:
     inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
       benchmark_message_counts:
         required: false
         type: string
@@ -98,7 +105,7 @@ jobs:
           make-rule: jvm-linux
           target-path: target/x86_64-unknown-linux-gnu/release/libcore_crypto_ffi.so
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
       # Because this workflow runs on ubuntu, we're using the generic action
@@ -109,13 +116,13 @@ jobs:
           make-rule: jvm-darwin
           target-path: target/aarch64-apple-darwin/release/libcore_crypto_ffi.dylib
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download kotlin bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: Run benchmark
         run: make jvm-bench

--- a/.github/workflows/benchmark-ts-browser-publish.yml
+++ b/.github/workflows/benchmark-ts-browser-publish.yml
@@ -33,8 +33,8 @@ jobs:
           COMMIT_HASH=$(git rev-parse --short HEAD)
           curl -sS --fail-with-body -u "ci-writer:$VM_PASSWORD" --data-binary @metrics.txt \
                --url-query extra_label=job=core-crypto-benchmark \
-               --url-query extra_label=repo=$GITHUB_REPOSITORY \
-               --url-query extra_label=commit=$COMMIT_HASH \
+               --url-query "extra_label=repo=$GITHUB_REPOSITORY" \
+               --url-query "extra_label=commit=$COMMIT_HASH" \
                --url-query extra_label=target=ts-browser \
               "https://monitoring.zinfra.io/prometheus/api/v1/import/prometheus?"
 

--- a/.github/workflows/benchmark-ts-browser.yml
+++ b/.github/workflows/benchmark-ts-browser.yml
@@ -5,6 +5,13 @@ concurrency:
 on:
   workflow_call:
     inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
       benchmark_message_counts:
         required: false
         type: string
@@ -89,7 +96,7 @@ jobs:
         uses: ./.github/actions/make/ts/browser
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: install chrome via puppeteer
         run: |

--- a/.github/workflows/benchmark-ts-native-publish.yml
+++ b/.github/workflows/benchmark-ts-native-publish.yml
@@ -33,8 +33,8 @@ jobs:
           COMMIT_HASH=$(git rev-parse --short HEAD)
           curl -sS --fail-with-body -u "ci-writer:$VM_PASSWORD" --data-binary @metrics.txt \
                --url-query extra_label=job=core-crypto-benchmark \
-               --url-query extra_label=repo=$GITHUB_REPOSITORY \
-               --url-query extra_label=commit=$COMMIT_HASH \
+               --url-query "extra_label=repo=$GITHUB_REPOSITORY" \
+               --url-query "extra_label=commit=$COMMIT_HASH" \
                --url-query extra_label=target=ts-native \
               "https://monitoring.zinfra.io/prometheus/api/v1/import/prometheus?"
 

--- a/.github/workflows/benchmark-ts-native.yml
+++ b/.github/workflows/benchmark-ts-native.yml
@@ -5,6 +5,13 @@ concurrency:
 on:
   workflow_call:
     inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
       benchmark_message_counts:
         required: false
         type: string
@@ -89,7 +96,7 @@ jobs:
         uses: ./.github/actions/make/ts/native
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: Run benchmark
         run: make ts-native-bench

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,23 +5,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Pin the artifact key generation for the whole run; see `artifact-generation.yml`.
+  artifact-generation:
+    uses: ./.github/workflows/artifact-generation.yml
+
   benchmark-jvm:
+    needs: artifact-generation
     uses: ./.github/workflows/benchmark-jvm.yml
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       runs_on: '["self-hosted", "benchmark"]'
     secrets:
       METRICS_WRITER_PASSWORD: ${{ secrets.METRICS_WRITER_PASSWORD }}
 
   benchmark-ts-browser:
+    needs: artifact-generation
     uses: ./.github/workflows/benchmark-ts-browser.yml
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       runs_on: '["self-hosted", "benchmark"]'
     secrets:
       METRICS_WRITER_PASSWORD: ${{ secrets.METRICS_WRITER_PASSWORD }}
 
   benchmark-ts-native:
+    needs: artifact-generation
     uses: ./.github/workflows/benchmark-ts-native.yml
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       runs_on: '["self-hosted", "benchmark"]'
     secrets:
       METRICS_WRITER_PASSWORD: ${{ secrets.METRICS_WRITER_PASSWORD }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           ndk_version=$(cat crypto-ffi/bindings/android/ndk.version)
           echo "y" | sdkmanager --install "ndk;$ndk_version"
-          echo ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ndk_version >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ndk_version" >> "$GITHUB_ENV"
 
       - name: build android lib
         uses: ./.github/actions/make/android/lib

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,4 +51,4 @@ jobs:
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ${{ matrix.task }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 defaults:
   run:
@@ -34,4 +42,4 @@ jobs:
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ${{ matrix.task }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/check-ts.yml
+++ b/.github/workflows/check-ts.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -26,13 +34,13 @@ jobs:
         uses: ./.github/actions/make/ts/browser
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download native files
         uses: ./.github/actions/make/ts/native
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: lint
         run: make ts-check

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -28,7 +28,7 @@ jobs:
           tool: cargo-deny@0.19
       - name: "check licenses / supply chain"
         run: |
-          cargo deny --all-features check >> $GITHUB_STEP_SUMMARY
+          cargo deny --all-features check >> "$GITHUB_STEP_SUMMARY"
       - name: "build a dependency licenses inventory and post it to summary"
         run: |
-          cargo deny --all-features list --layout crate --format json | jq -r 'to_entries[] | "* \(.key)", "    * \(.value.licenses[])"' >> $GITHUB_STEP_SUMMARY
+          cargo deny --all-features list --layout crate --format json | jq -r 'to_entries[] | "* \(.key)", "    * \(.value.licenses[])"' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-jvm.yml
+++ b/.github/workflows/docs-jvm.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 env:
   RELEASE: 1
@@ -31,13 +39,13 @@ jobs:
         uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download linux bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: generate Kotlin docs
         uses: ./.github/actions/make
@@ -46,7 +54,7 @@ jobs:
           make-rule: docs-kotlin
           target-path: target/kotlin/doc/html
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: upload kotlin docs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/docs-swift.yml
+++ b/.github/workflows/docs-swift.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 defaults:
   run:
@@ -24,13 +32,13 @@ jobs:
         uses: ./.github/actions/make/bindings-swift
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download artifacts for ios device
         uses: ./.github/actions/make/ios/build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
           task: ios-device
       - name: download artifacts for ios simulator
@@ -38,7 +46,7 @@ jobs:
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0

--- a/.github/workflows/docs-ts.yml
+++ b/.github/workflows/docs-ts.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 env:
   RELEASE: 1
@@ -27,13 +35,13 @@ jobs:
       uses: ./.github/actions/make/ts/browser
       with:
         gh-token: ${{ secrets.GITHUB_TOKEN }}
-        artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+        artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
     - name: download native files
       uses: ./.github/actions/make/ts/native
       with:
         gh-token: ${{ secrets.GITHUB_TOKEN }}
-        artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+        artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
     - name: make ts docs
       run: make docs-ts

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -64,7 +72,7 @@ jobs:
         with:
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
         # we separate shutdown from deletion to make sure the device is always removed, even when shutdown failed
       - name: delete ios simulator and kill android emulator

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           ndk_version=$(cat crypto-ffi/bindings/android/ndk.version)
           echo "y" | sdkmanager --install "ndk;$ndk_version"
-          echo ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ndk_version >> $GITHUB_ENV
-          echo ANDROID_NDK_ROOT=$ANDROID_NDK_HOME >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ndk_version" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_HOME" >> "$GITHUB_ENV"
 
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -59,13 +59,13 @@ jobs:
           bun-version: 1.3.12
       - name: Install chrome-headless-shell
         run: |
-          bun x @puppeteer/browsers install chrome-headless-shell@latest --path $PWD
-          echo "CHROME_PATH=$(echo $PWD/chrome-headless-shell/*/*/chrome-headless-shell)" >> $GITHUB_ENV
+          bun x @puppeteer/browsers install chrome-headless-shell@latest --path "$PWD"
+          echo "CHROME_PATH=$(echo "$PWD"/chrome-headless-shell/*/*/chrome-headless-shell)" >> "$GITHUB_ENV"
 
       - name: Install chromedriver
         run: |
-          bun x @puppeteer/browsers install chromedriver@latest --path $PWD
-          echo "CHROMEDRIVER_PATH=$(echo $PWD/chromedriver/*/*/chromedriver)" >> $GITHUB_ENV
+          bun x @puppeteer/browsers install chromedriver@latest --path "$PWD"
+          echo "CHROMEDRIVER_PATH=$(echo "$PWD"/chromedriver/*/*/chromedriver)" >> "$GITHUB_ENV"
 
       - name: Run e2e interop test
         uses: ./.github/actions/make/interop/test

--- a/.github/workflows/kotlin-check.yml
+++ b/.github/workflows/kotlin-check.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.7.0/ktlint
           chmod a+x ktlint
-          echo "$PWD" >> $GITHUB_PATH
+          echo "$PWD" >> "$GITHUB_PATH"
       - name: gradle setup
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:

--- a/.github/workflows/kotlin-check.yml
+++ b/.github/workflows/kotlin-check.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -36,7 +44,7 @@ jobs:
         uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
       # Because this workflow runs on ubuntu, we're using the generic action
@@ -47,13 +55,13 @@ jobs:
           make-rule: jvm-darwin
           target-path: target/aarch64-apple-darwin/release/libcore_crypto_ffi.dylib
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download kotlin bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: lint
         run: |

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           ndk_version=$(cat crypto-ffi/bindings/android/ndk.version)
           echo "y" | sdkmanager --install "ndk;$ndk_version"
-          echo ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ndk_version >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ndk_version" >> "$GITHUB_ENV"
       - uses: ./.github/actions/make/android/package
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 env:
   RELEASE: 1
@@ -36,4 +44,4 @@ jobs:
       - uses: ./.github/actions/make/android/package
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/package-ios.yml
+++ b/.github/workflows/package-ios.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 defaults:
   run:
@@ -25,20 +33,20 @@ jobs:
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios/build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -54,4 +62,4 @@ jobs:
               crypto-ffi/bindings/swift/WireCoreCrypto.xcframework.zip
               crypto-ffi/bindings/swift/WireCoreCryptoUniffi.xcframework.zip
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,10 +19,17 @@ env:
   RELEASE: 1
 
 jobs:
+  # Every `make` artifact key is suffixed with `vars.ARTIFACT_GENERATION`. Resolve that variable
+  # once per run and hand the value to every other job through `needs`, so that producers and
+  # consumers can never disagree about it. See `artifact-generation.yml` for why that matters.
+  artifact-generation:
+    uses: ./.github/workflows/artifact-generation.yml
+
   #################
   # Shared between JVM Linux and Android
 
   uniffi-bindgen-linux:
+    needs: artifact-generation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,9 +37,10 @@ jobs:
       - uses: ./.github/actions/make/uniffi-bindgen
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   ffi-library-linux:
+    needs: artifact-generation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -40,9 +48,10 @@ jobs:
       - uses: ./.github/actions/make/ffi-library
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   ffi-library-macos:
+    needs: artifact-generation
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,17 +59,21 @@ jobs:
       - uses: ./.github/actions/make/ffi-library
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   #################
   # Android
 
   build-android:
+    needs: artifact-generation
     uses: ./.github/workflows/build-android.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   bindings-android:
     runs-on: ubuntu-latest
     needs:
+      - artifact-generation
       - uniffi-bindgen-linux
       - ffi-library-linux
     steps:
@@ -69,24 +82,31 @@ jobs:
       - uses: ./.github/actions/make/android/bindings
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   package-android:
     needs:
+      - artifact-generation
       - bindings-android
       - build-android
     uses: ./.github/workflows/package-android.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   test-android:
     needs:
+      - artifact-generation
       - bindings-android
       - build-android
     uses: ./.github/workflows/test-android.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   #################
   # JVM Darwin
 
   build-jvm-darwin:
+    needs: artifact-generation
     if: github.repository == 'wireapp/core-crypto'
     runs-on: self-hosted
     steps:
@@ -95,12 +115,13 @@ jobs:
       - uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   #################
   # JVM Linux
 
   build-jvm-linux:
+    needs: artifact-generation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,10 +129,11 @@ jobs:
       - uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   bindings-jvm:
     needs:
+      - artifact-generation
       - uniffi-bindgen-linux
       - ffi-library-linux
     runs-on: ubuntu-latest
@@ -121,35 +143,46 @@ jobs:
       - uses: ./.github/actions/make/bindings-kotlin-jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   test-jvm:
     needs:
+      - artifact-generation
       - bindings-jvm
       - build-jvm-linux
       - build-jvm-darwin
     uses: ./.github/workflows/test-jvm.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   check-kotlin:
     needs:
+      - artifact-generation
       - bindings-jvm
       - build-jvm-linux
       - build-jvm-darwin
     uses: ./.github/workflows/kotlin-check.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   docs-jvm:
     needs:
+      - artifact-generation
       - bindings-jvm
       - build-jvm-linux
     uses: ./.github/workflows/docs-jvm.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   check-benchmark-jvm:
     needs:
+      - artifact-generation
       - bindings-jvm
       - build-jvm-linux
       - build-jvm-darwin
     uses: ./.github/workflows/benchmark-jvm.yml
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       publish: false
       benchmark_message_counts: "1"
       benchmark_message_sizes: "16"
@@ -161,19 +194,26 @@ jobs:
 
   test-kmp:
     needs:
+      - artifact-generation
       - ffi-library-linux
       - ffi-library-macos
       - build-jvm-linux
       - build-jvm-darwin
     uses: ./.github/workflows/test-kmp.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   #################
   # iOS/Swift
 
   build-ios:
+    needs: artifact-generation
     uses: ./.github/workflows/build-ios.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   bindings-swift:
+    needs: artifact-generation
     if: github.repository == 'wireapp/core-crypto'
     runs-on: self-hosted
     steps:
@@ -182,30 +222,40 @@ jobs:
       - uses: ./.github/actions/make/bindings-swift
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   package-ios:
     needs:
+      - artifact-generation
       - build-ios
       - bindings-swift
     uses: ./.github/workflows/package-ios.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   test-ios:
     needs:
+      - artifact-generation
       - build-ios
       - bindings-swift
     uses: ./.github/workflows/test-ios.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   docs-swift:
     needs:
+      - artifact-generation
       - build-ios
       - bindings-swift
     uses: ./.github/workflows/docs-swift.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   #################
   # Web
 
   bindings-ts-browser:
+    needs: artifact-generation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -217,9 +267,10 @@ jobs:
         uses: ./.github/actions/make/ts/browser
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   bindings-ts-native-linux:
+    needs: artifact-generation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -231,9 +282,10 @@ jobs:
         uses: ./.github/actions/make/ts/native
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   bindings-ts-native-darwin:
+    needs: artifact-generation
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -245,35 +297,49 @@ jobs:
         uses: ./.github/actions/make/ts/native
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   test-ts-browser:
     needs:
+      - artifact-generation
       - bindings-ts-browser
     uses: ./.github/workflows/test-ts-browser.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   test-ts-native:
     needs:
+      - artifact-generation
       - bindings-ts-native-linux
     uses: ./.github/workflows/test-ts-native.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   check-ts:
     needs:
+      - artifact-generation
       - bindings-ts-browser
       - bindings-ts-native-linux
     uses: ./.github/workflows/check-ts.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   docs-ts:
     needs:
+      - artifact-generation
       - bindings-ts-browser
       - bindings-ts-native-linux
     uses: ./.github/workflows/docs-ts.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   check-benchmark-ts-browser:
     needs:
+      - artifact-generation
       - bindings-ts-browser
     uses: ./.github/workflows/benchmark-ts-browser.yml
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       publish: false
       benchmark_message_counts: "1"
       benchmark_message_sizes: "16"
@@ -282,9 +348,11 @@ jobs:
 
   check-benchmark-ts-native:
     needs:
+      - artifact-generation
       - bindings-ts-native-linux
     uses: ./.github/workflows/benchmark-ts-native.yml
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       publish: false
       benchmark_message_counts: "1"
       benchmark_message_sizes: "16"
@@ -323,6 +391,7 @@ jobs:
   # Cross-platform jobs
 
   build-interop:
+    needs: artifact-generation
     if: github.repository == 'wireapp/core-crypto'
     runs-on: macos-latest
     steps:
@@ -333,10 +402,11 @@ jobs:
       - uses: ./.github/actions/make/interop/build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ needs.artifact-generation.outputs.generation }}
 
   e2e-interop-test:
     needs:
+      - artifact-generation
       - build-ios
       - bindings-swift
       - bindings-ts-browser
@@ -344,6 +414,8 @@ jobs:
       - build-android
       - build-interop
     uses: ./.github/workflows/interop.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   deploy-docs:
     needs:
@@ -359,6 +431,7 @@ jobs:
 
   prepare-publish:
     needs:
+      - artifact-generation
       - package-ios
       - package-android
       - bindings-ts-browser
@@ -369,6 +442,8 @@ jobs:
       - bindings-jvm
     if: github.ref_type == 'tag'
     uses: ./.github/workflows/prepare-publish.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -425,14 +500,21 @@ jobs:
           pgp-passphrase: ${{ secrets.PGP_PASSPHRASE }}
 
   publish-ios:
-    needs: prepare-publish
+    needs:
+      - prepare-publish
+      - artifact-generation
     uses: ./.github/workflows/publish-swift.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
 
   publish-npm:
-    needs: prepare-publish
+    needs:
+      - prepare-publish
+      - artifact-generation
     uses: ./.github/workflows/publish-npm.yml
     permissions:
       id-token: write
       contents: write
     with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
       release: true

--- a/.github/workflows/prepare-publish-android.yml
+++ b/.github/workflows/prepare-publish-android.yml
@@ -5,6 +5,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
     secrets:
       SONATYPE_USERNAME:
         required: true
@@ -53,7 +61,7 @@ jobs:
         uses: ./.github/actions/make/android/package
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: stage artifact in sonatype
         id: stage

--- a/.github/workflows/prepare-publish-jvm.yml
+++ b/.github/workflows/prepare-publish-jvm.yml
@@ -5,6 +5,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
     secrets:
       SONATYPE_USERNAME:
         required: true
@@ -50,13 +58,13 @@ jobs:
         uses: ./.github/actions/make/bindings-kotlin-jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download x86_64 linux artifact
         uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
       # Because this workflow runs on ubuntu, we're using the generic action
@@ -67,7 +75,7 @@ jobs:
           make-rule: jvm-darwin
           target-path: target/aarch64-apple-darwin/release/libcore_crypto_ffi.dylib
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: stage artifact in sonatype
         id: stage

--- a/.github/workflows/prepare-publish-kmp.yml
+++ b/.github/workflows/prepare-publish-kmp.yml
@@ -5,6 +5,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
     secrets:
       SONATYPE_USERNAME:
         required: true
@@ -50,48 +58,48 @@ jobs:
         uses: ./.github/actions/make/ffi-library
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download armv7-linux-androideabi binaries
         uses: ./.github/actions/make/android/lib
         with:
           task: android-armv7
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download aarch64-linux-android binaries
         uses: ./.github/actions/make/android/lib
         with:
           task: android-armv8
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download x86_64-linux-android binaries
         uses: ./.github/actions/make/android/lib
         with:
           task: android-x86
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download artifacts for ios device
         uses: ./.github/actions/make/ios/build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios/build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download aarch64 apple darwin artifact
         uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
       # Because this workflow runs on macOS, we're using the generic action
@@ -102,7 +110,7 @@ jobs:
           make-rule: jvm-linux
           target-path: target/x86_64-unknown-linux-gnu/release/libcore_crypto_ffi.a
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: stage artifact in sonatype
         id: stage

--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -2,6 +2,14 @@ name: prepare publish
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
     outputs:
       jvm_staging_repository_id:
         description: "Sonatype staging repository id staged for the jvm packages."
@@ -86,6 +94,8 @@ jobs:
   jvm:
     needs: verify-tag
     uses: ./.github/workflows/prepare-publish-jvm.yml
+    with:
+      artifact_generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -96,6 +106,8 @@ jobs:
   android:
     needs: verify-tag
     uses: ./.github/workflows/prepare-publish-android.yml
+    with:
+      artifact_generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -106,6 +118,8 @@ jobs:
   kmp:
     needs: verify-tag
     uses: ./.github/workflows/prepare-publish-kmp.yml
+    with:
+      artifact_generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -118,3 +132,4 @@ jobs:
     uses: ./.github/workflows/publish-npm.yml
     with:
       prepare: true
+      artifact_generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set tag name
         id: set-tag
-        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Force fetch the tag
         run: git fetch -f origin "$GITHUB_REF:$GITHUB_REF"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -147,6 +147,6 @@ jobs:
 
       - name: delete package from gh release
         if: ${{ inputs.release == true }}
-        run: gh release delete-asset $GITHUB_REF_NAME "${{ steps.tarball.outputs.filename }}" --yes
+        run: gh release delete-asset "$GITHUB_REF_NAME" "${{ steps.tarball.outputs.filename }}" --yes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -101,7 +101,9 @@ jobs:
         run: |
           cd crypto-ffi/bindings/js/packages/core-crypto
           gh release download "$GH_REF_NAME" --pattern "*.tgz" --dir . 2>/dev/null || true
-          filename=$(ls *.tgz 2>/dev/null | head -n 1)
+          shopt -s nullglob
+          tarballs=(*.tgz)
+          filename="${tarballs[0]-}"
           if [[ -z "$filename" ]]; then
             echo "::error ::No npm tarball found in release '$GH_REF_NAME'"
             exit 1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,6 +10,13 @@ permissions:
 on:
   workflow_call:
     inputs:
+        artifact_generation:
+          description: >
+            Artifact key generation suffix, pinned by the caller so that every job in a run
+            agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+            invoked directly.
+          required: false
+          type: string
         prepare:
           description: "If true, stage and validate artifacts."
           required: false
@@ -50,7 +57,7 @@ jobs:
         uses: ./.github/actions/make/ts/browser
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       # Note that for make/mtime reasons, we _must_ download native apple artifacts before
       # downloading native linux artifacts, otherwise the "package" step will trigger
@@ -64,14 +71,14 @@ jobs:
           target-path: |
             crypto-ffi/bindings/js/packages/core-crypto/dist/native/libcore_crypto_ffi.dylib
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download ts native linux artifacts
         if: ${{ inputs.prepare == true }}
         uses: ./.github/actions/make/ts/native
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: package tarball
         if: ${{ inputs.prepare == true }}

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -5,6 +5,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
 
 env:
   RELEASE: 1
@@ -23,20 +31,20 @@ jobs:
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-device
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download artifacts for ios simulator
         uses: ./.github/actions/make/ios/build
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           task: ios-simulator-arm
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download swift bindings
         uses: ./.github/actions/make/bindings-swift
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download xcframework
         uses: ./.github/actions/make
@@ -47,7 +55,7 @@ jobs:
               crypto-ffi/bindings/swift/WireCoreCrypto.xcframework.zip
               crypto-ffi/bindings/swift/WireCoreCryptoUniffi.xcframework.zip
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: upload xcframework
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -280,7 +280,9 @@ jobs:
         id: download
         run: |
           gh release download "$TAG" --pattern "*.tgz" --dir . 2>/dev/null || true
-          filename=$(ls *.tgz 2>/dev/null | head -n 1)
+          shopt -s nullglob
+          tarballs=(*.tgz)
+          filename="${tarballs[0]-}"
           if [[ -z "$filename" ]]; then
             echo "No npm tarball found in release '$TAG' — already published or never uploaded"
             echo "found=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,10 @@ env:
   RELEASE: 1
 
 jobs:
+  # Pin the artifact key generation for the whole run; see `artifact-generation.yml`.
+  artifact-generation:
+    uses: ./.github/workflows/artifact-generation.yml
+
   # For JVM/Android we use Sonatype's two-phase staging model.
   # 'prepare' uploads to a staging repo and closes it (validation happens here).
   # 'release' finds the closed staging repo and promotes it to Maven Central.
@@ -56,7 +60,10 @@ jobs:
     if: >
       (inputs.registry == 'all' || inputs.registry == 'jvm') &&
       inputs.sonatype-action == 'prepare-and-release'
+    needs: artifact-generation
     uses: ./.github/workflows/prepare-publish-jvm.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -120,7 +127,10 @@ jobs:
     if: >
       (inputs.registry == 'all' || inputs.registry == 'android') &&
       inputs.sonatype-action == 'prepare-and-release'
+    needs: artifact-generation
     uses: ./.github/workflows/prepare-publish-android.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -184,7 +194,10 @@ jobs:
     if: >
       (inputs.registry == 'all' || inputs.registry == 'kmp') &&
       inputs.sonatype-action == 'prepare-and-release'
+    needs: artifact-generation
     uses: ./.github/workflows/prepare-publish-kmp.yml
+    with:
+      artifact_generation: ${{ needs.artifact-generation.outputs.generation }}
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,10 @@ on:
           - npm
           - jvm
           - android
+          - kmp
       sonatype-action:
         description: >
-          For JVM/Android: 'release' promotes an existing closed staging repository.
+          For JVM/Android/KMP: 'release' promotes an existing closed staging repository.
           'prepare-and-release' re-stages from scratch first (requires workflow
           artifacts from the original run to still be available).
         required: false
@@ -36,6 +37,13 @@ on:
         type: string
         default: ""
       android-staging-repository-id:
+        description: >
+          Required when 'sonatype-action' is 'release'.
+          In that case, you must manually specify the sonatype repository id which will be promoted.
+        required: false
+        type: string
+        default: ""
+      kmp-staging-repository-id:
         description: >
           Required when 'sonatype-action' is 'release'.
           In that case, you must manually specify the sonatype repository id which will be promoted.

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -39,4 +47,4 @@ jobs:
         with:
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 defaults:
@@ -48,7 +56,7 @@ jobs:
         with:
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: Delete simulator
         if: always()

--- a/.github/workflows/test-jvm.yml
+++ b/.github/workflows/test-jvm.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -32,7 +40,7 @@ jobs:
         uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       # The specific jvm action uses `uname -s` to determine which `jvm` make rule to call.
       # Because this workflow runs on ubuntu, we're using the generic action
@@ -43,13 +51,13 @@ jobs:
           make-rule: jvm-darwin
           target-path: target/aarch64-apple-darwin/release/libcore_crypto_ffi.dylib
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download kotlin bindings
         uses: ./.github/actions/make/bindings-kotlin-jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: build and test jvm package
         uses: ./.github/actions/make
@@ -58,4 +66,4 @@ jobs:
           make-rule: jvm-test
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/test-kmp.yml
+++ b/.github/workflows/test-kmp.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -35,13 +43,13 @@ jobs:
         uses: ./.github/actions/make/ffi-library
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: download platform jvm library
         uses: ./.github/actions/make/jvm
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: build and test kmp package
         uses: ./.github/actions/make
@@ -50,4 +58,4 @@ jobs:
           make-rule: kmp-jvm-test
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/test-ts-browser.yml
+++ b/.github/workflows/test-ts-browser.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -30,7 +38,7 @@ jobs:
         uses: ./.github/actions/make/ts/browser
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: install chrome via puppeteer
         run: |
@@ -50,4 +58,4 @@ jobs:
           make-rule: ts-browser-test
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/.github/workflows/test-ts-native.yml
+++ b/.github/workflows/test-ts-native.yml
@@ -4,6 +4,14 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      artifact_generation:
+        description: >
+          Artifact key generation suffix, pinned by the caller so that every job in a run
+          agrees on it. Falls back to `vars.ARTIFACT_GENERATION` when this workflow is
+          invoked directly.
+        required: false
+        type: string
   workflow_dispatch:
 
 env:
@@ -26,7 +34,7 @@ jobs:
         uses: ./.github/actions/make/ts/native
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}
 
       - name: test
         uses: ./.github/actions/make
@@ -35,4 +43,4 @@ jobs:
           make-rule: ts-native-test
           always-run: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-generation: ${{ vars.ARTIFACT_GENERATION }}
+          artifact-generation: ${{ inputs.artifact_generation || vars.ARTIFACT_GENERATION }}

--- a/make/ts.mk
+++ b/make/ts.mk
@@ -72,7 +72,52 @@ $(WASM_FFI_LIB) $(BROWSER_TS_IMPL) $(RUST_MODULES_STAMP) &: $(ubrn-deps)
 $(RUST_MODULES_CARGO_LOCK): Cargo.lock $(RUST_MODULES_STAMP)
 	cp Cargo.lock $(RUST_MODULES_CARGO_LOCK)
 
+# The wasm build compiles a C shim (sqlite-wasm-rs), so it needs a clang whose WebAssembly
+# backend was compiled in. Apple clang's was not, which is why CI restores $(WASM_GEN) from an
+# artifact on macOS rather than building it there. When that restore misses, the build used to
+# spend minutes compiling Rust before dying deep inside a cc-rs invocation, naming neither the
+# real constraint nor the missed artifact. Probe the compiler up front instead.
+#
+# Resolve the compiler the way cc-rs does, so we probe what the build would really use. `CC` needs
+# the `origin` guard because make defines it whether or not anyone asked for it.
+WASM_CC := $(firstword \
+	$(CC_wasm32_unknown_unknown) \
+	$(CC_wasm32-unknown-unknown) \
+	$(TARGET_CC) \
+	$(if $(filter-out default,$(origin CC)),$(CC)) \
+	clang)
+
+define check-wasm-cc
+@if ! probe=$$($(WASM_CC) --target=$(WASM_TARGET_TRIPLE) -c -x c /dev/null -o /dev/null 2>&1); then \
+	printf '%s\n' \
+	  '' \
+	  "cannot build $(WASM_TARGET_TRIPLE): '$(WASM_CC)' has no usable WebAssembly backend" \
+	  '' \
+	  "$$probe" \
+	  '' \
+	  'This build compiles a C shim (sqlite-wasm-rs) for wasm, so it needs a clang built with' \
+	  'the WebAssembly backend. Apple clang lacks it, so macOS cannot build wasm by default.' \
+	  '' \
+	  'In CI, getting here means the wasm-build artifact was not restored, so the fetch-or-build' \
+	  'fallback tried to build wasm on a runner that cannot. Check the "Download artifact" step' \
+	  'of the make/ts/browser action: the job that produces the artifact must have run in this' \
+	  'workflow run, under the same artifact generation.' \
+	  '' \
+	  'Locally, install a wasm-capable clang and point the build at it:' \
+	  '  brew install llvm' \
+	  '  export CC_wasm32_unknown_unknown="$$(brew --prefix llvm)/bin/clang"' \
+	  '' \
+	  >&2; \
+	if [ -n "$${GITHUB_ACTIONS:-}" ]; then \
+	  printf '::error title=cannot build wasm here::%s\n' \
+	    "'$(WASM_CC)' cannot target $(WASM_TARGET_TRIPLE); the wasm-build artifact was not restored, see the job log"; \
+	fi; \
+	exit 1; \
+fi
+endef
+
 $(WASM_FILE): $(RUST_MODULES_CARGO_LOCK) $(RUST_MODULES_STAMP) $(JS_DIR)/Cargo.rust-modules.toml
+	$(check-wasm-cc)
 	cd $(RUST_MODULES_WASM) && \
 	RUSTFLAGS="$(WASM_BUILD_RUSTFLAGS)" cargo build --target $(WASM_TARGET_TRIPLE) $(CARGO_BUILD_ARGS)
 
@@ -103,6 +148,7 @@ $(WASM_GEN) &: $(wasm-build-deps)
 # With Rust 1.97's v0 mangling, wasm-bindgen's demangler can map distinct symbols to
 # the same generated export name. Stable Rust cannot opt back into legacy mangling.
 # See https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#symbol-mangling-v0-enabled-by-default
+	$(check-wasm-cc)
 	$(MAKE) $(WASM_FILE)
 	cd $(JS_DIR) && \
 	wasm-bindgen --target web \


### PR DESCRIPTION
Several misc improvements to CI intended to make slow failures into fast failures.
Also, turns out there's a linter for GHA, so fix what it reports, then include it.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
