### PR TITLE
chore(keystore): unconditionally explicitly enable foreign keys

### DIFF
--- a/keystore/src/connection/mod.rs
+++ b/keystore/src/connection/mod.rs
@@ -111,6 +111,7 @@ impl Database {
     ) -> CryptoKeystoreResult<Self> {
         #[cfg(feature = "log-queries")]
         conn.trace_v2(TraceEventCodes::SQLITE_TRACE_STMT, Some(log_query));
+        conn.pragma_update(None, "foreign_keys", "ON")?;
 
         // path is an empty string for in-memory databases
         if let Some(path) = conn.path()


### PR DESCRIPTION
This is redundant on native platforms where it is the default, but was not previously enabled on web, which uses a different sqlite backend.

We make it explicit and universal here, since we always want this behavior.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
