### PR TITLE
chore(keystore): do not clobber `user_version` in ios [WPB-28638]

### DIFF
--- a/keystore/src/connection/ios_wal_compat.rs
+++ b/keystore/src/connection/ios_wal_compat.rs
@@ -70,9 +70,13 @@ pub(crate) fn handle_ios_wal_compat(conn: &rusqlite::Connection, path: &str) -> 
     // Do not encrypt first 32 bytes of the database, so the header can be read by iOS.
     conn.pragma_update(None, "cipher_plaintext_header_size", 32)?;
 
-    // This is needed to trigger a write of the first database page, which is necessary due
-    // to us changing cipher_plaintext_header_size.
-    conn.pragma_update(None, "user_version", 2u32)?;
+    // cipher_plaintext_header_size operates in-memory only, until the first DB page is rewritten.
+    // We can trigger such a rewrite by setting the user version, which is specified by sqlite
+    // to be used for arbitrary user purposes. The write still goes through if we set it to the
+    // same value it already had, which is useful, because we set it elsewhere to the value of
+    // the currently-applied migration.
+    let current_user_version = conn.pragma_query_value(None, "user_version", |row| row.get::<_, i32>(0))?;
+    conn.pragma_update(None, "user_version", current_user_version)?;
 
     Ok(())
 }


### PR DESCRIPTION
We use it to track the current DB migration value, and check it in a few places, so having ios setting it unconditionally to `2` is a bit of a footgun. So far the only place it changes behavior is by invalidating the check against duplicate calls of `migrate_db_key_type_to_bytes`, but it's just nicer to have it do a sensible thing.

<!-- # PR Submission Checklist for internal contributors -->

<!-- Have you  checked that -->

<!-- [ ] You added a **PR description** -->
<!-- - The **PR Title** -->
  <!-- - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow² -->
  <!-- - [ ] contains a reference JIRA issue number like `SQPIT-764` -->
  <!-- - [ ] answers the question: _If merged, this PR will: ..._ ³ -->

<!-- 1. https://sparkbox.com/foundry/semantic_commit_messages -->
<!-- 1. https://github.com/wireapp/.github#usage -->
<!-- 1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`. -->
