### PR TITLE
chore: speed up slow tests [WPB-28455]

### DIFF
--- a/cc-book/src/cc10/migration-guide.md
+++ b/cc-book/src/cc10/migration-guide.md
@@ -87,11 +87,6 @@ recent credential of a given type and cipher suite, clients can simply choose th
 1. Register the credential with `transactionContext.addCredential(credential)`. This persists it and returns a
    `CredentialRef`: a compact, stable handle you pass to the rest of the API in place of the old selector pair.
 
-   - Credentials registered with a single client must be distinct on the
-     `(credentialType, signatureScheme, creation timestamp)` tuple, where the timestamp has one-second resolution. If
-     you need several credentials sharing a type and signature scheme, wait one full second between registering each. We
-     expect to relax this limitation in the future.
-
 1. On MLS initialization, previously stored credentials are loaded automatically. Enumerate them with
    `getCredentials()`, or filter with `findCredentials(...)`, to recover their `CredentialRef`s.
 

--- a/cc-book/src/release_notes.md
+++ b/cc-book/src/release_notes.md
@@ -15,6 +15,11 @@
   group member specifically. This enables the long-awaited read receipts feature for MLS. Regular MLS messages aren't a
   good fit for read receipts because of the massive amount of irrelevant messages that would need to be distributed.
 
+- The documentation for `addCredential` previously stated that credentials registered with a single client must be
+  distinct in credential type, signature scheme, and creation timestamp, and that you therefore had to wait a full
+  second between registrations. This was never true of any released version; we fixed it before releasing 10.0.0. If you
+  added a delay between `addCredential` calls to comply, you can remove it.
+
 ## CoreCrypto 10
 
 ### v10.5.2 - 2026-09-09

--- a/crypto-ffi/src/core_crypto_context/mls.rs
+++ b/crypto-ffi/src/core_crypto_context/mls.rs
@@ -361,12 +361,6 @@ impl CoreCryptoContext {
     }
 
     /// Adds a `Credential` to this client.
-    ///
-    /// Note that while an arbitrary number of credentials can be generated,
-    /// those which are added to a CoreCrypto instance must be distinct in credential type,
-    /// signature scheme, and the timestamp of creation. This timestamp has only
-    /// 1 second of resolution, limiting the number of credentials which
-    /// can be added. This is a known limitation and will be relaxed in the future.
     pub async fn add_credential(&self, credential: Arc<Credential>) -> CoreCryptoResult<CredentialRef> {
         let credential = std::sync::Arc::unwrap_or_clone(credential);
         let credential_ref = self.inner.add_credential(credential.0).await?;

--- a/crypto/src/mls/conversation/group_metadata.rs
+++ b/crypto/src/mls/conversation/group_metadata.rs
@@ -210,7 +210,8 @@ mod tests {
     /// conversation, so it is gone by the time `decrypt_message` returns. What is observable, and
     /// what this shape used to break, is that the eviction goes through at all.
     #[apply(all_cred_cipher)]
-    async fn eviction_succeeds_when_our_leaf_slot_is_recycled(case: TestContext) {
+    async fn eviction_succeeds_when_our_leaf_slot_is_recycled(mut case: TestContext) {
+        case.sessions_in_memory = true;
         const ALL_MEMBERS_COUNT: usize = 7;
         const INITIAL_MEMBERS_COUNT: usize = 6;
         const REMAINING_MEMBERS_COUNT: usize = 4;

--- a/crypto/src/mls/conversation/mod.rs
+++ b/crypto/src/mls/conversation/mod.rs
@@ -79,7 +79,8 @@ mod tests {
     }
 
     #[apply(all_cred_cipher)]
-    pub async fn create_many_people_conversation(case: TestContext) {
+    pub async fn create_many_people_conversation(mut case: TestContext) {
+        case.sessions_in_memory = true;
         const SIZE_PLUS_1: usize = GROUP_SAMPLE_SIZE + 1;
         let alice_and_friends = case.sessions::<SIZE_PLUS_1>().await;
         Box::pin(async move {

--- a/crypto/src/mls/conversation/mutable/decrypt/buffer_messages.rs
+++ b/crypto/src/mls/conversation/mutable/decrypt/buffer_messages.rs
@@ -452,6 +452,7 @@ mod tests {
             return;
         }
 
+        case.sessions_in_memory = true;
         let [external_0, new_member, member_27, observer, member_114, member_115] = case.sessions().await;
         Box::pin(async move {
             // set up external_0 as the backend / delivery service

--- a/crypto/src/mls/conversation/mutable/history_sharing.rs
+++ b/crypto/src/mls/conversation/mutable/history_sharing.rs
@@ -300,7 +300,8 @@ mod tests {
     #[apply(all_cred_cipher)]
     /// In this test, we're testing our mls library. However, our current mls fork doesn't have this test, and we
     /// require this behavior for history sharing, that's why this test lives here, for now.
-    async fn can_remove_two_and_add_one_member_in_commit(case: TestContext) {
+    async fn can_remove_two_and_add_one_member_in_commit(mut case: TestContext) {
+        case.sessions_in_memory = true;
         // This many members are initially in the conversation.
         const INITIAL_MEMBERS_COUNT: usize = 6;
         // This many members are removed from the conversation.

--- a/crypto/src/mls/conversation/mutable/own_commit.rs
+++ b/crypto/src/mls/conversation/mutable/own_commit.rs
@@ -135,11 +135,6 @@ mod tests {
             // In this case Alice will try to rotate her credential but her commit will be denied
             // by the backend (because another commit from Bob had precedence)
 
-            // all credentials need to be distinguishable by type, scheme, and timestamp
-            // we need to wait a second so the new credential has a distinct timestamp
-            // (our DB has a timestamp resolution of 1s)
-            smol::Timer::after(std::time::Duration::from_secs(1)).await;
-
             // Alice creates a new Credential, updating her handle/display_name
             let (new_handle, new_display_name) = ("new_alice_wire", "New Alice Smith");
             let credential = alice

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -339,8 +339,12 @@ mod tests {
             let alice_cred = Credential::x509(case.cipher_suite(), alice_cert).unwrap();
             let bob_cert = x509_test_chain.issue_simple_certificate_bundle("bob", Some(expiration_time));
             let bob_cred = Credential::x509(case.cipher_suite(), bob_cert).unwrap();
-            let alice = SessionContext::new_with_credential(&case, alice_cred).await.unwrap();
-            let bob = SessionContext::new_with_credential(&case, bob_cred).await.unwrap();
+            let alice = SessionContext::new_with_credential(&case, alice_cred, case.sessions_in_memory)
+                .await
+                .unwrap();
+            let bob = SessionContext::new_with_credential(&case, bob_cred, case.sessions_in_memory)
+                .await
+                .unwrap();
 
             let conversation = case.create_conversation([&alice, &bob]).await;
             // this should work since the certificate is not yet expired

--- a/crypto/src/mls/credential/mod.rs
+++ b/crypto/src/mls/credential/mod.rs
@@ -332,7 +332,7 @@ mod tests {
         }
         Box::pin(async move {
             let mut x509_test_chain = case.set_test_chain(&[], &[], None).await;
-            let expiration_time = core::time::Duration::from_secs(14);
+            let expiration_time = core::time::Duration::from_secs(5);
             let start = web_time::Instant::now();
 
             let alice_cert = x509_test_chain.issue_simple_certificate_bundle("alice", None);
@@ -354,7 +354,7 @@ mod tests {
             let elapsed = start.elapsed();
             // Give time to the certificate to expire
             if expiration_time > elapsed {
-                smol::Timer::after(expiration_time - elapsed + core::time::Duration::from_secs(2)).await;
+                smol::Timer::after(expiration_time - elapsed + core::time::Duration::from_secs(1)).await;
             }
 
             assert!(conversation.is_functional_and_contains([&alice, &bob]).await);

--- a/crypto/src/test_utils/mod.rs
+++ b/crypto/src/test_utils/mod.rs
@@ -97,17 +97,28 @@ pub struct SessionContext {
     core_crypto: Arc<CoreCrypto>,
     // We need to store the `TempDir` struct for the duration of the test session,
     // because its drop implementation takes care of the directory deletion.
-    _db: Option<(Arc<Database>, Arc<tempfile::TempDir>)>,
+    _db_dir: Option<Arc<tempfile::TempDir>>,
 }
 
 impl SessionContext {
     /// Use this if you want to instantiate a session with a credential different from
     /// the default one of the test context
-    pub async fn new_with_credential(context: &TestContext, credential: Credential) -> crate::Result<Self> {
-        // We need to store the `TempDir` struct for the duration of the test session,
-        // because its drop implementation takes care of the directory deletion.
-        let (db_path, db_dir) = tmp_db_file();
-        let db = Database::open(&db_path, &DatabaseKey::generate()).await.unwrap();
+    ///
+    /// `in_memory` controls whether the database is a "real" one on disc, or a transient one in memory.
+    pub async fn new_with_credential(
+        context: &TestContext,
+        credential: Credential,
+        in_memory: bool,
+    ) -> crate::Result<Self> {
+        let (db_dir, db) = if in_memory {
+            (None, Database::open_in_memory().unwrap())
+        } else {
+            // We need to store the `TempDir` struct for the duration of the test session,
+            // because its drop implementation takes care of the directory deletion.
+            let (db_path, db_dir) = tmp_db_file();
+            let db = Database::open(&db_path, &DatabaseKey::generate()).await.unwrap();
+            (Some(Arc::new(db_dir)), db)
+        };
 
         let core_crypto = CoreCrypto::new(db.clone());
         let transaction = core_crypto.new_transaction().await.unwrap();
@@ -141,7 +152,7 @@ impl SessionContext {
             x509_test_chain: Arc::new(maybe_chain),
             history_observer: Default::default(),
             core_crypto,
-            _db: Some((db, db_dir.into())),
+            _db_dir: db_dir,
         };
         Ok(session_context)
     }
@@ -173,7 +184,7 @@ impl SessionContext {
             x509_test_chain: Arc::new(maybe_chain),
             history_observer: Default::default(),
             core_crypto,
-            _db: None,
+            _db_dir: None,
         }
     }
 

--- a/crypto/src/test_utils/test_context.rs
+++ b/crypto/src/test_utils/test_context.rs
@@ -78,6 +78,10 @@ pub struct TestContext {
     pub transport: Arc<dyn MlsTransportTestExt>,
     pub db: Option<(Arc<Database>, Option<Arc<tempfile::TempDir>>)>,
     pub chain: Arc<RwLock<Option<X509TestChain>>>,
+    /// When `true`, sessions created by this test context will use in-memory databases.
+    ///
+    /// This can substantially speed up initialization of multiple sessions.
+    pub sessions_in_memory: bool,
 }
 
 impl TestContext {
@@ -295,7 +299,11 @@ impl TestContext {
         };
         let mut sessions = Vec::with_capacity(N);
         for credential in credentials {
-            sessions.push(SessionContext::new_with_credential(self, credential).await.unwrap());
+            sessions.push(
+                SessionContext::new_with_credential(self, credential, self.sessions_in_memory)
+                    .await
+                    .unwrap(),
+            );
         }
         sessions.try_into().expect("Vector should be of length N.")
     }
@@ -378,6 +386,7 @@ impl Default for TestContext {
             transport: Arc::<CoreCryptoTransportSuccessProvider>::default(),
             db: None,
             chain: Arc::default(),
+            sessions_in_memory: false,
         }
     }
 }

--- a/crypto/src/test_utils/test_conversation/mod.rs
+++ b/crypto/src/test_utils/test_conversation/mod.rs
@@ -158,7 +158,7 @@ impl<'a> TestConversation<'a> {
         let result_futures = self.members().enumerate().flat_map(|(idx, member)| {
             self.members()
                 .enumerate()
-                .filter(move |(other_idx, _)| idx != *other_idx)
+                .filter(move |(other_idx, _)| idx < *other_idx)
                 .map(async move |(_, other_member)| self.can_talk(member, other_member).await)
         });
 

--- a/crypto/src/transaction_context/e2e_identity/conversation_state.rs
+++ b/crypto/src/transaction_context/e2e_identity/conversation_state.rs
@@ -161,9 +161,6 @@ mod tests {
             let expiration_time = core::time::Duration::from_secs(14);
             let start = web_time::Instant::now();
 
-            // delay a bit so we don't get a credential conflict when adding this credential to alice
-            smol::Timer::after(std::time::Duration::from_secs(1)).await;
-
             let intermediate_ca = alice.x509_chain_unchecked().find_local_intermediate_ca();
             // this completely invents a new client id for alice, which gets propagated into the credential
             let cert = CertificateBundle::new_with_default_values(intermediate_ca, Some(expiration_time));

--- a/crypto/src/transaction_context/e2e_identity/conversation_state.rs
+++ b/crypto/src/transaction_context/e2e_identity/conversation_state.rs
@@ -158,7 +158,9 @@ mod tests {
         Box::pin(async move {
             let conversation = case.create_conversation([&alice, &bob]).await;
 
-            let expiration_time = core::time::Duration::from_secs(14);
+            // on my local machine this passes with values as low as 2 seconds,
+            // but this also needs to pass on a presumably-congested CI machine
+            let expiration_time = core::time::Duration::from_secs(5);
             let start = web_time::Instant::now();
 
             let intermediate_ca = alice.x509_chain_unchecked().find_local_intermediate_ca();

--- a/keystore/src/connection/migrations/mod.rs
+++ b/keystore/src/connection/migrations/mod.rs
@@ -7,11 +7,18 @@ use crate::{CryptoKeystoreResult, DatabaseKey};
 
 refinery::embed_migrations!("src/connection/migrations");
 
+const COMPOSITE_SCHEMA: &str = include_str!("../composite-schema.sql");
+
 #[derive(Default)]
 pub(crate) enum MigrationTarget {
+    /// Perform all migrations
     #[default]
     Latest,
+    /// Perform all migrations up to the specified version
     Version(u16),
+    /// Execute the composite schema, producing the final form of the database without going through each individual
+    /// migration.
+    Composite,
 }
 
 pub(super) fn run_migrations(conn: &mut rusqlite::Connection, target: MigrationTarget) -> CryptoKeystoreResult<()> {
@@ -34,6 +41,11 @@ pub(super) fn run_migrations(conn: &mut rusqlite::Connection, target: MigrationT
     let target_version = match target {
         MigrationTarget::Latest => latest_migration_version,
         MigrationTarget::Version(target_argument) => (latest_migration_version).min(target_argument as i32),
+        MigrationTarget::Composite => {
+            conn.execute_batch(COMPOSITE_SCHEMA)?;
+            conn.pragma_update(None, "user_version", latest_migration_version)?;
+            return Ok(());
+        }
     };
 
     // This version is known to have an additional newline in some releases, but the actual migration work is

--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -151,7 +151,7 @@ impl Database {
     /// In-memory databases are never encrypted.
     pub fn open_in_memory() -> CryptoKeystoreResult<Arc<Self>> {
         let connection = Connection::open_in_memory()?;
-        Self::init(connection, Box::new(filesystem::Nop), MigrationTarget::Latest).map(Into::into)
+        Self::init(connection, Box::new(filesystem::Nop), MigrationTarget::Composite).map(Into::into)
     }
 
     /// Open an encrypted `Database` at the provided location.

--- a/keystore/tests/searchable_entities.rs
+++ b/keystore/tests/searchable_entities.rs
@@ -182,8 +182,6 @@ mod stored_credential {
         );
     }
 
-    // we don't have a good way to just delay for a second in wasm, so skip this test which relies on that behavior
-    #[cfg(not(target_os = "unknown"))]
     #[apply(all_storage_types)]
     async fn search_finds_only_entities_with_matching_search_key(context: KeystoreTestContext) {
         let store = context.store();
@@ -195,11 +193,10 @@ mod stored_credential {
         irrelevant_entity.ciphersuite = relevant_entity.ciphersuite + 1;
 
         let tx = store.new_transaction().await.unwrap();
-        for entity in [&mut relevant_entity, &mut irrelevant_entity] {
-            entity.pre_save().unwrap();
+        for (idx, entity) in [&mut relevant_entity, &mut irrelevant_entity].into_iter().enumerate() {
+            // we don't care about real creation times for the purpose of this test, just that we can search effectively
+            entity.created_at = idx as _;
             entity.save(&*tx).unwrap();
-            // ensure the entities are created in different seconds so they don't accidentally match
-            smol::Timer::after(std::time::Duration::from_secs(1)).await;
         }
         tx.commit().await.unwrap();
 


### PR DESCRIPTION
As a bonus, point out in an explicit release note that we never did actually need clients to space out their credentials--by the time we released 10.0, that limitation was already obsolete.