### PR TITLE
chore(test/ts): increase timeout

### DIFF
--- a/crypto-ffi/bindings/js/package.json
+++ b/crypto-ffi/bindings/js/package.json
@@ -54,6 +54,9 @@
         "uniffi-bindgen-react-native": "^0.31.0-5",
         "yarn": "^1.22.22"
     },
+    "mocha": {
+        "timeout": 5000
+    },
     "trustedDependencies": [
         "uniffi-bindgen-react-native"
     ]


### PR DESCRIPTION
The default timeout of 2000 ms was exceeded occasionally which made our ts tests flaky in CI.