### PR TITLE
refactor(crypto/crypto-ffi): identities don't have a natural order

### DIFF
--- a/crypto/src/identity.rs
+++ b/crypto/src/identity.rs
@@ -6,7 +6,7 @@ use crate::{ClientId, CredentialType, RecursiveError};
 
 /// Represents the identity claims identifying a client
 /// Those claims are verifiable by any member in the group
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WireIdentity {
     /// Unique client identifier e.g. `T4Coy4vdRzianwfOgXpn6A:6add501bacd1d90e@whitehouse.gov`
     pub client_id: Option<ClientId>,
@@ -24,7 +24,7 @@ pub struct WireIdentity {
 ///
 /// We don't use an enum here since the sole purpose of this is to be exposed through the FFI (and
 /// union types are impossible to carry over the FFI boundary)
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct X509Identity {
     /// user handle e.g. `john_wire`
     pub handle: String,

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -250,41 +250,37 @@ mod tests {
         #[macro_rules_attribute::apply(smol_macros::test)]
         async fn should_not_fail_when_basic() {
             let case = TestContext::default();
-
             let [alice_android, alice_ios] = case.sessions().await;
-            Box::pin(async move {
-                let conversation = case.create_conversation([&alice_android, &alice_ios]).await;
+            let conversation = case.create_conversation([&alice_android, &alice_ios]).await;
 
-                let (android_id, ios_id) = (alice_android.get_client_id().await, alice_ios.get_client_id().await);
+            let (android_id, ios_id) = (alice_android.get_client_id().await, alice_ios.get_client_id().await);
 
-                let mut android_ids = conversation
-                    .guard()
-                    .await
-                    .get_device_identities(&[android_id.clone(), ios_id.clone()])
-                    .await
-                    .unwrap();
-                android_ids.sort();
+            let mut android_ids = conversation
+                .guard()
+                .await
+                .get_device_identities(&[android_id.clone(), ios_id.clone()])
+                .await
+                .unwrap();
+            android_ids.sort_by_key(|id| id.client_id.clone());
 
-                let mut ios_ids = conversation
-                    .guard_of(&alice_ios)
-                    .await
-                    .get_device_identities(&[android_id, ios_id])
-                    .await
-                    .unwrap();
-                ios_ids.sort();
+            let mut ios_ids = conversation
+                .guard_of(&alice_ios)
+                .await
+                .get_device_identities(&[android_id, ios_id])
+                .await
+                .unwrap();
+            ios_ids.sort_by_key(|id| id.client_id.clone());
 
-                assert_eq!(ios_ids.len(), 2);
-                assert_eq!(ios_ids, android_ids);
+            assert_eq!(ios_ids.len(), 2);
+            assert_eq!(ios_ids, android_ids);
 
-                assert!(ios_ids.iter().all(|i| {
-                    matches!(i.credential_type, CredentialType::Basic)
-                        && matches!(i.status, IdentityStatus::Valid)
-                        && i.x509_identity.is_none()
-                        && !i.thumbprint.is_empty()
-                        && i.client_id.is_some()
-                }));
-            })
-            .await
+            assert!(ios_ids.iter().all(|i| {
+                matches!(i.credential_type, CredentialType::Basic)
+                    && matches!(i.status, IdentityStatus::Valid)
+                    && i.x509_identity.is_none()
+                    && !i.thumbprint.is_empty()
+                    && i.client_id.is_some()
+            }));
         }
 
         #[macro_rules_attribute::apply(smol_macros::test)]

--- a/crypto/src/mls/credential/credential_type.rs
+++ b/crypto/src/mls/credential/credential_type.rs
@@ -3,7 +3,7 @@ use openmls::prelude::CredentialType as MlsCredentialType;
 use super::Error;
 
 /// All supported Credential types.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum CredentialType {
     /// Basic credential i.e. a KeyPair
     #[default]

--- a/e2e-identity/src/x509_check/mod.rs
+++ b/e2e-identity/src/x509_check/mod.rs
@@ -50,7 +50,7 @@ impl From<certval::Error> for RustyX509CheckError {
 
 pub type RustyX509CheckResult<T> = Result<T, RustyX509CheckError>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IdentityStatus {
     /// All is fine
     Valid,


### PR DESCRIPTION
Note: this is not a breaking change, because uniffi doesn't by default export derived traits.